### PR TITLE
feat(gh-action-crawling): add scanning of remote URL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
     repo-token:
         description: 'github token'
         required: true
+    url:
+        description: 'remote site url'
+        required: false
 runs:
     using: 'node12'
     main: 'dist/index.js'

--- a/src/scanner/scanner.ts
+++ b/src/scanner/scanner.ts
@@ -40,8 +40,15 @@ export class Scanner {
 
         try {
             await this.allProgressReporter.start();
-            const baseUrl = await this.fileServer.start();
-            scanUrl = url.resolve(baseUrl, this.taskConfig.getScanUrlRelativePath());
+
+            const remoteUrl: string = this.taskConfig.getUrl();
+            if(remoteUrl) {
+                scanUrl = remoteUrl;
+            }
+            else {
+                const baseUrl = await this.fileServer.start();
+                scanUrl = url.resolve(baseUrl, this.taskConfig.getScanUrlRelativePath());
+            }
 
             this.logger.logInfo(`Starting accessibility scanning of URL ${scanUrl}.`);
 

--- a/src/scanner/scanner.ts
+++ b/src/scanner/scanner.ts
@@ -42,10 +42,9 @@ export class Scanner {
             await this.allProgressReporter.start();
 
             const remoteUrl: string = this.taskConfig.getUrl();
-            if(remoteUrl) {
+            if (remoteUrl) {
                 scanUrl = remoteUrl;
-            }
-            else {
+            } else {
                 const baseUrl = await this.fileServer.start();
                 scanUrl = url.resolve(baseUrl, this.taskConfig.getScanUrlRelativePath());
             }

--- a/src/task-config.spec.ts
+++ b/src/task-config.spec.ts
@@ -104,6 +104,19 @@ describe(TaskConfig, () => {
         actionCoreMock.verifyAll();
     });
 
+    it('getUrl', () => {
+        const remoteUrl = 'remote-url';
+        actionCoreMock
+            .setup((am) => am.getInput('url'))
+            .returns(() => remoteUrl)
+            .verifiable(Times.once());
+
+        const res = taskConfig.getUrl();
+
+        expect(res).toBe(remoteUrl);
+        actionCoreMock.verifyAll();
+    });
+
     it('getRunId', () => {
         const res = taskConfig.getRunId();
 

--- a/src/task-config.ts
+++ b/src/task-config.ts
@@ -37,6 +37,10 @@ export class TaskConfig {
         return chromePath;
     }
 
+    public getUrl(): string {
+        return this.actionCoreObj.getInput('url');
+    }
+    
     public getRunId(): number {
         return parseInt(this.processObj.env.GITHUB_RUN_ID, 10);
     }

--- a/src/task-config.ts
+++ b/src/task-config.ts
@@ -40,7 +40,7 @@ export class TaskConfig {
     public getUrl(): string {
         return this.actionCoreObj.getInput('url');
     }
-    
+
     public getRunId(): number {
         return parseInt(this.processObj.env.GITHUB_RUN_ID, 10);
     }


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
* Added `url` input to action.yml and corresponding getUrl to task-config.ts
* Modified scanner.ts to use remote url as the scan url if `url` is specified in the input. If `url` is not specified, start the file server and use scan url relative path for the scan url.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Addresses WI: # 1837995

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
Verified the following scenarios:
* [Added `url` input in test repo](https://github.com/lisli1/test-action/runs/2452665414?check_suite_focus=true) and checked that the resulting artifact scan report and an exported report from running FastPass on the same URL had the same results
* [Removed `url` from test repo](https://github.com/lisli1/test-action/runs/2452718082?check_suite_focus=true) to check that the local file is scanned when the `url` input is not present
* [Added empty string `''` for `url` input in test repo](https://github.com/lisli1/test-action/runs/2452730011?check_suite_focus=true) and verified that the local file is scanned instead of trying to scan a non-existing remote URL
<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: # 1837995
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
