### PR TITLE
fix: escape special characters in markdown

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,7 @@
 **/*.png
 **/*.sh
 **/*.ts.snap
+**/*.snap.md
 **/bin/
 **/obj/
 **/yarn-*.log

--- a/dev/website-root/index.html
+++ b/dev/website-root/index.html
@@ -23,6 +23,7 @@ Licensed under the MIT License.
                 <input id="input-radio-1" type="radio" name="color" value="red" checked /> Red<br />
                 <input type="radio" name="color" value="green" /> Green<br />
                 <input type="radio" name="color" value="blue" /> Blue
+                <input type="image" src="img1.png" name="submit" height="36" width="113" />
             </form>
         </div>
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -66143,8 +66143,12 @@ exports.Logger = Logger;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.sectionSeparator = exports.footerSeparator = exports.productTitle = exports.bold = exports.heading = exports.listItem = exports.image = exports.link = exports.snippet = void 0;
+exports.sectionSeparator = exports.footerSeparator = exports.productTitle = exports.bold = exports.heading = exports.listItem = exports.image = exports.link = exports.snippet = exports.escaped = void 0;
 const strings_1 = __webpack_require__(/*! ../content/strings */ "./src/content/strings.ts");
+const escaped = (markdown) => {
+    return markdown.replace(/</g, '\\<');
+};
+exports.escaped = escaped;
 const snippet = (text) => {
     return `\`${text}\``;
 };
