### PR TITLE
feat(ado/infra): Document release strategy

### DIFF
--- a/dev/release-strategy.md
+++ b/dev/release-strategy.md
@@ -73,6 +73,7 @@ On each iteration, the ADO extension release pipeline will do the following:
 #### Pipeline questions:
 
 -   What should trigger the build pipeline? Every commit?
+-   What should trigger the release pipelines? Manually triggered?
 -   How do we tag the sources repo when the Action release pipeline runs?
 -   Are there scenarios where we would publish _just_ the action or _just_ the ADO extension?
 

--- a/dev/release-strategy.md
+++ b/dev/release-strategy.md
@@ -9,7 +9,7 @@ Licensed under the MIT License.
 
 -   We will store the both the sources and the releases in the `accessibility-insights-action` repo (unchanged from today). If we later decide to change this, we will move the source code to a new repo and keep the consumption experience unchanged.
 -   All code contributions will merge into the main branch
--   All releases will be pipeline-controlled
+-   All releases will be workflow-controlled
 -   We will create a new branch for each release of the GitHub Action. That branch will contain just the files needed to release the action (`action.yml`, the code packed into `index.js`, etc.)
 -   The existing ./dist folder of the repo will first be removed, then added to `./.gitignore`. It will exist only for local building and testing
 
@@ -48,26 +48,24 @@ Each release will have a tag that points to the corresponding sources in the mai
 
 It is expected that there will be some cases where the `-gh` suffixed tag and the `-ado` suffixed tag will point to the same commit.
 
-### Pipelines
+### Workflows
 
-Logically we will have one build pipeline and two release pipelines (one for the GitHub action, one for the ADO extension). These may or may not be completely separate pipelines at first. Here are the responsibilities of each pipeline.
+Logically we will have one build workflow and two release workflows (one for the GitHub action, one for the ADO extension). Here are the responsibilities of each workflow.
 
-#### Build pipeline
+#### Build workflow
 
-On each iteration, the **build pipeline** will do the following:
+This will be implemented as a GitHub action that triggers on each commit. When triggered,, the **build workflow** will do the following:
 
--   Clone the repo (`main` branch)
--   Build the `/dist` folder and the _signed_ ADO extension (if signing is required)
+-   Clone the repo (`main` branch) at the lastest SHA
+-   Build the `/dist` folder and ADO extension (Open question: Should we sign in this action?)
 -   Perform any possible self-validation
--   Publish the contents of the `/dist` folder as the _Action artifact_
--   Publish the ADO extension as the _ADO artifact_
 
-#### Action release pipeline
+#### Action release workflow
 
-On each iteration, the **action release pipeline** will do the following: Assume that our release version is `vX.Y.Z`
+This will be implemented as a GitHub action that is manually triggered. When triggered, the **action release workflow** will do the following: Assume that our release version is `vX.Y.Z`
 
--   Clone the repo
--   Download the _Action artifact_ created by the build pipeline
+-   Clone the repo (`main` branch) at a specific SHA
+-   Build the `/dist` folder as the _Action artifact_
 -   Create a new branch (_releases/vX.Y.Z_), probably failing the release if the branch already exists
 -   Copy the _Action artifact_ into the new branch
 -   Commit the new branch
@@ -77,19 +75,18 @@ On each iteration, the **action release pipeline** will do the following: Assume
 -   Create a tag that corresponds to the SHA that build this release (_vX.Y.X-sources-gh_)
 -   Push all new tags
 
-#### ADO extension release pipeline
+#### ADO extension release workflow
 
-On each iteration, the **ADO extension release** pipeline will do the following:
+This will be implemented as an ADO pipeline that is manually triggered. When triggered, the **ADO extension release workflow** will do the following:
 
--   Download the _ADO artifact_ created by the build pipeline
--   Publish the ADO artifact to the marketplace
+-   Clone the repo (`main` branch) at a specific SHA
+-   Build and sign the _ADO artifact_ from the sources in `main`
+-   Publish the _ADO artifact_ to the marketplace
 -   Create a tag that corresponds to the SHA that build this release (_vX.Y.X-sources-ado_)
 -   Push the new tag
 
-#### Pipeline questions:
+#### Workflow questions:
 
--   What should trigger the **build pipeline**? Every commit?
--   What should trigger the release pipelines? Manually triggered?
 -   Do we need Canary/Insider/Production for release validation, or are we OK with just Production?
 
 ### Models for consuming the action
@@ -116,7 +113,7 @@ The yaml file excerpt would look something like this:
 
 #### Use the latest version
 
