### PR TITLE
feat(ado/infra): publish ado-extension distribution folder each build

### DIFF
--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -1,6 +1,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+trigger: # trigger only affects CI builds
+    branches:
+        include:
+            - main
+
 variables:
     linuxImage: 'ubuntu-18.04'
     windowsImage: 'windows-2019'

--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -31,19 +31,6 @@ jobs:
           - script: yarn lint:check
             displayName: Check for lint errors
 
-    - job: 'Tests'
-      pool:
-          vmImage: $(linuxImage)
-          demands: npm
-      steps:
-          - task: NodeTool@0
-            inputs:
-                versionSpec: '12.x'
-            displayName: use node 12.x
-
-          - script: yarn install --frozen-lockfile
-            displayName: Install dependencies
-
           - script: yarn test -- -- --ci --coverage
             displayName: Run tests
             env:
@@ -53,7 +40,7 @@ jobs:
             displayName: Publish code coverage to codecov
 
     - job: 'SDT'
-      condition: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
       pool:
           vmImage: $(windowsImage)
           demands: npm

--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -53,6 +53,7 @@ jobs:
             displayName: Publish code coverage to codecov
 
     - job: 'SDT'
+      condition: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
       pool:
           vmImage: $(windowsImage)
           demands: npm
@@ -162,3 +163,9 @@ jobs:
                 pathtoPublish: '$(System.DefaultWorkingDirectory)/drop'
                 artifactName: 'drop'
             displayName: publish drop
+
+          - task: PublishBuildArtifacts@1
+            inputs:
+                pathtoPublish: '$(System.DefaultWorkingDirectory)/packages/ado-extension/dist'
+                artifactName: 'ado-extension-drop'
+            displayName: publish ado-extension-drop


### PR DESCRIPTION
#### Details

This PR publishes `packages/ado-extension/dist` as an artifact every time the CI build runs. This allows us to create a release pipeline that consumes these artifacts and packages/publishes a VSIX file.

I limit this build to run on CI (our tests for this repository are in GitHub workflows) - doesn't make sense to create artifacts or run SDT on PRs.

I also combined the test & lint jobs for now (PublishBuildDrops is still the longest) and made sure we build before running tests (otherwise consumers of @accessibility-isnights-action/shared can't import properly).

Lastly, I add a condition to SDT so it only runs on the main branch. This lets us queue CI builds on test branches for test releases without modifying the pipeline structure too much. May come back and change this if we separate SDT into its own pipeline.

##### Motivation

enables us to get releases working - like the prototype, it'd be nice to get automated deployment early to speed up dev time

##### Context

Validation: https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=25234&view=results

Not in this PR:
- refactoring gh-action drop name to avoid regressing gh-action releases; should address holistically in a separate PR
- modifying CG to produce independent NOTICE files for gh-action or ado-extension; need to address separately

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
