### PR TITLE
feat(gh-action-crawling): add crawling options to action input metadata

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
         required: false
         default: '100'
     discovery-patterns:
-        description: 'List of URLs to crawl in addition to URLs discovered from crawling the provided URL, separated by space.'
+        description: 'List of RegEx patterns to crawl in addition to the provided URL, separated by space.'
         required: false
     input-file:
         description: 'File path that contains list of URLs (each separated by a new line) to scan in addition to URLs discovered from crawling the provided URL.'

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,20 @@ inputs:
         description: 'github token'
         required: true
     url:
-        description: 'remote site url'
+        description: 'The hosted URL to scan/crawl for accessibility issues.'
+        required: false
+    max-urls:
+        description: 'Maximum number of pages opened by crawler. The crawl will stop when this limit is reached.'
+        required: false
+        default: '100'
+    discovery-patterns:
+        description: 'List of URLs to crawl in addition to URLs discovered from crawling the provided URL, separated by space.'
+        required: false
+    input-file:
+        description: 'File path that contains list of URLs (each separated by a new line) to scan in addition to URLs discovered from crawling the provided URL.'
+        required: false
+    input-urls:
+        description: 'List of URLs to crawl in addition to URLs discovered from crawling the provided URL, separated by space.'
         required: false
 runs:
     using: 'node12'

--- a/src/task-config.spec.ts
+++ b/src/task-config.spec.ts
@@ -4,89 +4,42 @@ import 'reflect-metadata';
 
 import * as actionCore from '@actions/core';
 import * as process from 'process';