-If we need this functionality (for the validation pipeilne, perhaps), we can make the release pipeline responsible for maintaining a `latest` tag that always references the release with the _highest version_. If we do this, then the yaml file excerpt would look something like this:
+If we need this functionality (for the validation pipeilne, perhaps), we can make the ADO release workflow responsible for maintaining a `latest` tag that always references the release with the _highest version_. If we do this, then the yaml file excerpt would look something like this:
 
 ```
   steps:

--- a/dev/release-strategy.md
+++ b/dev/release-strategy.md
@@ -1,0 +1,39 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+
+## Release Strategy
+
+This repo will be the release point for our GitHub action. We will use a release strategy that enables supports for multiple versions, while providing sufficient flexibility to also support releases other than actions. To this end, we will adopt the following branch structure for releases of major versions 1 to N of the GitHub action:
+
+```
+/main
+/release
+  /action
+    /v1
+    .
+    .
+    .
+    /vN
+```
+
+Releases of other components (such as the Azure DevOps extension) will be siblings of the `/release/action` branch.
+
+The contents of each versioned branch will get completely refreshed with each new release, so syncing the version branch will always return the latest release of _that version_. We will also create a new tag (_e.g._, `v1.0.3`) with each new release. All branches under the `/release` branch will be locked down by branch policy that restricts all changes to the build pipeline. One potential exception to this practice might be a repo administrator creating the new branch (_e.g._, `/release/v2`) when a new major release is being prepared.
+
+Users wishing to always use _latest release_ of the `v1` action would include the following in their yml file:
+
+```
+  steps:
+    name: Check Accessibility
+    uses: actions/microsoft/accessibility-insights-action/release/action/v1
+```
+
+Users wishing to use a _specific release_ (_e.g._, `v1.0.3`) of the `v1` action would include the following in their yml file:
+
+```
+  steps:
+    name: Check Accessibility
+    uses: actions/microsoft/accessibility-insights-action/release/action/v1@v1.0.3
+```

--- a/dev/release-strategy.md
+++ b/dev/release-strategy.md
@@ -9,25 +9,37 @@ Licensed under the MIT License.
 
 -   We will store the both the sources and the releases in the `accessibility-insights-action` repo (unchanged from today). If we later decide to change this, we will move the source code to a new repo and keep the consumption experience unchanged.
 -   All code contributions will merge into the main branch
--   All releases will be workflow-controlled
+-   All releases will be workflow-controlled and will be external to the main branch
 -   We will create a new commit for each release of the GitHub Action.
 -   The existing ./dist folder of the repo will first be removed, then added to `./.gitignore`. It will exist only for local building and testing
 
-### Release branches
+### Release organization
 
-Each release will be associated with a commit containing _just the files needed for release_ (_i.e._, without the original source files). To minimize potential confusion, our preferred option is to keep each of these commits _disassociated_ from any specific branch. We believe that this is possible with relatively little effort. If, however, this proves infeasible, then we will have exactly _one_ branch used for releases of the GitHub action. That branch will be named `releases/gh`. We currently believe that the ADO extension will release via the ADO marketplace and will _not_ require a corresponding release commit. In a worst-case scenario (we need branches both for both action and for ADO), we will use a branch named `releases/ado` for ADO releases.
+Each release will be associated with a commit containing _just the files needed for release_ (_i.e._, without the original source files). The structure of each commit will be:
+
+```
+NOTICE.html
+README.md
+action.yml
+/dist
+    index.js
+    package.json
+    yarn.lock
+```
+
+To minimize potential confusion, each commit will be _unassociated_ with any specific branch. We currently believe that the ADO extension will release via the ADO marketplace and will _not_ require a corresponding release commit.
 
 ### Tags
 
 #### Release tags
 
-Each release of the GitHub Action will have a tag that points to a specific commit within the repo. That commit will contain just the files needed to release the action (current thought is `index.js`, `action.yaml`, `notice.html`, `license.md`, `readme.md`--the readme will probably point back to the source tag used to create the release). In addition, each major release version will have a tag that points to the latest release of that major version. We could optionally also have a `latest` tag, which would point to the highest released version, as shown here:
+Each release of the GitHub Action will have a tag that points to a specific commit within the repo. In addition, each major release version will have a tag that points to the highest version of that major version.
 
 ```
 v1.0.1   <== v1.0.1
 v1.0.2   <== v1.0.2
 v1.0.3   <== v1.0.3, v1
