### PR TITLE
chore: Map environment variables using 'env' context instead of inline bash script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,8 +67,6 @@ runs:
           env:
               INPUT_OUTPUT-DIR: ${{ inputs.output-dir }}
               INPUT_SITE-DIR: ${{ inputs.site-dir }}
-              INPUT_OUTPUT-DIR: ${{ inputs.output-dir }}
-              INPUT_SITE-DIR: ${{ inputs.site-dir }}
               INPUT_SCAN-URL-RELATIVE-PATH: ${{ inputs.scan-url-relative-path }}
               INPUT_CHROME-PATH: ${{ inputs.chrome-path }}
               INPUT_REPO-TOKEN: ${{ inputs.repo-token }}

--- a/action.yml
+++ b/action.yml
@@ -59,22 +59,22 @@ runs:
                   echo 'Chromium package successfully installed on docker container'
               fi
           shell: bash
-        - name: Map action inputs into inner steps
-          run: |
-              echo "INPUT_OUTPUT-DIR=${{ inputs.output-dir }}" >> $GITHUB_ENV
-              echo "INPUT_SITE-DIR=${{ inputs.site-dir }}" >> $GITHUB_ENV
-              echo "INPUT_SCAN-URL-RELATIVE-PATH=${{ inputs.scan-url-relative-path }}" >> $GITHUB_ENV
-              echo "INPUT_CHROME-PATH=${{ inputs.chrome-path }}" >> $GITHUB_ENV
-              echo "INPUT_REPO-TOKEN=${{ inputs.repo-token }}" >> $GITHUB_ENV
-              echo "INPUT_URL=${{ inputs.url }}" >> $GITHUB_ENV
-              echo "INPUT_MAX-URLS=${{ inputs.max-urls }}" >> $GITHUB_ENV
-              echo "INPUT_DISCOVERY-PATTERNS=${{ inputs.discovery-patterns }}" >> $GITHUB_ENV
-              echo "INPUT_INPUT-FILE=${{ inputs.input-file }}" >> $GITHUB_ENV
-              echo "INPUT_INPUT-URLS=${{ inputs.input-urls }}" >> $GITHUB_ENV
-              echo "INPUT_LOCALHOST-PORT=${{ inputs.localhost-port }}" >> $GITHUB_ENV
-          shell: bash
         - name: Run action
           run: |
               echo 'Starting accessibility scanner...'
               node $GITHUB_ACTION_PATH/dist/index.js
           shell: bash
+          env:
+              INPUT_OUTPUT-DIR: ${{ inputs.output-dir }}
+              INPUT_SITE-DIR: ${{ inputs.site-dir }}
+              INPUT_OUTPUT-DIR: ${{ inputs.output-dir }}
+              INPUT_SITE-DIR: ${{ inputs.site-dir }}
+              INPUT_SCAN-URL-RELATIVE-PATH: ${{ inputs.scan-url-relative-path }}
+              INPUT_CHROME-PATH: ${{ inputs.chrome-path }}
+              INPUT_REPO-TOKEN: ${{ inputs.repo-token }}
+              INPUT_URL: ${{ inputs.url }}
+              INPUT_MAX-URLS: ${{ inputs.max-urls }}
+              INPUT_DISCOVERY-PATTERNS: ${{ inputs.discovery-patterns }}
+              INPUT_INPUT-FILE: ${{ inputs.input-file }}
+              INPUT_INPUT-URLS: ${{ inputs.input-urls }}
+              INPUT_LOCALHOST-PORT: ${{ inputs.localhost-port }}


### PR DESCRIPTION
#### Details

https://github.com/actions/runner/issues/665 mentions that input arguments are not implicitly mapped to environment variables in composite action steps. This `action.yml` file contained an inline script to map the environment variables. This PR replaces the inline script with the `env` context.

##### Motivation

This is simpler and helps protect the action from possible future runtime injection in the bash script (imagine the script included something like `${{ github.event.pull_request.title }}`.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