@@ -66284,7 +66288,7 @@ let ResultMarkdownBuilder = class ResultMarkdownBuilder {
             return lines.join('');
         };
         this.failedRuleListItem = (failureCount, ruleId, description) => {
-            return markdown_formatter_1.listItem(`${markdown_formatter_1.bold(`${failureCount} × ${ruleId}`)}:  ${description}`);
+            return markdown_formatter_1.listItem(`${markdown_formatter_1.bold(`${failureCount} × ${markdown_formatter_1.escaped(ruleId)}`)}:  ${markdown_formatter_1.escaped(description)}`);
         };
     }
     buildErrorContent() {

--- a/dist/yarn.lock
+++ b/dist/yarn.lock
@@ -353,10 +353,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz#90420f9f9c6d3987f176a19a7d8e764271a2f55d"
   integrity sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==
 
-"@eslint/eslintrc@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.2.tgz#f63d0ef06f5c0c57d76c4ab5f63d3835c51b0179"
-  integrity sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==
+"@eslint/eslintrc@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
+  integrity sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==
   dependencies:
     ajv "^6.12.4"
     debug "^4.1.1"
@@ -1275,23 +1275,15 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@^4.28.3":
-  version "4.28.3"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.28.3.tgz#95f1d475c08268edffdcb2779993c488b6434b44"
-  integrity sha512-ZyWEn34bJexn/JNYvLQab0Mo5e+qqQNhknxmc8azgNd4XqspVYR5oHq9O11fLwdZMRcj4by15ghSlIEq+H5ltQ==
+"@typescript-eslint/parser@^4.28.4":
+  version "4.28.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.28.4.tgz#bc462dc2779afeefdcf49082516afdc3e7b96fab"
+  integrity sha512-4i0jq3C6n+og7/uCHiE6q5ssw87zVdpUj1k6VlVYMonE3ILdFApEzTWgppSRG4kVNB/5jxnH+gTeKLMNfUelQA==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.28.3"
-    "@typescript-eslint/types" "4.28.3"
-    "@typescript-eslint/typescript-estree" "4.28.3"
+    "@typescript-eslint/scope-manager" "4.28.4"
+    "@typescript-eslint/types" "4.28.4"
+    "@typescript-eslint/typescript-estree" "4.28.4"
     debug "^4.3.1"
-
-"@typescript-eslint/scope-manager@4.28.3":
-  version "4.28.3"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.28.3.tgz#c32ad4491b3726db1ba34030b59ea922c214e371"
-  integrity sha512-/8lMisZ5NGIzGtJB+QizQ5eX4Xd8uxedFfMBXOKuJGP0oaBBVEMbJVddQKDXyyB0bPlmt8i6bHV89KbwOelJiQ==
-  dependencies:
-    "@typescript-eslint/types" "4.28.3"
-    "@typescript-eslint/visitor-keys" "4.28.3"
 
 "@typescript-eslint/scope-manager@4.28.4":
   version "4.28.4"
@@ -1301,28 +1293,10 @@
     "@typescript-eslint/types" "4.28.4"
     "@typescript-eslint/visitor-keys" "4.28.4"
 
-"@typescript-eslint/types@4.28.3":
-  version "4.28.3"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.28.3.tgz#8fffd436a3bada422c2c1da56060a0566a9506c7"
-  integrity sha512-kQFaEsQBQVtA9VGVyciyTbIg7S3WoKHNuOp/UF5RG40900KtGqfoiETWD/v0lzRXc+euVE9NXmfer9dLkUJrkA==
-
 "@typescript-eslint/types@4.28.4":
   version "4.28.4"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.28.4.tgz#41acbd79b5816b7c0dd7530a43d97d020d3aeb42"
   integrity sha512-3eap4QWxGqkYuEmVebUGULMskR6Cuoc/Wii0oSOddleP4EGx1tjLnZQ0ZP33YRoMDCs5O3j56RBV4g14T4jvww==
-
-"@typescript-eslint/typescript-estree@4.28.3":
-  version "4.28.3"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.3.tgz#253d7088100b2a38aefe3c8dd7bd1f8232ec46fb"
-  integrity sha512-YAb1JED41kJsqCQt1NcnX5ZdTA93vKFCMP4lQYG6CFxd0VzDJcKttRlMrlG+1qiWAw8+zowmHU1H0OzjWJzR2w==
-  dependencies:
-    "@typescript-eslint/types" "4.28.3"
-    "@typescript-eslint/visitor-keys" "4.28.3"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@4.28.4":
   version "4.28.4"
@@ -1336,14 +1310,6 @@
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
-
-"@typescript-eslint/visitor-keys@4.28.3":
-  version "4.28.3"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.3.tgz#26ac91e84b23529968361045829da80a4e5251c4"
-  integrity sha512-ri1OzcLnk1HH4gORmr1dllxDzzrN6goUIz/P4MHFV0YZJDCADPR3RvYNp0PW2SetKTThar6wlbFTL00hV2Q+fg==
-  dependencies:
-    "@typescript-eslint/types" "4.28.3"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.28.4":
   version "4.28.4"
@@ -2489,16 +2455,16 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
-codecov@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.8.2.tgz#ab24f18783998c39e809ea210af899f8dbcc790e"
-  integrity sha512-6w/kt/xvmPsWMfDFPE/T054txA9RTgcJEw36PNa6MYX+YV29jCHCRFXwbQ3QZBTOgnex1J2WP8bo2AT8TWWz9g==
+codecov@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.8.3.tgz#9c3e364b8a700c597346ae98418d09880a3fdbe7"
+  integrity sha512-Y8Hw+V3HgR7V71xWH2vQ9lyS358CbGCldWlJFR0JirqoGtOoas3R3/OclRTvgUYFK29mmJICDPauVKmpqbwhOA==
   dependencies:
     argv "0.0.2"
-    ignore-walk "3.0.3"
+    ignore-walk "3.0.4"
     js-yaml "3.14.1"
-    teeny-request "7.0.1"
-    urlgrey "0.4.4"
+    teeny-request "7.1.1"
+    urlgrey "1.0.0"
 
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
@@ -3267,13 +3233,13 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint@^7.30.0:
-  version "7.30.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.30.0.tgz#6d34ab51aaa56112fd97166226c9a97f505474f8"
-  integrity sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==
+eslint@^7.31.0:
+  version "7.31.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.31.0.tgz#f972b539424bf2604907a970860732c5d99d3aca"
+  integrity sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==
   dependencies:
     "@babel/code-frame" "7.12.11"
-    "@eslint/eslintrc" "^0.4.2"
+    "@eslint/eslintrc" "^0.4.3"
     "@humanwhocodes/config-array" "^0.5.0"
     ajv "^6.10.0"
     chalk "^4.0.0"
@@ -3554,6 +3520,13 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-url-parser@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/fast-url-parser/-/fast-url-parser-1.1.3.tgz#f4af3ea9f34d8a271cf58ad2b3759f431f0b318d"
+  integrity sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=
+  dependencies:
+    punycode "^1.3.2"
+
 fastest-levenshtein@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
@@ -3600,7 +3573,7 @@ filenamify-url@^2.1.1, filenamify-url@^2.1.2:
     filenamify "^4.3.0"
     humanize-url "^2.1.1"
 
-filenamify@^4.1.0, filenamify@^4.3.0:
+filenamify@^4.1.0, filenamify@^4.2.0, filenamify@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-4.3.0.tgz#62391cb58f02b09971c9d4f9d63b3cf9aba03106"
   integrity sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==
@@ -4190,10 +4163,10 @@ ieee754@^1.1.13, ieee754@^1.2.1:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-ignore-walk@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
+ignore-walk@3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.4.tgz#c9a09f69b7c7b479a5d74ac1a3c0d4236d2a6335"
+  integrity sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==
   dependencies:
     minimatch "^3.0.4"
 
@@ -4647,7 +4620,7 @@ jest-diff@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
-jest-diff@^26.0.0:
+jest-diff@^26.0.0, jest-diff@^26.6.1:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
   integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
@@ -4718,6 +4691,16 @@ jest-extended@^0.11.5:
     expect "^24.1.0"
     jest-get-type "^22.4.3"
     jest-matcher-utils "^22.0.0"
+
+jest-file-snapshot@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/jest-file-snapshot/-/jest-file-snapshot-0.5.0.tgz#8b0169a94f2716109f8a0e1d015895b54e927525"
+  integrity sha512-A3cqn9RRB6yl/bMsN9+EiNU94JTptLmoFqmSfSeuku22UYotYF6C/Ntw7C2Kai0C7deirYfpDwRpdlyLhItvMQ==
+  dependencies:
+    chalk "^4.1.0"
+    filenamify "^4.2.0"
+    jest-diff "^26.6.1"
+    mkdirp "^1.0.4"
 
 jest-get-type@^22.4.3:
   version "22.4.3"
@@ -6269,6 +6252,11 @@ punycode@1.3.2:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
+punycode@^1.3.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+  integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
+
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -7252,10 +7240,10 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-teeny-request@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-7.0.1.tgz#bdd41fdffea5f8fbc0d29392cb47bec4f66b2b4c"
-  integrity sha512-sasJmQ37klOlplL4Ia/786M5YlOcoLGQyq2TE4WHSRupbAuDaQW0PfVxV4MtdBtRJ4ngzS+1qim8zP6Zp35qCw==
+teeny-request@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-7.1.1.tgz#2b0d156f4a8ad81de44303302ba8d7f1f05e20e6"
+  integrity sha512-iwY6rkW5DDGq8hE2YgNQlKbptYpY5Nn2xecjQiNjOXWbKzPGUfmeUBCSQbbr306d7Z7U2N0TPl+/SwYRfua1Dg==
   dependencies:
     http-proxy-agent "^4.0.0"
     https-proxy-agent "^5.0.0"
@@ -7598,10 +7586,12 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-urlgrey@0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
-  integrity sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=
+urlgrey@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-1.0.0.tgz#72d2f904482d0b602e3c7fa599343d699bbe1017"
+  integrity sha512-hJfIzMPJmI9IlLkby8QrsCykQ+SXDeO2W5Q9QTW3QpqZVTx4a/K7p8/5q+/isD8vsbVaFgql/gvAoQCRQ2Cb5w==
+  dependencies:
+    fast-url-parser "^1.1.3"
 
 use@^3.1.0:
   version "3.1.1"

--- a/jest.config.js
+++ b/jest.config.js
@@ -29,7 +29,7 @@ module.exports = {
         '@uifabric/styling': '@uifabric/styling/lib-commonjs',
     },
     reporters: ['default', ['jest-junit', { outputDirectory: '<rootDir>/test-results/unit', outputName: 'junit.xml' }]],
-    setupFilesAfterEnv: ['jest-extended'],
+    setupFilesAfterEnv: ['jest-extended', `<rootDir>/src/jest-setup.ts`],
     transform: {
         '^.+\\.(ts|tsx)$': 'ts-jest',
     },

--- a/license-check-and-add-config.json
+++ b/license-check-and-add-config.json
@@ -12,6 +12,7 @@
         "**/test-results",
         "**/dist",
         "**/*.snap",
+        "**/*.snap.md",
         "NOTICES.txt"
     ],
     "license": "./copyright-header.txt",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "fork-ts-checker-webpack-plugin": "^6.2.12",
         "jest": "^27.0.6",
         "jest-extended": "^0.11.5",