-v2.0.0   <== v2.0.0, v2, latest
+v2.0.0   <== v2.0.0, v2
 ```
 
 #### Source tags
@@ -41,53 +53,48 @@ Each release will have a corresponding tag that identifies the commit used to ge
 
 It is expected that there will be some cases where the `-gh` suffixed tag and the `-ado` suffixed tag will point to the same commit.
 
-### Workflows
+### Pipelines
 
-Logically we will have one build workflow and two release workflows (one for the GitHub action, one for the ADO extension). Here are the responsibilities of each workflow.
+We will have one build pipeline and two release pipelines (one for the GitHub action, one for the ADO extension). Here are the responsibilities of each workflow.
 
-#### Build workflow
+#### Build pipeline
 
-This will be implemented as a GitHub action if possible, an ADO pipeline if not. In either case, the workflow will trigger on each commit. Once triggered, the **build workflow** will do the following:
+This will be implemented as an ADO pipeline that will trigger on each commit to the `main` branch. Once triggered, the **build pipeline** will do the following:
 
--   Clone the repo (`main` branch) at the lastest SHA
--   Build the `/dist` folder and ADO extension
+-   Clone the repo (`main` branch) at the specified SHA
+-   Build the GitHub action and ADO extension
+-   Perform any required signing
 -   Perform any possible self-validation
+-   Publish the GitHub action as the _Action artifact_
+-   Publish the ADO extension as the _ADO artifact_
 
-#### Action release workflow
+#### Action release pipeline
 
-This will be implemented as a GitHub action if possible, an ADO pipeline if not. In either case, the workflow will be manually triggered. Once triggered, the **action release workflow** will do the following: Assume that our release version is `vX.Y.Z`
+This will be implemented as manually triggered ADO pipeline. Once triggered, the **action release pipeline** will do the following: Assume that our release version is `vX.Y.Z`
 
--   Clone the repo at a specified source commit
--   Build the `/dist` folder as the _Action artifact_
--   Create a new orphaned branch (_releases/gh/vX.Y.Z_), failing if the branch already exists.
--   Copy the _Action artifact_ into the new branch
--   Commit the new branch
--   Create a release tag (_vX.Y.Z_)
+-   Download the _Action artifact_ from the **build pipeline**
+-   Commit the _Action artifact_ to the repo (external to any branch)
+-   Create a release tag (_vX.Y.Z_) pointing the new commmit
 -   Create or update the major version tag (_vX_)
--   Create or update the `latest` tag (if we use it and if no higher-versioned release already exists)
 -   Create a `vX.Y.Z-sources-gh` tag that corresponds to the specified source commit
 -   Push all of the created/updated tags
--   Delete the orphaned branch. The commit will now exist outside of any branch
 
 #### ADO extension release workflow
 
 This will be implemented as an ADO pipeline that is manually triggered. Once triggered, the **ADO extension release workflow** will do the following:
 
--   Clone the repo at a specified source commit
--   Build and sign the _ADO artifact_
+-   Download the _ADO artifact_ from the **build pipeline**
 -   Publish the _ADO artifact_ to the marketplace
 -   Create a `vX.Y.Z-sources-ado` tag that corresponds to the specified source commit
 -   Push the new tag
 
 #### Open questions:
 
--   Is it possible to generate the Action's ThirdPartyNotices file through a GitHub action, or is that only available through an ADO pipeline?
--   Should we sign bits during the build workflow, or should we accept the risk of discovering signing issues only in the release workflows?
 -   Do we need Canary/Insider/Production for release validation, or are we OK with just Production?
 
-### Models for consuming the action
+### Models for consuming the GitHub action
 
-#### Pin to the latest version a major version
+#### Pin to the highest version a major version
 
 The yaml file excerpt would look something like this:
 
@@ -105,14 +112,4 @@ The yaml file excerpt would look something like this:
   steps:
     name: Check Accessibility
     uses: actions/microsoft/accessibility-insights-action@v1.0.3
-```
-
-#### Use the latest version
-
-If we need this functionality (for the validation pipeilne, perhaps), we can make the ADO release workflow responsible for maintaining a `latest` tag that always references the release with the _highest version_. If we do this, then the yaml file excerpt would look something like this:
-
-```
-  steps:
-    name: Check Accessibility
-    uses: actions/microsoft/accessibility-insights-action@latest
 ```

--- a/dev/release-strategy.md
+++ b/dev/release-strategy.md
@@ -18,10 +18,10 @@ Licensed under the MIT License.
 The repo will contain 1 branch per released version of the GitHub action. We are explicitly assuming that the ADO extension will release via the ADO marketplace and will not require a corresponding release branch. The name of the branch will be the same as the name of the release for the GitHub Action, as shown here:
 
 ```
-/v1.0.1
-/v1.0.2
-/v1.0.3
-/v2.0.0
+v1.0.1
+v1.0.2
+v1.0.3
+v2.0.0
 ```
 
 ### Tags
