### PR TITLE
feat(ado/infra):  Generate release commit info during build

### DIFF
--- a/packages/RELEASE_COMMIT.md
+++ b/packages/RELEASE_COMMIT.md
@@ -1,8 +1,0 @@
-<!--
-Copyright (c) Microsoft Corporation. All rights reserved.
-Licensed under the MIT License.
--->
-
-# About
-
-This release was generated from this source tree [Commit_Message](https://github.com/microsoft/accessibility-insights-action/tree/Commit_SHA).

--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -152,7 +152,7 @@ jobs:
                                   
                                   # About
                                   
-                                  This release was generated from this source tree [$(Build.SourceVersion)\](https://github.com/microsoft/accessibility-insights-action/tree/$(Build.SourceVersion)).
+                                  This release was generated from this source tree [$(Build.SourceVersion)](https://github.com/microsoft/accessibility-insights-action/tree/$(Build.SourceVersion)).
                                   ' > '$(System.DefaultWorkingDirectory)/drop/RELEASE_COMMIT.md'
 
             displayName: 'Generate Release README Info'

--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -143,11 +143,6 @@ jobs:
                 outputfile: '$(System.DefaultWorkingDirectory)/NOTICE.html'
                 outputformat: html
 
-          - bash: |
-                sed -i "s/Commit_Message/$(Build.SourceVersionMessage)/g" "./packages/RELEASE_COMMIT.md"
-                sed -i "s/Commit_SHA/$(Build.SourceVersion)/g" "./packages/RELEASE_COMMIT.md"
-            displayName: generate release README Info
-
           - task: CopyFiles@2
             displayName: 'Copy Files to: drop'
             inputs:
@@ -157,9 +152,21 @@ jobs:
                     $(System.DefaultWorkingDirectory)/packages/gh-action/dist/package.json
                     $(System.DefaultWorkingDirectory)/packages/gh-action/dist/yarn.lock
                     $(System.DefaultWorkingDirectory)/packages/gh-action/action.yml
-                    $(System.DefaultWorkingDirectory)/packages/RELEASE_COMMIT.md
 
                 TargetFolder: '$(System.DefaultWorkingDirectory)/drop'
+
+          - bash: |
+                echo '<!--
+                                  Copyright (c) Microsoft Corporation. All rights reserved.
+                                  Licensed under the MIT License.
+                                  -->
+                                  
+                                  # About
+                                  
+                                  This release was generated from this source tree [$(Build.SourceVersionMessage)\](https://github.com/microsoft/accessibility-insights-action/tree/$(Build.SourceVersion)).
+                                  ' > '$(System.DefaultWorkingDirectory)/RELEASE_COMMIT.md'
+
+            displayName: 'Generate Release README Info'
 
           - task: PublishBuildArtifacts@1
             inputs:

--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -164,7 +164,7 @@ jobs:
                                   # About
                                   
                                   This release was generated from this source tree [$(Build.SourceVersionMessage)\](https://github.com/microsoft/accessibility-insights-action/tree/$(Build.SourceVersion)).
-                                  ' > '$(System.DefaultWorkingDirectory)/RELEASE_COMMIT.md'
+                                  ' > '$(System.DefaultWorkingDirectory)/drop/RELEASE_COMMIT.md'
 
             displayName: 'Generate Release README Info'
 

--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -152,7 +152,7 @@ jobs:
                                   
                                   # About
                                   
-                                  This release was generated from this source tree [$(Build.SourceVersionMessage)\](https://github.com/microsoft/accessibility-insights-action/tree/$(Build.SourceVersion)).
+                                  This release was generated from this source tree [$(Build.SourceVersion)\](https://github.com/microsoft/accessibility-insights-action/tree/$(Build.SourceVersion)).
                                   ' > '$(System.DefaultWorkingDirectory)/drop/RELEASE_COMMIT.md'
 
             displayName: 'Generate Release README Info'


### PR DESCRIPTION
#### Details

Generate the release commit info in the build pipeline.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
