### PR TITLE
chore: restore required GITHUB_TOKEN permissions when self-validating the action

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -65,6 +65,9 @@ jobs:
   self-test:
     name: Self-validate action
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@v2
     - name: Scan test site


### PR DESCRIPTION
#### Details

By default our repo's GitHub token has [permissive access](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token). A recent workflow in this repository shows the following permissions:

```
GITHUB_TOKEN Permissions
  Actions: write
  Checks: write
  Contents: write
  Deployments: write
  Discussions: write
  Issues: write
  Metadata: read
  Packages: write
  PullRequests: write
  RepositoryProjects: write
  SecurityEvents: write
  Statuses: write
```
I changed the default scope to be read-only. This works for builds & unit tests, but the accessibility action requires some special write permissions. This PR adds the required permissions explicitly.

##### Motivation

Fix self-validation now that the default GitHub token access is read-only.

##### Context

Here are some helpful docs: https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