@@ -31,10 +31,10 @@ The repo will contain 1 branch per released version of the GitHub action. We are
 Each release of the GitHub Action will have a tag that points to each specific release branch within the repo. In addition, each major release version will have a tag that points to the latest release of that major version. We could optionally also have a `latest` tag, which would point to the highest released version, as shown here:
 
 ```
-/v1.0.1   <== v1.0.1
-/v1.0.2   <== v1.0.2
-/v1.0.3   <== v1.0.3, v1
-/v2.0.0   <== v2.0.0, v2, latest
+v1.0.1   <== v1.0.1
+v1.0.2   <== v1.0.2
+v1.0.3   <== v1.0.3, v1
+v2.0.0   <== v2.0.0, v2, latest
 ```
 
 #### Source tags

--- a/dev/release-strategy.md
+++ b/dev/release-strategy.md
@@ -23,7 +23,6 @@ README.md
 action.yml
 /dist
     index.js
-    index.js.map
     package.json
     yarn.lock
 ```

--- a/dev/release-strategy.md
+++ b/dev/release-strategy.md
@@ -76,6 +76,7 @@ On each iteration, the ADO extension release pipeline will do the following:
 -   What should trigger the release pipelines? Manually triggered?
 -   How do we tag the sources repo when the Action release pipeline runs?
 -   Are there scenarios where we would publish _just_ the action or _just_ the ADO extension?
+-   Do we need Canary/Insider/Production for release validation, or are we OK with just Production?
 
 ### Models for consuming the action
 

--- a/dev/release-strategy.md
+++ b/dev/release-strategy.md
@@ -54,10 +54,10 @@ Logically we will have one build workflow and two release workflows (one for the
 
 #### Build workflow
 
-This will be implemented as a GitHub action that triggers on each commit. When triggered,, the **build workflow** will do the following:
+This will be implemented as a GitHub action that triggers on each commit. When triggered, the **build workflow** will do the following:
 
 -   Clone the repo (`main` branch) at the lastest SHA
--   Build the `/dist` folder and ADO extension (Open question: Should we sign in this action?)
+-   Build the `/dist` folder and ADO extension
 -   Perform any possible self-validation
 
 #### Action release workflow
@@ -66,7 +66,7 @@ This will be implemented as a GitHub action that is manually triggered. When tri
 
 -   Clone the repo (`main` branch) at a specific SHA
 -   Build the `/dist` folder as the _Action artifact_
--   Create a new branch (_releases/vX.Y.Z_), probably failing the release if the branch already exists
+-   Create a new parentless branch (_releases/gh/vX.Y.Z_), failing if the branch already exists.
 -   Copy the _Action artifact_ into the new branch
 -   Commit the new branch
 -   Create a release tag (_vX.Y.Z_)
@@ -85,8 +85,10 @@ This will be implemented as an ADO pipeline that is manually triggered. When tri
 -   Create a tag that corresponds to the SHA that build this release (_vX.Y.X-sources-ado_)
 -   Push the new tag
 
-#### Workflow questions:
+#### Open questions:
 
+-   Is it possible to generate the Action's ThirdPartyNotices file through a GitHub action, or is that only available through an ADO pipeline?
+-   Should we sign bits during the build workflow, or should we accept the risk of discovering signing issues only in the release workflows?
 -   Do we need Canary/Insider/Production for release validation, or are we OK with just Production?
 
 ### Models for consuming the action

--- a/dev/release-strategy.md
+++ b/dev/release-strategy.md
@@ -23,6 +23,7 @@ README.md
 action.yml
 /dist
     index.js
+    index.js.map
     package.json
     yarn.lock
 ```

--- a/dev/release-strategy.md
+++ b/dev/release-strategy.md
@@ -5,25 +5,76 @@ Licensed under the MIT License.
 
 ## Release Strategy
 
-### Release Branch
+### Repos
 
-This repo will be the release point for our GitHub action. We'll create a single top-level `/release` branch, parallel to the `/main` branch, and it will be used by all consumers.
+-   We will store the sources in the `accessibility-insights-action` repo (unchanged from today)
+-   We will store the action releases in a _separate_ repo. Name is TBD, but maybe `accessibility-insights-action-dist`. For purposes of this doc, we'll call the two repos "the sources repo" and "the distribution repo"
+-   For a given release (_e.g._, `v1.0.3`), we will use the same tag name in both repos to make it easy to correlate the two.
+-   All changes to the distribution repo will be controlled by the pipeline
+-   Each release in the distribution repo will be in a branch that matches its tag. That branch will contain just the files needed to release the action (`action.yml`, the code packed into `index.js`, etc.)
+-   Consuming actions will reference the distribution repo.
+
+### Branches in the distribution repo
+
+The distribution repo will contain 1 branch per released version. The name of the branch will be the same as the name of the release, as shown here:
 
 ```
-/main
-/release
+/v1.0.1
+/v1.0.2
+/v1.0.3
+/v2.0.0
 ```
 