+        "jest-file-snapshot": "^0.5.0",
         "jest-junit": "^12.2.0",
         "license-check-and-add": "^4.0.2",
         "mockdate": "^3.0.5",

--- a/src/jest-setup.ts
+++ b/src/jest-setup.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { toMatchFile } from 'jest-file-snapshot';
+
+expect.extend({ toMatchFile });

--- a/src/mark-down/__custom-snapshots__/axe-descriptions.snap.md
+++ b/src/mark-down/__custom-snapshots__/axe-descriptions.snap.md
@@ -1,0 +1,104 @@
+### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
+* **URLs**: 1 URL(s) failed, 1 URL(s) passed, and 1 were not scannable
+* **Rules**: 96 check(s) failed, 1 check(s) passed, and 2 were not applicable
+* Download the **Accessibility Insights artifact** to view the detailed results of these checks
+#### Failed instances
+* **1 × accesskeys**:  Ensures every accesskey attribute value is unique
+* **1 × area-alt**:  Ensures \<area> elements of image maps have alternate text
+* **1 × aria-allowed-attr**:  Ensures ARIA attributes are allowed for an element's role
+* **1 × aria-allowed-role**:  Ensures role attribute has an appropriate value for the element
+* **1 × aria-command-name**:  Ensures every ARIA button, link and menuitem has an accessible name
+* **1 × aria-dialog-name**:  Ensures every ARIA dialog and alertdialog node has an accessible name
+* **1 × aria-hidden-body**:  Ensures aria-hidden='true' is not present on the document body.
+* **1 × aria-hidden-focus**:  Ensures aria-hidden elements do not contain focusable elements
+* **1 × aria-input-field-name**:  Ensures every ARIA input field has an accessible name
+* **1 × aria-meter-name**:  Ensures every ARIA meter node has an accessible name
+* **1 × aria-progressbar-name**:  Ensures every ARIA progressbar node has an accessible name
+* **1 × aria-required-attr**:  Ensures elements with ARIA roles have all required ARIA attributes
+* **1 × aria-required-children**:  Ensures elements with an ARIA role that require child roles contain them
+* **1 × aria-required-parent**:  Ensures elements with an ARIA role that require parent roles are contained by them
+* **1 × aria-roledescription**:  Ensure aria-roledescription is only used on elements with an implicit or explicit role
+* **1 × aria-roles**:  Ensures all elements with a role attribute use a valid value
+* **1 × aria-text**:  Ensures "role=text" is used on elements with no focusable descendants
+* **1 × aria-toggle-field-name**:  Ensures every ARIA toggle field has an accessible name
+* **1 × aria-tooltip-name**:  Ensures every ARIA tooltip node has an accessible name
+* **1 × aria-treeitem-name**:  Ensures every ARIA treeitem node has an accessible name
+* **1 × aria-valid-attr-value**:  Ensures all ARIA attributes have valid values
+* **1 × aria-valid-attr**:  Ensures attributes that begin with aria- are valid ARIA attributes
+* **1 × audio-caption**:  Ensures \<audio> elements have captions
+* **1 × autocomplete-valid**:  Ensure the autocomplete attribute is correct and suitable for the form field
+* **1 × avoid-inline-spacing**:  Ensure that text spacing set through style attributes can be adjusted with custom stylesheets
+* **1 × blink**:  Ensures \<blink> elements are not used
+* **1 × button-name**:  Ensures buttons have discernible text
+* **1 × bypass**:  Ensures each page has at least one mechanism for a user to bypass navigation and jump straight to the content
+* **1 × color-contrast**:  Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
+* **1 × css-orientation-lock**:  Ensures content is not locked to any specific display orientation, and the content is operable in all display orientations
+* **1 × definition-list**:  Ensures \<dl> elements are structured correctly
+* **1 × dlitem**:  Ensures \<dt> and \<dd> elements are contained by a \<dl>
+* **1 × document-title**:  Ensures each HTML document contains a non-empty \<title> element
+* **1 × duplicate-id-active**:  Ensures every id attribute value of active elements is unique
+* **1 × duplicate-id-aria**:  Ensures every id attribute value used in ARIA and in labels is unique
+* **1 × duplicate-id**:  Ensures every id attribute value is unique
+* **1 × empty-heading**:  Ensures headings have discernible text
+* **1 × empty-table-header**:  Ensures table headers have discernible text
+* **1 × focus-order-semantics**:  Ensures elements in the focus order have an appropriate role
+* **1 × form-field-multiple-labels**:  Ensures form field does not have multiple label elements
+* **1 × frame-focusable-content**:  Ensures \<frame> and \<iframe> elements with focusable content do not have tabindex=-1
+* **1 × frame-tested**:  Ensures \<iframe> and \<frame> elements contain the axe-core script
+* **1 × frame-title-unique**:  Ensures \<iframe> and \<frame> elements contain a unique title attribute
+* **1 × frame-title**:  Ensures \<iframe> and \<frame> elements have an accessible name
+* **1 × heading-order**:  Ensures the order of headings is semantically correct
+* **1 × hidden-content**:  Informs users about hidden content.
+* **1 × html-has-lang**:  Ensures every HTML document has a lang attribute
+* **1 × html-lang-valid**:  Ensures the lang attribute of the \<html> element has a valid value
+* **1 × html-xml-lang-mismatch**:  Ensure that HTML elements with both valid lang and xml:lang attributes agree on the base language of the page
+* **1 × identical-links-same-purpose**:  Ensure that links with the same accessible name serve a similar purpose
+* **1 × image-alt**:  Ensures \<img> elements have alternate text or a role of none or presentation
+* **1 × image-redundant-alt**:  Ensure image alternative is not repeated as text
+* **1 × input-button-name**:  Ensures input buttons have discernible text
+* **1 × input-image-alt**:  Ensures \<input type="image"> elements have alternate text
+* **1 × label-content-name-mismatch**:  Ensures that elements labelled through their content must have their visible text as part of their accessible name
+* **1 × label-title-only**:  Ensures that every form element is not solely labeled using the title or aria-describedby attributes
+* **1 × label**:  Ensures every form element has a label
+* **1 × landmark-banner-is-top-level**:  Ensures the banner landmark is at top level
+* **1 × landmark-complementary-is-top-level**:  Ensures the complementary landmark or aside is at top level
+* **1 × landmark-contentinfo-is-top-level**:  Ensures the contentinfo landmark is at top level
+* **1 × landmark-main-is-top-level**:  Ensures the main landmark is at top level
+* **1 × landmark-no-duplicate-banner**:  Ensures the document has at most one banner landmark
+* **1 × landmark-no-duplicate-contentinfo**:  Ensures the document has at most one contentinfo landmark
+* **1 × landmark-no-duplicate-main**:  Ensures the document has at most one main landmark
+* **1 × landmark-one-main**:  Ensures the document has a main landmark
+* **1 × landmark-unique**:  Landmarks should have a unique role or role/label/title (i.e. accessible name) combination
+* **1 × link-in-text-block**:  Links can be distinguished without relying on color
+* **1 × link-name**:  Ensures links have discernible text
+* **1 × list**:  Ensures that lists are structured correctly
+* **1 × listitem**:  Ensures \<li> elements are used semantically
+* **1 × marquee**:  Ensures \<marquee> elements are not used
+* **1 × meta-refresh**:  Ensures \<meta http-equiv="refresh"> is not used
+* **1 × meta-viewport-large**:  Ensures \<meta name="viewport"> can scale a significant amount
+* **1 × meta-viewport**:  Ensures \<meta name="viewport"> does not disable text scaling and zooming
+* **1 × nested-interactive**:  Nested interactive controls are not announced by screen readers
+* **1 × no-autoplay-audio**:  Ensures \<video> or \<audio> elements do not autoplay audio for more than 3 seconds without a control mechanism to stop or mute the audio
+* **1 × object-alt**:  Ensures \<object> elements have alternate text
+* **1 × p-as-heading**:  Ensure p elements are not used to style headings
+* **1 × page-has-heading-one**:  Ensure that the page, or at least one of its frames contains a level-one heading
+* **1 × presentation-role-conflict**:  Flags elements whose role is none or presentation and which cause the role conflict resolution to trigger.
+* **1 × region**:  Ensures all page content is contained by landmarks
+* **1 × role-img-alt**:  Ensures [role='img'] elements have alternate text
+* **1 × scope-attr-valid**:  Ensures the scope attribute is used correctly on tables
+* **1 × scrollable-region-focusable**:  Elements that have scrollable content must be accessible by keyboard
+* **1 × select-name**:  Ensures select element has an accessible name
+* **1 × server-side-image-map**:  Ensures that server-side image maps are not used
+* **1 × skip-link**:  Ensure all skip links have a focusable target
+* **1 × svg-img-alt**:  Ensures svg elements with an img, graphics-document or graphics-symbol role have an accessible text
+* **1 × tabindex**:  Ensures tabindex attribute values are not greater than 0
+* **1 × table-duplicate-name**:  Ensure that tables do not have the same summary and caption
+* **1 × table-fake-caption**:  Ensure that tables with a caption use the \<caption> element.
+* **1 × td-has-header**:  Ensure that each non-empty data cell in a large table has one or more table headers
+* **1 × td-headers-attr**:  Ensure that each cell in a table using the headers refers to another cell in that table
+* **1 × th-has-data-cells**:  Ensure that each table header in a data table refers to data cells
+* **1 × valid-lang**:  Ensures lang attributes have valid values
+* **1 × video-caption**:  Ensures \<video> elements have captions
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent.

