### PR TITLE
run publish coverage action only for pull request builds

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -59,6 +59,7 @@ jobs:
         NODE_OPTIONS: --max_old_space_size=4096
      
     - name: Publish code coverage
+      if: github.event_name == 'pull_request'
       uses: 5monkeys/cobertura-action@master
       with:
         path: ${{ github.workspace }}/test-results/unit/coverage/cobertura-coverage.xml


### PR DESCRIPTION
If the publish coverage action runs on push builds, it creates a failure annotation stating "pr not found"