### PR TITLE
chore: allow contributors to run the action on PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,4 +18,6 @@
 - [ ] Added relevant unit test for your changes. (`yarn test`)
 - [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
 - [ ] Ran precheckin (`yarn precheckin`)
-- [ ] Run this action on my PR (This will run against test files in `dev/website-root`)
+
+If you want to run the action against files in `dev/website-root`, check the box below:
+- [ ] Run this action on my PR

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,3 +18,4 @@
 - [ ] Added relevant unit test for your changes. (`yarn test`)
 - [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
 - [ ] Ran precheckin (`yarn precheckin`)
+- [ ] Run this action on my PR (This will run against test files in `dev/website-root`)

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+name: Test action in PR
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  self-validate:
+    if: contains(github.event.pull_request.body, '- [x] Run this action on my PR')
+    name: Self validate
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Scan test site
+      uses: ./
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        site-dir: ${{ github.workspace }}/dev/website-root 
+
+    - name: Upload report artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: accessibility-reports
+        path: ${{ github.workspace }}/_accessibility-reports


### PR DESCRIPTION
#### Details

This change amends the PR workflow so that a contributor can check the "Run this action on my PR" box to initiate a run of the action on 'itself'.

If you check this box during your PR, the action (built from your PR branch) will run on some test files we have in `website-root`. The accessibility check itself will fail because the files have accessibility issues. But it can be helpful to quickly validate changes.

If the box is not checked, the run is skipped. The default is off.

##### Motivation

Let people easily test the action in their PRs

Screenshot of checks of this original PR (box unchecked):
![shows skipped accessibility run](https://user-images.githubusercontent.com/7775527/117712359-12dc5e80-b189-11eb-8cb9-90d4bf2f5d23.png)

Screenshot of the checks after the box is checked:
![shows accessibility run queued](https://user-images.githubusercontent.com/7775527/117712472-3dc6b280-b189-11eb-8493-113e5742c102.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)

If you want to run the action against files in `dev/website-root`, check the box below:
- [x] Run this action on my PR
