### PR TITLE
fix: prevent error when injecting axe.min.js introduced in #395

### DIFF
--- a/src/scanner/scanner.spec.ts
+++ b/src/scanner/scanner.spec.ts
@@ -3,6 +3,7 @@
 import 'reflect-metadata';
 
 import { AIScanner, AxeScanResults } from 'accessibility-insights-scan';
+import * as path from 'path';
 import { IMock, It, Mock, Times } from 'typemoq';
 import * as util from 'util';
 import { LocalFileServer } from '../local-file-server';
@@ -27,7 +28,7 @@ describe(Scanner, () => {
     let axeScanResults: AxeScanResults;
     const scanUrl = 'localhost';
     const baseUrl = 'base';
-    const axeSourcePath = require.resolve('axe-core/axe.min.js');
+    const axeSourcePath = path.resolve(__dirname, 'node_modules', 'axe-core', 'axe.min.js');
     const chromePath = 'chrome path';
 
     beforeEach(() => {

--- a/src/scanner/scanner.ts
+++ b/src/scanner/scanner.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { AIScanner } from 'accessibility-insights-scan';
 import { inject, injectable } from 'inversify';
+import * as path from 'path';
 import * as url from 'url';
 import * as util from 'util';
 
@@ -45,7 +46,8 @@ export class Scanner {
             this.logger.logInfo(`Starting accessibility scanning of URL ${scanUrl}.`);
 
             const chromePath = this.taskConfig.getChromePath();
-            const axeCoreSourcePath = require.resolve('axe-core/axe.min.js');
+            // Note: this is relative to /dist/index.js, not this source file
+            const axeCoreSourcePath = path.resolve(__dirname, 'node_modules', 'axe-core', 'axe.min.js');
 
             const axeScanResults = await this.scanner.scan(scanUrl, chromePath, axeCoreSourcePath);
 


### PR DESCRIPTION
#### Description of changes

Fixes a bug introduced in #395 where resolving axe.min.js doesn't work correctly when the bundled index.js is run from a working directory that isn't its own directory (because `require.resolve` returns a relative path as #395 used it).

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
