### PR TITLE
chore: document release strategy in preparation for default branch rename

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,6 +6,7 @@ name: Build
 on: 
   push:
     branches: 
+      - main
       - master
   pull_request:
     branches: 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+
+# Contributing
+
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
+provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## Release instructions
+
+To create a new release, a repo maintainer should follow these steps:
+
+1. Create and merge a release pull request to `main` which:
+  * Updates `/package.json` with a new semantic version number
+  * Updates `/NOTICES.txt` based on the dependencies in `yarn.lock`
+  * Updates `/dist/` with the results of `yarn build`
+2. Wait for a passing CI build against `main`
+3. Create/update the corresponding git tags for the release:
+  * Create a new release tag using the version in `package.json` (eg, `git tag v1.2.3`)
+  * Update the corresponding major-version tag (eg, `git tag -f v1`)
+  * Push both tags

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,9 @@ To create a new release, a repo maintainer should follow these steps:
   * Updates `/package.json` with a new semantic version number
   * Updates `/NOTICES.txt` based on the dependencies in `yarn.lock`
   * Updates `/dist/` with the results of `yarn build`
-2. Wait for a passing CI build against `main`
+2. Validate the release build
+  * Wait for a passing CI build against `main`
+  * Update a separate test repository to refer to `accessibility-insights-action@mergecommithash` and verify that it functions as expected
 3. Create/update the corresponding git tags for the release:
   * Create a new release tag using the version in `package.json` (eg, `git tag v1.2.3`)
   * Update the corresponding major-version tag (eg, `git tag -f v1`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,18 +22,13 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 To create a new release, a repo maintainer should follow these steps:
 
 1. Create and merge a release pull request to `main` which:
-
--   Updates `/package.json` with a new semantic version number
--   Updates `/NOTICES.txt` based on the dependencies in `yarn.lock`
--   Updates `/dist/` with the results of `yarn build`
-
+    - Updates `/package.json` with a new semantic version number
+    - Updates `/NOTICES.txt` based on the dependencies in `yarn.lock`
+    - Updates `/dist/` with the results of `yarn build`
 2. Validate the release build
-
--   Wait for a passing CI build against `main`
--   Update a separate test repository to refer to `accessibility-insights-action@mergecommithash` and verify that it functions as expected
-
+    - Wait for a passing CI build against `main`
+    - Update a separate test repository to refer to `accessibility-insights-action@mergecommithash` and verify that it functions as expected
 3. Create/update the corresponding git tags for the release:
-
--   Create a new release tag using the version in `package.json` (eg, `git tag v1.2.3`)
--   Update the corresponding major-version tag (eg, `git tag -f v1`)
--   Push both tags
+    - Create a new release tag using the version in `package.json` (eg, `git tag v1.2.3`)
+    - Update the corresponding major-version tag (eg, `git tag -f v1`)
+    - Push both tags

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,13 +22,18 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 To create a new release, a repo maintainer should follow these steps:
 
 1. Create and merge a release pull request to `main` which:
-  * Updates `/package.json` with a new semantic version number
-  * Updates `/NOTICES.txt` based on the dependencies in `yarn.lock`
-  * Updates `/dist/` with the results of `yarn build`
+
+-   Updates `/package.json` with a new semantic version number
+-   Updates `/NOTICES.txt` based on the dependencies in `yarn.lock`
+-   Updates `/dist/` with the results of `yarn build`
+
 2. Validate the release build
-  * Wait for a passing CI build against `main`
-  * Update a separate test repository to refer to `accessibility-insights-action@mergecommithash` and verify that it functions as expected
+
+-   Wait for a passing CI build against `main`
+-   Update a separate test repository to refer to `accessibility-insights-action@mergecommithash` and verify that it functions as expected
+
 3. Create/update the corresponding git tags for the release:
-  * Create a new release tag using the version in `package.json` (eg, `git tag v1.2.3`)
-  * Update the corresponding major-version tag (eg, `git tag -f v1`)
-  * Push both tags
+
+-   Create a new release tag using the version in `package.json` (eg, `git tag v1.2.3`)
+-   Update the corresponding major-version tag (eg, `git tag -f v1`)
+-   Push both tags

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Licensed under the MIT License.
 # ![Product Logo](./icons/brand-blue-48px.png) Accessibility Insights Action
 
 [![Actions Status](https://github.com/microsoft/accessibility-insights-action/workflows/Build/badge.svg)](https://github.com/microsoft/accessibility-insights-action/actions)
-[![codecov](https://codecov.io/gh/microsoft/accessibility-insights-action/branch/master/graph/badge.svg)](https://codecov.io/gh/microsoft/accessibility-insights-action)
+[![codecov](https://codecov.io/gh/microsoft/accessibility-insights-action/branch/main/graph/badge.svg)](https://codecov.io/gh/microsoft/accessibility-insights-action)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=microsoft/accessibility-insights-action)](https://dependabot.com)
 
 Accessibility Insights Action helps integrate automated accessibility tests in GitHub workflow.
@@ -15,7 +15,16 @@ Accessibility Insights Action helps integrate automated accessibility tests in G
 
 **This repo does not assume any responsibility for supporting issues that might be caused due to its use at this point in time.**
 
-# Contributing
+## Usage
+
+To use this action in your workflow (which, again, we don't yet recommend at all for any production projects), we recommend referring to a version tag:
+
+* `microsoft/accessibility-insights-action@v1` is updated with each `v1.x.y` release to refer to the most recent API-compatible version.
+* `microsoft/accessibility-insights-action@v1.0.0` refers to the exact version `v1.0.0`; use this to pin to a specific version.
+
+Avoid refering to `@main` directly; it may contain undocumented breaking changes.
+
+## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
@@ -28,3 +37,5 @@ provided by the bot. You will only need to do this once across all repos using o
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Accessibility Insights Action helps integrate automated accessibility tests in G
 
 To use this action in your workflow (which, again, we don't yet recommend at all for any production projects), we recommend referring to a version tag:
 
-* `microsoft/accessibility-insights-action@v1` is updated with each `v1.x.y` release to refer to the most recent API-compatible version.
-* `microsoft/accessibility-insights-action@v1.0.0` refers to the exact version `v1.0.0`; use this to pin to a specific version.
+-   `microsoft/accessibility-insights-action@v1` is updated with each `v1.x.y` release to refer to the most recent API-compatible version.
+-   `microsoft/accessibility-insights-action@v1.0.0` refers to the exact version `v1.0.0`; use this to pin to a specific version.
 
 Avoid refering to `@main` directly; it may contain undocumented breaking changes.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Licensed under the MIT License.
 # ![Product Logo](./icons/brand-blue-48px.png) Accessibility Insights Action
 
 [![Actions Status](https://github.com/microsoft/accessibility-insights-action/workflows/Build/badge.svg)](https://github.com/microsoft/accessibility-insights-action/actions)
-[![codecov](https://codecov.io/gh/microsoft/accessibility-insights-action/branch/main/graph/badge.svg)](https://codecov.io/gh/microsoft/accessibility-insights-action)
+[![codecov](https://codecov.io/gh/microsoft/accessibility-insights-action/branch/master/graph/badge.svg)](https://codecov.io/gh/microsoft/accessibility-insights-action)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=microsoft/accessibility-insights-action)](https://dependabot.com)
 
 Accessibility Insights Action helps integrate automated accessibility tests in GitHub workflow.


### PR DESCRIPTION
#### Details

This PR establishes our versioning strategy (based on the standard GitHub actions documentation) and documents both a release process based on it and usage in the README to consume via the new strategy.

##### Motivation

Two motivating factors:

* Enable a more forwards-compatible versioning strategy while there are still few consumers
* Unblock renaming the default branch from master to main

##### Context

@AhmedAbdoOrtiga and I discussed a few options for release strategy before settling on this. The most challenging tradeoff was whether to stick with `v0.x.y` (to indicate that the package is not considered stable) or to start from `v1` (to avoid user confusion when the semver level allowing breaking changes switches from minor to major during a `v0.1` to `v1` switch). We decided to go with `v1` and trust that the README notice + lack of publishing to the marketplace will be sufficient to denote it as non-production-ready.

After this PR merges, there will be another PR behind it which follows the documentation to perform a v1.0.0 release. After that we'll update consumers to reference `accessibility-insights-action@v1` instead of `accessibility-insights-action@master`, and then we'll be able to proceed with the default branch rename.

Out-of-scope for this PR: automating the release steps

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
