### PR TITLE
updating http-signature version

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
         "y18n": ">=5.0.5",
         "socket.io": ">=2.4.0",
         "marked": ">=2.0.0",
-        "hosted-git-info": ">=3.0.8"
+        "hosted-git-info": ">=3.0.8",
+        "http-signature": ">=1.3.1"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4095,14 +4095,14 @@ http-proxy-agent@^4.0.0, http-proxy-agent@^4.0.1:
     agent-base "6"
     debug "4"
 
-http-signature@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
-  integrity sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
+http-signature@>=1.3.1, http-signature@~1.2.0:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.3.5.tgz#9f19496ffbf3227298d7b5f156e0e1a948678683"
+  integrity sha512-NwoTQYSJoFt34jSBbwzDHDofoA61NGXzu6wXh95o1Ry62EnmKjXb/nR/RknLeZ3G/uGwrlKNY2z7uPt+Cdl7Tw==
   dependencies:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
-    sshpk "^1.7.0"
+    sshpk "^1.14.1"
 
 http2-wrapper@^1.0.0-beta.5.2:
   version "1.0.3"
@@ -6964,7 +6964,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sshpk@^1.7.0:
+sshpk@^1.14.1:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
   integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==


### PR DESCRIPTION
The current version depends on a vulnerable version of sshpk. Updated to 1.3.1 

#### Details

<!-- Usually a sentence or two describing what the PR changes -->

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [X] Addresses an existing issue: Fixes #0000
- [X] Added relevant unit test for your changes. (`yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`yarn precheckin`)
- [X] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
