### PR TITLE
Using resolutions to fix marked Dependabot alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "serialize-javascript": ">=3.1.0",
         "apify-shared": ">=0.5.0",
         "y18n": ">=5.0.5",
-        "socket.io": ">=2.4.0"
+        "socket.io": ">=2.4.0",
+        "marked": ">=2.0.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5194,10 +5194,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.0.tgz#7221ce2395fa6cf6d722e6f2871a32d3513c85ca"
-  integrity sha512-tiRxakgbNPBr301ihe/785NntvYyhxlqcL3YaC8CaxJQh7kiaEtrN9B/eK2I2943Yjkh5gw25chYFDQhOMCwMA==
+marked@>=2.0.0, marked@^1.1.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.0.tgz#9662bbcb77ebbded0662a7be66ff929a8611cee5"
+  integrity sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q==
 
 match-all@^1.2.6:
   version "1.2.6"


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Dependabot cannot update marked to a non-vulnerable version
The latest possible version that can be installed is 1.2.9 because of the following conflicting dependency:

accessibility-insights-scan@0.6.0 requires marked@^1.1.0 via a transitive dependency on apify-shared@0.5.0
The earliest fixed version is 2.0.0.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
