### PR TITLE
feat(ado/infra): Remove release instruction 

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -94,20 +94,3 @@ _Note_: When run act first time choose **large** image option.
 _Note_: When you get an error about composite actions is not supported then [build act from source](https://github.com/nektos/act#building-from-source) to use latest features.
 
 Action is running inside a docker container. After action is completed the docker container is still running to preserve chrome setup and reduce subsequent action startup time.
-
-# Release instructions
-
-To create a new release, a repo maintainer should follow these steps:
-
-1. Create and merge a release pull request to `main` which:
-    - Updates `/package.json` with a new semantic version number
-    - Updates `/docs/usage.md` if needed to reference the upcoming tag
-    - Updates `/dist/` with the results of `yarn build`
-    - Updates `/NOTICES.txt` based on the dependencies in `yarn.lock`. If your release PR updates `yarn.lock`, you might consider splitting this step out into a separate follow-up PR.
-2. Validate the release build
-    - Wait for a passing CI build against `main`
-    - Update a separate test repository to refer to `accessibility-insights-action@mergecommithash` and verify that it functions as expected
-3. Create/update the corresponding git tags for the release:
-    - Create a new release tag using the version in `package.json` (eg, `git tag v1.2.3`)
-    - Update the corresponding major-version tag (eg, `git tag -f v1`)
-    - Push both tags


### PR DESCRIPTION
#### Details

Remove release instruction from the repo.

##### Motivation

The release process was automated and the instruction to use our pipelines was moved internally.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
