### PR TITLE
fix: avoid bundling MPL dependencies into same file as non-MPL code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 node_modules/
+!/dist/node_modules/
 drop/
 test-results/
 out/

--- a/src/scanner/scanner.spec.ts
+++ b/src/scanner/scanner.spec.ts
@@ -3,7 +3,6 @@
 import 'reflect-metadata';
 
 import { AIScanner, AxeScanResults } from 'accessibility-insights-scan';
-import * as path from 'path';
 import { IMock, It, Mock, Times } from 'typemoq';
 import * as util from 'util';
 import { LocalFileServer } from '../local-file-server';
@@ -28,7 +27,7 @@ describe(Scanner, () => {
     let axeScanResults: AxeScanResults;
     const scanUrl = 'localhost';
     const baseUrl = 'base';
-    const axeSourcePath = path.resolve(__dirname, 'axe.js');
+    const axeSourcePath = require.resolve('axe-core/axe.min.js');
     const chromePath = 'chrome path';
 
     beforeEach(() => {

--- a/src/scanner/scanner.ts
+++ b/src/scanner/scanner.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { AIScanner } from 'accessibility-insights-scan';
 import { inject, injectable } from 'inversify';
-import * as path from 'path';
 import * as url from 'url';
 import * as util from 'util';
 
@@ -46,7 +45,7 @@ export class Scanner {
             this.logger.logInfo(`Starting accessibility scanning of URL ${scanUrl}.`);
 
             const chromePath = this.taskConfig.getChromePath();
-            const axeCoreSourcePath = path.resolve(__dirname, 'axe.js');
+            const axeCoreSourcePath = require.resolve('axe-core/axe.min.js');
 
             const axeScanResults = await this.scanner.scan(scanUrl, chromePath, axeCoreSourcePath);
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,10 @@ module.exports = (env) => {
         entry: {
             ['index']: path.resolve('./src/index.ts'),
         },
+        // We special case MPL-licensed deps because we want to avoid including their source in
+        // the same file as non-MPL code. Note that each entry here should have a corresponding
+        // entry in copyWebpackPlugin config to copy the non-bundled forms to /dist.
+        externals: ['axe-core', '@axe-core/puppeteer'],
         mode: 'development',
         module: {
             rules: [
@@ -51,11 +55,8 @@ module.exports = (env) => {
             new CaseSensitivePathsPlugin(),
             new copyWebpackPlugin({
                 patterns: [
-                    {
-                        context: './',
-                        from: 'node_modules/axe-core/axe.min.js',
-                        to: 'axe.js',
-                    },
+                    `node_modules/axe-core/*`, // we only use the root-level axe.min.js and the package metadata/LICENSE stuff
+                    `node_modules/@axe-core/puppeteer/**/*`,
                 ],
             }),
         ],


### PR DESCRIPTION
#### Description of changes

This updates our build process per CELA guidance to avoid bundling MPL code into the same files as non-MPL code for distribution.

#### Pull request checklist

- [x] Addresses an existing issue: 1797828
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