-### Pipeline manipulation of `release` branch
+### Tags in the distribution repo
 
-For each release, the pipeline will do the following:
+The distribution repo will have a tag that points to each specific release within the repo. In addition, each major release version will have a tag that points to the latest release of that major version. We could optionally also have a `latest` tag, which would point to the highest released version, as shown here:
 
--   Clone the `/release` branch at its latest commit
--   Delete all files from the `/release` branch
--   Copy the newly built distributable files to the `/release` branch
--   Commit the changes to the `/release` branch
--   Create a tag that corresponds to the commit. Expected format is `v1.0.3`
--   Create or update the major version tag (name matches the major version of the just-created tag, so `v1` in this case) to reference the same commit. We will only update this tag if the new release is a higher version than the major version tag, so if the major version tag pointed to `v1.0.4`, we wouldn't "rewind" it back to `v1.0.3`
+```
+/v1.0.1   <== v1.0.1
+/v1.0.2   <== v1.0.2
+/v1.0.3   <== v1.0.3, v1
+/v2.0.0   <== v2.0.0, v2, latest
+```
+
+### Pipelines
+
+Logically we will have a build pipeline and 2 release pipelines (one for the GitHub action, one for the ADO extension). These may or may not be completely separate pipelines at first. Here are the responsibilities of each pipeline
+
+#### Build pipeline
+
+On each iteration, the build pipeline will do the following:
+
+-   Clone the source repo
+-   Build the `/dist` folder and the _signed_ ADO extension (if signing is required)
+-   Perform any possible self-validation
+-   Publish the contents of the `/dist` folder as an artifact
+-   Publish the ADO extension as an artifact
+
+#### Action release pipeline
+
+On each iteration, the action release pipeline will do the following:
+
+-   Clone the distribution repo
+-   Download the action artifact created by the release pipeline
+-   Create a new branch of the appropriate name (probably fail if the branch already exists)
+-   Copy the action artifact into the new branch
+-   Commit the new branch
+-   Create a release tag
+-   Create or update the major version tag
+-   Create or update the `latest` tag (if we use it)
+
+#### ADO extension release pipeline
+
+On each iteration, the ADO extension release pipeline will do the following:
+
+-   Download the action artifact created by the release pipeline
+-   Publish the ADO artifact
+
+#### Pipeline questions:
+
+-   What should trigger the build pipeline? Every commit?
+-   How do we tag the sources repo when the Action release pipeline runs?
+-   Are there scenarios where we would publish _just_ the action or _just_ the ADO extension?
 
 ### Models for consuming the action
 
@@ -34,7 +85,7 @@ The yaml file excerpt would look something like this:
 ```
   steps:
     name: Check Accessibility
-    uses: actions/microsoft/accessibility-insights-action@v1
+    uses: actions/microsoft/accessibility-insights-action-dist@v1
 ```
 
 #### Pin to a specific release
@@ -44,19 +95,7 @@ The yaml file excerpt would look something like this:
 ```
   steps:
     name: Check Accessibility
-    uses: actions/microsoft/accessibility-insights-action@v1.0.3
-```
-
-#### Use the most recent commit to the release branch
-
-Note that this is generally not recommended, both because it will float and because the returned version is unpredictable. It will always return the _most recent commit_ to the `/release` branch, which is not guaranteed to be the latest _version_ in some maintenance scenarios. That said, it is a supported scenario:
-
-The yaml file excerpt would look something like this:
-
-```
-  steps:
-    name: Check Accessibility
-    uses: actions/microsoft/accessibility-insights-action/release
+    uses: actions/microsoft/accessibility-insights-action-dist@v1.0.3
 ```
 
 #### Use the latest version


### PR DESCRIPTION
#### Details

Discuss and document how we intend to manage our releases in a way that supports multiple versions and allows users to easily control what version of the action they use. In turn, this will inform the actions taken by the build and release pipelines.

##### Motivation

Flush out assumptions

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [1862304](https://dev.azure.com/mseng/1ES/_workitems/edit/1862304)
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
- [n/a] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