--- a/src/mark-down/__snapshots__/markdown-formatter.spec.ts.snap
+++ b/src/mark-down/__snapshots__/markdown-formatter.spec.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`MarkdownFormatter bold 1`] = `"**text**"`;
 
+exports[`MarkdownFormatter escaped 1`] = `"This string contains the \\\\<img> tag"`;
+
 exports[`MarkdownFormatter footerSeparator 1`] = `"---"`;
 
 exports[`MarkdownFormatter heading 1`] = `"## heading"`;

--- a/src/mark-down/__snapshots__/markdown-formatter.spec.ts.snap
+++ b/src/mark-down/__snapshots__/markdown-formatter.spec.ts.snap
@@ -2,8 +2,6 @@
 
 exports[`MarkdownFormatter bold 1`] = `"**text**"`;
 
-exports[`MarkdownFormatter escaped 1`] = `"This string contains the \\\\<img> tag"`;
-
 exports[`MarkdownFormatter footerSeparator 1`] = `"---"`;
 
 exports[`MarkdownFormatter heading 1`] = `"## heading"`;

--- a/src/mark-down/markdown-formatter.spec.ts
+++ b/src/mark-down/markdown-formatter.spec.ts
@@ -16,7 +16,7 @@ import {
 
 describe('MarkdownFormatter', () => {
     it('escaped', () => {
-        expect(escaped('This string contains the <img> tag')).toMatchSnapshot();
+        expect(escaped('<img>')).toEqual('\\<img>');
     });
 
     it('snippet', () => {

--- a/src/mark-down/markdown-formatter.spec.ts
+++ b/src/mark-down/markdown-formatter.spec.ts
@@ -1,9 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { bold, footerSeparator, heading, image, link, listItem, productTitle, sectionSeparator, snippet } from './markdown-formatter';
+import {
+    bold,
+    escaped,
+    footerSeparator,
+    heading,
+    image,
+    link,
+    listItem,
+    productTitle,
+    sectionSeparator,
+    snippet,
+} from './markdown-formatter';
 
 describe('MarkdownFormatter', () => {
+    it('escaped', () => {
+        expect(escaped('This string contains the <img> tag')).toMatchSnapshot();
+    });
+
     it('snippet', () => {
         expect(snippet('code')).toMatchSnapshot();
     });

--- a/src/mark-down/markdown-formatter.ts
+++ b/src/mark-down/markdown-formatter.ts
@@ -3,6 +3,10 @@
 
 import { brand, brandLogoImg, toolName } from '../content/strings';
 
+export const escaped = (markdown: string): string => {
+    return markdown.replace(/</g, '\\<');
+};
+
 export const snippet = (text: string): string => {
     return `\`${text}\``;
 };

--- a/src/mark-down/result-markdown-builder.ts
+++ b/src/mark-down/result-markdown-builder.ts
@@ -4,7 +4,7 @@
 import { CombinedReportParameters } from 'accessibility-insights-report';
 import { injectable } from 'inversify';
 import { brand } from '../content/strings';
-import { bold, footerSeparator, heading, link, listItem, productTitle, sectionSeparator } from './markdown-formatter';
+import { bold, escaped, footerSeparator, heading, link, listItem, productTitle, sectionSeparator } from './markdown-formatter';
 
 @injectable()
 export class ResultMarkdownBuilder {
@@ -82,7 +82,7 @@ export class ResultMarkdownBuilder {
     };
 
     private failedRuleListItem = (failureCount: number, ruleId: string, description: string) => {
-        return listItem(`${bold(`${failureCount} × ${ruleId}`)}:  ${description}`);
+        return listItem(`${bold(`${failureCount} × ${escaped(ruleId)}`)}:  ${escaped(description)}`);
     };
 
     private scanResultDetails(scanResult: string, footer?: string): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3573,7 +3573,7 @@ filenamify-url@^2.1.1, filenamify-url@^2.1.2:
     filenamify "^4.3.0"
     humanize-url "^2.1.1"
 
-filenamify@^4.1.0, filenamify@^4.3.0:
+filenamify@^4.1.0, filenamify@^4.2.0, filenamify@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-4.3.0.tgz#62391cb58f02b09971c9d4f9d63b3cf9aba03106"
   integrity sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==
@@ -4620,7 +4620,7 @@ jest-diff@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
-jest-diff@^26.0.0:
+jest-diff@^26.0.0, jest-diff@^26.6.1:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
   integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
@@ -4691,6 +4691,16 @@ jest-extended@^0.11.5:
     expect "^24.1.0"
     jest-get-type "^22.4.3"
     jest-matcher-utils "^22.0.0"
+
+jest-file-snapshot@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/jest-file-snapshot/-/jest-file-snapshot-0.5.0.tgz#8b0169a94f2716109f8a0e1d015895b54e927525"
+  integrity sha512-A3cqn9RRB6yl/bMsN9+EiNU94JTptLmoFqmSfSeuku22UYotYF6C/Ntw7C2Kai0C7deirYfpDwRpdlyLhItvMQ==
+  dependencies:
+    chalk "^4.1.0"
+    filenamify "^4.2.0"
+    jest-diff "^26.6.1"
+    mkdirp "^1.0.4"
 
 jest-get-type@^22.4.3:
   version "22.4.3"


### PR DESCRIPTION
This PR escapes the < character in axe-core rule IDs and descriptions. The GitHub action (and later, the ADO extension) both render markdown. Without this change, strings like `<img>` or `<video>` are (unsuccessfully) rendered as actual HTML images or videos in both GitHub and Azure DevOps.

#### Details

We replace instances of `<` with `\<` so that tags are not rendered in their HTML forms. GitHub describes some backslash-escaped values [here](https://enterprise.github.com/downloads/en/markdown-cheatsheet.pdf). While HTML tags aren't listed, experimentally this change works well. Azure DevOps [also describes backslash-escaped values](https://docs.microsoft.com/en-us/azure/devops/project/wiki/markdown-guidance?view=azure-devops#ignore-or-escape-markdown-syntax-to-enter-specific-or-literal-characters).

This PR only escapes the `<` character to keep scope small. To help guard against other unexpected renderings (imagine axe-core descriptions with hashtags or asterisks), we [generate a markdown snapshot file](https://github.com/microsoft/accessibility-insights-action/blob/cd14d867721e61155bcf8ee369e537e3d890ecd7/src/mark-down/__custom-snapshots__/axe-descriptions.snap.md) with all possible axe-core IDs and descriptions. Each time this file changes, reviewers can check whether we require changes to markdown generation.

After this change, running automated checks on the generated markdown UI shows no errors.

##### Motivation

Addresses issue #674 

##### Validation

The comment on this PR should properly render `<img>`. I've added a rule failure to the demo website so every PR should produce this error. This PR also adds a snapshot.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