-import { IMock, Mock, Times } from 'typemoq';
+import { Mock, Times } from 'typemoq';
 
 import { TaskConfig } from './task-config';
 
 describe(TaskConfig, () => {
-    let processStub: typeof process;
-    let actionCoreMock: IMock<typeof actionCore>;
-    let taskConfig: TaskConfig;
     const runId = 789;
     const workspace = 'some-workspace';
+    const processStub = {
+        env: {
+            GITHUB_WORKSPACE: workspace,
+            GITHUB_RUN_ID: `${runId}`,
+        },
+    } as any;
 
-    beforeEach(() => {
-        processStub = {
-            env: {
-                GITHUB_WORKSPACE: workspace,
-                GITHUB_RUN_ID: `${runId}`,
-            },
-        } as any;
-        actionCoreMock = Mock.ofType<typeof actionCore>();
+    const actionCoreMock = Mock.ofType<typeof actionCore>();
+    const taskConfig = new TaskConfig(processStub, actionCoreMock.object);
 
-        taskConfig = new TaskConfig(processStub, actionCoreMock.object);
-    });
-
-    it('getReportOutDir', () => {
-        const outputDir = 'output-dir';
+    it.each`
+        inputOption                 | inputValue   | expectedValue       | getInputFunc
+        ${'repo-token'}             | ${'token'}   | ${'token'}          | ${taskConfig.getToken}
+        ${'scan-url-relative-path'} | ${'path'}    | ${'path'}           | ${taskConfig.getScanUrlRelativePath}
+        ${'chrome-path'}            | ${'path'}    | ${'path'}           | ${taskConfig.getChromePath}
+        ${'input-file'}             | ${'path'}    | ${'path'}           | ${taskConfig.getInputFile}
+        ${'output-dir'}             | ${'path'}    | ${'path'}           | ${taskConfig.getReportOutDir}
+        ${'site-dir'}               | ${'path'}    | ${'path'}           | ${taskConfig.getSiteDir}
+        ${'url'}                    | ${'url'}     | ${'url'}            | ${taskConfig.getUrl}
+        ${'discovery-patterns'}     | ${'a bb  c'} | ${['a', 'bb', 'c']} | ${taskConfig.getDiscoveryPatterns}
+        ${'input-urls'}             | ${'a bb  c'} | ${['a', 'bb', 'c']} | ${taskConfig.getInputUrls}
+        ${'max-urls'}               | ${'20'}      | ${20}               | ${taskConfig.getMaxUrls}
+    `('$getInputFunc provides parsed version of $inputOption', ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
         actionCoreMock
-            .setup((am) => am.getInput('output-dir'))
-            .returns(() => outputDir)
+            .setup((am) => am.getInput(inputOption))
+            .returns(() => inputValue)
             .verifiable(Times.once());
-        const dir = taskConfig.getReportOutDir();
-        expect(dir).toBe(outputDir);
-    });
-
-    it('getSiteDir', () => {
-        const siteDir = 'site';
-        actionCoreMock
-            .setup((am) => am.getInput('site-dir'))
-            .returns(() => siteDir)
-            .verifiable(Times.once());
-
-        const dir = taskConfig.getSiteDir();
-
-        expect(dir).toBe(siteDir);
-        actionCoreMock.verifyAll();
-    });
-
-    it('getScanUrlRelativePath', () => {
-        const relativePath = 'path';
-        actionCoreMock
-            .setup((am) => am.getInput('scan-url-relative-path'))
-            .returns(() => relativePath)
-            .verifiable(Times.once());
-
-        const res = taskConfig.getScanUrlRelativePath();
-
-        expect(res).toBe(relativePath);
-        actionCoreMock.verifyAll();
-    });
-
-    it('getToken', () => {
-        const token = 'repo-token';
-        actionCoreMock
-            .setup((am) => am.getInput('repo-token'))
-            .returns(() => token)
-            .verifiable(Times.once());
-
-        const res = taskConfig.getToken();
-
-        expect(res).toBe(token);
-        actionCoreMock.verifyAll();
-    });
-
-    it('getChromePath', () => {
-        const chromePath = 'chrome-path';
-        actionCoreMock
-            .setup((am) => am.getInput('chrome-path'))
-            .returns(() => chromePath)
-            .verifiable(Times.once());
-
-        const res = taskConfig.getChromePath();
-
-        expect(res).toBe(chromePath);
-        actionCoreMock.verifyAll();
+        const retrievedOption = getInputFunc.call(taskConfig);
+        expect(retrievedOption).toStrictEqual(expectedValue);
     });
 
     it('getChromePath returns empty', () => {
@@ -101,26 +54,16 @@ describe(TaskConfig, () => {
         const res = taskConfig.getChromePath();
 
         expect(res).toBe(chromePath);
-        actionCoreMock.verifyAll();
-    });
-
-    it('getUrl', () => {
-        const remoteUrl = 'remote-url';
-        actionCoreMock
-            .setup((am) => am.getInput('url'))
-            .returns(() => remoteUrl)
-            .verifiable(Times.once());
-
-        const res = taskConfig.getUrl();
-
-        expect(res).toBe(remoteUrl);
-        actionCoreMock.verifyAll();
     });
 
     it('getRunId', () => {
         const res = taskConfig.getRunId();
 
         expect(res).toBe(runId);
+    });
+
+    afterEach(() => {
         actionCoreMock.verifyAll();
+        actionCoreMock.reset();
     });
 });

--- a/src/task-config.spec.ts
+++ b/src/task-config.spec.ts
@@ -23,24 +23,27 @@ describe(TaskConfig, () => {
 
     it.each`
         inputOption                 | inputValue   | expectedValue       | getInputFunc
-        ${'repo-token'}             | ${'token'}   | ${'token'}          | ${taskConfig.getToken}
-        ${'scan-url-relative-path'} | ${'path'}    | ${'path'}           | ${taskConfig.getScanUrlRelativePath}
-        ${'chrome-path'}            | ${'path'}    | ${'path'}           | ${taskConfig.getChromePath}
-        ${'input-file'}             | ${'path'}    | ${'path'}           | ${taskConfig.getInputFile}
-        ${'output-dir'}             | ${'path'}    | ${'path'}           | ${taskConfig.getReportOutDir}
-        ${'site-dir'}               | ${'path'}    | ${'path'}           | ${taskConfig.getSiteDir}
-        ${'url'}                    | ${'url'}     | ${'url'}            | ${taskConfig.getUrl}
-        ${'discovery-patterns'}     | ${'a bb  c'} | ${['a', 'bb', 'c']} | ${taskConfig.getDiscoveryPatterns}
-        ${'input-urls'}             | ${'a bb  c'} | ${['a', 'bb', 'c']} | ${taskConfig.getInputUrls}
-        ${'max-urls'}               | ${'20'}      | ${20}               | ${taskConfig.getMaxUrls}
-    `('$getInputFunc provides parsed version of $inputOption', ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
-        actionCoreMock
-            .setup((am) => am.getInput(inputOption))
-            .returns(() => inputValue)
-            .verifiable(Times.once());
-        const retrievedOption = getInputFunc.call(taskConfig);
-        expect(retrievedOption).toStrictEqual(expectedValue);
-    });
+        ${'repo-token'}             | ${'token'}   | ${'token'}          | ${() => taskConfig.getToken()}
+        ${'scan-url-relative-path'} | ${'path'}    | ${'path'}           | ${() => taskConfig.getScanUrlRelativePath()}
+        ${'chrome-path'}            | ${'path'}    | ${'path'}           | ${() => taskConfig.getChromePath()}
+        ${'input-file'}             | ${'path'}    | ${'path'}           | ${() => taskConfig.getInputFile()}
+        ${'output-dir'}             | ${'path'}    | ${'path'}           | ${() => taskConfig.getReportOutDir()}
+        ${'site-dir'}               | ${'path'}    | ${'path'}           | ${() => taskConfig.getSiteDir()}
+        ${'url'}                    | ${'url'}     | ${'url'}            | ${() => taskConfig.getUrl()}
+        ${'discovery-patterns'}     | ${'a bb  c'} | ${['a', 'bb', 'c']} | ${() => taskConfig.getDiscoveryPatterns()}
+        ${'input-urls'}             | ${'a bb  c'} | ${['a', 'bb', 'c']} | ${() => taskConfig.getInputUrls()}
+        ${'max-urls'}               | ${'20'}      | ${20}               | ${() => taskConfig.getMaxUrls()}
+    `(
+        'parses "$inputValue" as $expectedValue when provided as $inputOption',
+        ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
+            actionCoreMock
+                .setup((am) => am.getInput(inputOption))
+                .returns(() => inputValue)
+                .verifiable(Times.once());
+            const retrievedOption = getInputFunc();
+            expect(retrievedOption).toStrictEqual(expectedValue);
+        },
+    );
 
     it('getChromePath returns empty', () => {
         const chromePath = 'some path';

--- a/src/task-config.ts
+++ b/src/task-config.ts
@@ -41,6 +41,22 @@ export class TaskConfig {
         return this.actionCoreObj.getInput('url');
     }
 
+    public getMaxUrls(): number {
+        return parseInt(this.actionCoreObj.getInput('max-urls'));
+    }
+
+    public getDiscoveryPatterns(): string[] {
+        return this.actionCoreObj.getInput('discovery-patterns').split(/\s+/);
+    }
+
+    public getInputFile(): string {
+        return this.actionCoreObj.getInput('input-file');
+    }
+
+    public getInputUrls(): string[] {
+        return this.actionCoreObj.getInput('input-urls').split(/\s+/);
+    }
+
     public getRunId(): number {
         return parseInt(this.processObj.env.GITHUB_RUN_ID, 10);
     }


### PR DESCRIPTION
#### Details

This PR adds crawling options similar to [accessibility-insights-scan](https://www.npmjs.com/package/accessibility-insights-scan). It adds:
- url
- maxUrls
- discoveryPatterns
- inputFile
- inputUrls

tested [here](https://github.com/karanbirsingh/test-a11y-action/runs/2463027566?check_suite_focus=true) (action accepts `max-urls` in test)

##### Motivation

We want to pass these along to the crawler.

##### Context

In the CLI we do some parsing and error checking:
- https://github.com/microsoft/accessibility-insights-service/blob/main/packages/cli/src/cli.ts#L28
- https://github.com/microsoft/accessibility-insights-service/blob/main/packages/cli/src/crawler-parameters-builder.ts

We might want to expose some of this from AICrawler and reuse it. Otherwise in a follow-up PR we can reimplement some of these error checks.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
