### PR TITLE
feat(ado/infra): Refactor to set IoC using inversify

### DIFF
--- a/packages/gh-action/package.json
+++ b/packages/gh-action/package.json
@@ -30,7 +30,9 @@
         "url": "https://github.com/microsoft/accessibility-insights-action/issues"
     },
     "homepage": "https://github.com/microsoft/accessibility-insights-action#readme",
-    "devDependencies": {},
+    "devDependencies": {
+        "inversify": "^5.1.1"
+    },
     "dependencies": {
         "reflect-metadata": "^0.1.13",
         "@accessibility-insights-action/shared": "^1.0.0"

--- a/packages/gh-action/package.json
+++ b/packages/gh-action/package.json
@@ -34,6 +34,9 @@
         "inversify": "^5.1.1"
     },
     "dependencies": {
+        "@actions/core": "^1.4.0",
+        "@actions/github": "^5.0.0",
+        "@octokit/rest": "^18.9.0",
         "reflect-metadata": "^0.1.13",
         "@accessibility-insights-action/shared": "^1.0.0"
     }

--- a/packages/gh-action/package.json
+++ b/packages/gh-action/package.json
@@ -30,10 +30,9 @@
         "url": "https://github.com/microsoft/accessibility-insights-action/issues"
     },
     "homepage": "https://github.com/microsoft/accessibility-insights-action#readme",
-    "devDependencies": {
-        "inversify": "^5.1.1"
-    },
+    "devDependencies": {},
     "dependencies": {
+        "inversify": "^5.1.1",
         "@actions/core": "^1.4.0",
         "@actions/github": "^5.0.0",
         "@octokit/rest": "^18.9.0",

--- a/packages/gh-action/src/check-run/check-run-creator.spec.ts
+++ b/packages/gh-action/src/check-run/check-run-creator.spec.ts
@@ -5,15 +5,7 @@ import 'reflect-metadata';
 import * as github from '@actions/github';
 import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
 import { IMock, Mock, Times } from 'typemoq';
-import {
-    iocTypes,
-    Logger,
-    ProgressReporter,
-    ReportMarkdownConvertor,
-    checkRunDetailsTitle,
-    checkRunName,
-    disclaimerText,
-} from '@accessibility-insights-action/shared';
+import { Logger, ReportMarkdownConvertor, checkRunDetailsTitle, disclaimerText } from '@accessibility-insights-action/shared';
 import { CheckRunCreator } from './check-run-creator';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 

--- a/packages/gh-action/src/check-run/check-run-creator.spec.ts
+++ b/packages/gh-action/src/check-run/check-run-creator.spec.ts
@@ -5,10 +5,15 @@ import 'reflect-metadata';
 import * as github from '@actions/github';
 import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
 import { IMock, Mock, Times } from 'typemoq';
-import { disclaimerText } from '../../content/mark-down-strings';
-import { checkRunDetailsTitle } from '../../content/strings';
-import { Logger } from '../../logger/logger';
-import { ReportMarkdownConvertor } from '../../mark-down/report-markdown-convertor';
+import {
+    iocTypes,
+    Logger,
+    ProgressReporter,
+    ReportMarkdownConvertor,
+    checkRunDetailsTitle,
+    checkRunName,
+    disclaimerText,
+} from '@accessibility-insights-action/shared';
 import { CheckRunCreator } from './check-run-creator';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 

--- a/packages/gh-action/src/check-run/check-run-creator.ts
+++ b/packages/gh-action/src/check-run/check-run-creator.ts
@@ -6,7 +6,6 @@ import { Octokit } from '@octokit/rest';
 import { inject, injectable } from 'inversify';
 import { isNil } from 'lodash';
 import {
-    iocTypes,
     Logger,
     ProgressReporter,
     ReportMarkdownConvertor,
@@ -15,6 +14,7 @@ import {
     disclaimerText,
 } from '@accessibility-insights-action/shared';
 import { CombinedReportParameters } from 'accessibility-insights-report';
+import { GitHubIocTypes } from '../ioc/gh-ioc-types';
 
 // Pulling these types from RestEndpointMethodTypes would be better, but we can't do so until
 // https://github.com/octokit/rest.js/issues/2000 is resolved. The better versions would be:
@@ -41,7 +41,7 @@ export class CheckRunCreator extends ProgressReporter {
     constructor(
         @inject(ReportMarkdownConvertor) private readonly reportMarkdownConvertor: ReportMarkdownConvertor,
         @inject(Octokit) private readonly octokit: Octokit,
-        @inject(iocTypes.Github) private readonly githubObj: typeof github,
+        @inject(GitHubIocTypes.Github) private readonly githubObj: typeof github,
         @inject(Logger) private readonly logger: Logger,
     ) {
         super();

--- a/packages/gh-action/src/check-run/check-run-creator.ts
+++ b/packages/gh-action/src/check-run/check-run-creator.ts
@@ -5,12 +5,15 @@ import * as github from '@actions/github';
 import { Octokit } from '@octokit/rest';
 import { inject, injectable } from 'inversify';
 import { isNil } from 'lodash';
-import { disclaimerText } from '../../content/mark-down-strings';
-import { checkRunDetailsTitle, checkRunName } from '../../content/strings';
-import { iocTypes } from '../../ioc/ioc-types';
-import { Logger } from '../../logger/logger';
-import { ReportMarkdownConvertor } from '../../mark-down/report-markdown-convertor';
-import { ProgressReporter } from '../progress-reporter';
+import {
+    iocTypes,
+    Logger,
+    ProgressReporter,
+    ReportMarkdownConvertor,
+    checkRunDetailsTitle,
+    checkRunName,
+    disclaimerText,
+} from '@accessibility-insights-action/shared';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 
 // Pulling these types from RestEndpointMethodTypes would be better, but we can't do so until

--- a/packages/gh-action/src/index.ts
+++ b/packages/gh-action/src/index.ts
@@ -3,12 +3,12 @@
 import 'reflect-metadata';
 import './module-name-mapper';
 
-import { setupSharedIocContainer } from '@accessibility-insights-action/shared';
 import { Logger } from '@accessibility-insights-action/shared';
 import { Scanner } from '@accessibility-insights-action/shared';
+import { setupIocContainer } from './ioc/setup-ioc-container';
 
 (async () => {
-    const container = setupSharedIocContainer();
+    const container = setupIocContainer();
     const logger = container.get(Logger);
     await logger.setup();
 

--- a/packages/gh-action/src/index.ts
+++ b/packages/gh-action/src/index.ts
@@ -3,12 +3,12 @@
 import 'reflect-metadata';
 import './module-name-mapper';
 
-import { setupIocContainer } from '@accessibility-insights-action/shared';
+import { setupSharedIocContainer } from '@accessibility-insights-action/shared';
 import { Logger } from '@accessibility-insights-action/shared';
 import { Scanner } from '@accessibility-insights-action/shared';
 
 (async () => {
-    const container = setupIocContainer();
+    const container = setupSharedIocContainer();
     const logger = container.get(Logger);
     await logger.setup();
 

--- a/packages/gh-action/src/ioc/gh-ioc-types.ts
+++ b/packages/gh-action/src/ioc/gh-ioc-types.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export const GitHubIocTypes = {
+    Github: 'Github',
+};

--- a/packages/gh-action/src/ioc/setup-ioc-container.spec.ts
+++ b/packages/gh-action/src/ioc/setup-ioc-container.spec.ts
@@ -10,6 +10,7 @@ import { iocTypes } from '@accessibility-insights-action/shared';
 import { GHTaskConfig } from '../task-config/gh-task-config';
 import { PullRequestCommentCreator } from '../pull-request/pull-request-comment-creator';
 import { CheckRunCreator } from '../check-run/check-run-creator';
+import { GitHubIocTypes } from './gh-ioc-types';
 
 describe(setupIocContainer, () => {
     let testSubject: Container;
@@ -22,7 +23,7 @@ describe(setupIocContainer, () => {
         verifySingletonDependencyResolution(testSubject, key);
     });
     test.each([
-        { key: iocTypes.Github, value: github },
+        { key: GitHubIocTypes.Github, value: github },
         { key: iocTypes.TaskConfig, value: GHTaskConfig },
         { key: iocTypes.ProgressReporters, value: [PullRequestCommentCreator, CheckRunCreator] },
     ])('verify constant value resolution %s', (pair: { key: string; value: any }) => {

--- a/packages/gh-action/src/ioc/setup-ioc-container.spec.ts
+++ b/packages/gh-action/src/ioc/setup-ioc-container.spec.ts
@@ -8,6 +8,8 @@ import { Container } from 'inversify';
 import { setupIocContainer } from './setup-ioc-container';
 import { iocTypes } from '@accessibility-insights-action/shared';
 import { GHTaskConfig } from '../task-config/gh-task-config';
+import { PullRequestCommentCreator } from '../pull-request/pull-request-comment-creator';
+import { CheckRunCreator } from '../check-run/check-run-creator';
 
 describe(setupIocContainer, () => {
     let testSubject: Container;
@@ -22,8 +24,9 @@ describe(setupIocContainer, () => {
     test.each([
         { key: iocTypes.Github, value: github },
         { key: iocTypes.TaskConfig, value: GHTaskConfig },
+        { key: iocTypes.ProgressReporters, value: [PullRequestCommentCreator, CheckRunCreator] },
     ])('verify constant value resolution %s', (pair: { key: string; value: any }) => {
-        expect(testSubject.get(pair.key)).toBe(pair.value);
+        expect(testSubject.get(pair.key)).toEqual(pair.value);
     });
 
     function verifySingletonDependencyResolution(container: Container, key: any): void {

--- a/packages/gh-action/src/ioc/setup-ioc-container.spec.ts
+++ b/packages/gh-action/src/ioc/setup-ioc-container.spec.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import * as github from '@actions/github';
+import { Octokit } from '@octokit/rest';
+import { Container } from 'inversify';
+import { setupIocContainer } from './setup-ioc-container';
+import { iocTypes } from '@accessibility-insights-action/shared';
+import { GHTaskConfig } from '../task-config/gh-task-config';
+
+describe(setupIocContainer, () => {
+    let testSubject: Container;
+
+    beforeEach(() => {
+        testSubject = setupIocContainer();
+    });
+
+    test.each([Octokit])('verify singleton resolution %p', (key: any) => {
+        verifySingletonDependencyResolution(testSubject, key);
+    });
+    test.each([
+        { key: iocTypes.Github, value: github },
+        { key: iocTypes.TaskConfig, value: GHTaskConfig },
+    ])('verify constant value resolution %s', (pair: { key: string; value: any }) => {
+        expect(testSubject.get(pair.key)).toBe(pair.value);
+    });
+
+    function verifySingletonDependencyResolution(container: Container, key: any): void {
+        expect(container.get(key)).toBeDefined();
+        expect(container.get(key)).toBe(container.get(key));
+    }
+});

--- a/packages/gh-action/src/ioc/setup-ioc-container.spec.ts
+++ b/packages/gh-action/src/ioc/setup-ioc-container.spec.ts
@@ -19,12 +19,11 @@ describe(setupIocContainer, () => {
         testSubject = setupIocContainer();
     });
 
-    test.each([Octokit])('verify singleton resolution %p', (key: any) => {
+    test.each([iocTypes.TaskConfig, Octokit])('verify singleton resolution %p', (key: any) => {
         verifySingletonDependencyResolution(testSubject, key);
     });
     test.each([
         { key: GitHubIocTypes.Github, value: github },
-        { key: iocTypes.TaskConfig, value: GHTaskConfig },
         { key: iocTypes.ProgressReporters, value: [PullRequestCommentCreator, CheckRunCreator] },
     ])('verify constant value resolution %s', (pair: { key: string; value: any }) => {
         expect(testSubject.get(pair.key)).toEqual(pair.value);

--- a/packages/gh-action/src/ioc/setup-ioc-container.spec.ts
+++ b/packages/gh-action/src/ioc/setup-ioc-container.spec.ts
@@ -19,15 +19,18 @@ describe(setupIocContainer, () => {
         testSubject = setupIocContainer();
     });
 
-    test.each([iocTypes.TaskConfig, Octokit])('verify singleton resolution %p', (key: any) => {
-        verifySingletonDependencyResolution(testSubject, key);
-    });
-    test.each([
-        { key: GitHubIocTypes.Github, value: github },
-        { key: iocTypes.ProgressReporters, value: [PullRequestCommentCreator, CheckRunCreator] },
-    ])('verify constant value resolution %s', (pair: { key: string; value: any }) => {
-        expect(testSubject.get(pair.key)).toEqual(pair.value);
-    });
+    test.each([CheckRunCreator, PullRequestCommentCreator, iocTypes.TaskConfig, iocTypes.ProgressReporters, Octokit])(
+        'verify singleton resolution %p',
+        (key: any) => {
+            verifySingletonDependencyResolution(testSubject, key);
+        },
+    );
+    test.each([{ key: GitHubIocTypes.Github, value: github }])(
+        'verify constant value resolution %s',
+        (pair: { key: string; value: any }) => {
+            expect(testSubject.get(pair.key)).toEqual(pair.value);
+        },
+    );
 
     function verifySingletonDependencyResolution(container: Container, key: any): void {
         expect(container.get(key)).toBeDefined();

--- a/packages/gh-action/src/ioc/setup-ioc-container.spec.ts
+++ b/packages/gh-action/src/ioc/setup-ioc-container.spec.ts
@@ -7,7 +7,6 @@ import { Octokit } from '@octokit/rest';
 import { Container } from 'inversify';
 import { setupIocContainer } from './setup-ioc-container';
 import { iocTypes } from '@accessibility-insights-action/shared';
-import { GHTaskConfig } from '../task-config/gh-task-config';
 import { PullRequestCommentCreator } from '../pull-request/pull-request-comment-creator';
 import { CheckRunCreator } from '../check-run/check-run-creator';
 import { GitHubIocTypes } from './gh-ioc-types';

--- a/packages/gh-action/src/ioc/setup-ioc-container.ts
+++ b/packages/gh-action/src/ioc/setup-ioc-container.ts
@@ -4,7 +4,7 @@
 import * as github from '@actions/github';
 import { Octokit } from '@octokit/rest';
 import * as inversify from 'inversify';
-import { iocTypes, setupSharedIocContainer, ProgressReporter } from '@accessibility-insights-action/shared';
+import { iocTypes, setupSharedIocContainer } from '@accessibility-insights-action/shared';
 import { GHTaskConfig } from '../task-config/gh-task-config';
 import { GitHubIocTypes } from './gh-ioc-types';
 import { PullRequestCommentCreator } from '../pull-request/pull-request-comment-creator';

--- a/packages/gh-action/src/ioc/setup-ioc-container.ts
+++ b/packages/gh-action/src/ioc/setup-ioc-container.ts
@@ -22,7 +22,7 @@ export function setupIocContainer(container = new inversify.Container({ autoBind
             const pullRequestCommentCreator = context.container.get(PullRequestCommentCreator);
             const checkRunCreator = context.container.get(CheckRunCreator);
 
-            return { checkRunCreator, pullRequestCommentCreator };
+            return [checkRunCreator, pullRequestCommentCreator];
         })
         .inSingletonScope();
 

--- a/packages/gh-action/src/ioc/setup-ioc-container.ts
+++ b/packages/gh-action/src/ioc/setup-ioc-container.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as github from '@actions/github';
+import { Octokit } from '@octokit/rest';
+import * as inversify from 'inversify';
+import { iocTypes, setupSharedIocContainer } from '@accessibility-insights-action/shared';
+import { GitHubIocTypes } from './gh-ioc-types';
+import { GHTaskConfig } from '../task-config/gh-task-config';
+
+export function setupIocContainer(container = new inversify.Container({ autoBindInjectable: true })): inversify.Container {
+    container = setupSharedIocContainer(container);
+    // container.bind(GitHubIocTypes.Github).toConstantValue(github);
+    container.bind(iocTypes.TaskConfig).toConstantValue(GHTaskConfig);
+    // container
+    //     .bind(Octokit)
+    //     .toDynamicValue((context) => {
+    //         const taskConfig = context.container.get(GHTaskConfig);
+
+    //         return new Octokit({ auth: taskConfig.getToken() });
+    //     })
+    //     .inSingletonScope();
+
+    return container;
+}

--- a/packages/gh-action/src/ioc/setup-ioc-container.ts
+++ b/packages/gh-action/src/ioc/setup-ioc-container.ts
@@ -13,7 +13,7 @@ import { CheckRunCreator } from '../check-run/check-run-creator';
 export function setupIocContainer(container = new inversify.Container({ autoBindInjectable: true })): inversify.Container {
     container = setupSharedIocContainer(container);
     container.bind(GitHubIocTypes.Github).toConstantValue(github);
-    container.bind(iocTypes.TaskConfig).toConstantValue(GHTaskConfig);
+    container.bind(iocTypes.TaskConfig).to(GHTaskConfig).inSingletonScope();
     container.bind(iocTypes.ProgressReporters).toConstantValue([PullRequestCommentCreator, CheckRunCreator]);
 
     container

--- a/packages/gh-action/src/ioc/setup-ioc-container.ts
+++ b/packages/gh-action/src/ioc/setup-ioc-container.ts
@@ -5,21 +5,25 @@ import * as github from '@actions/github';
 import { Octokit } from '@octokit/rest';
 import * as inversify from 'inversify';
 import { iocTypes, setupSharedIocContainer } from '@accessibility-insights-action/shared';
-import { GitHubIocTypes } from './gh-ioc-types';
 import { GHTaskConfig } from '../task-config/gh-task-config';
+import { GitHubIocTypes } from './gh-ioc-types';
+import { PullRequestCommentCreator } from '../pull-request/pull-request-comment-creator';
+import { CheckRunCreator } from '../check-run/check-run-creator';
 
 export function setupIocContainer(container = new inversify.Container({ autoBindInjectable: true })): inversify.Container {
     container = setupSharedIocContainer(container);
-    // container.bind(GitHubIocTypes.Github).toConstantValue(github);
+    container.bind(GitHubIocTypes.Github).toConstantValue(github);
     container.bind(iocTypes.TaskConfig).toConstantValue(GHTaskConfig);
-    // container
-    //     .bind(Octokit)
-    //     .toDynamicValue((context) => {
-    //         const taskConfig = context.container.get(GHTaskConfig);
+    container.bind(iocTypes.ProgressReporters).toConstantValue([PullRequestCommentCreator, CheckRunCreator]);
 
-    //         return new Octokit({ auth: taskConfig.getToken() });
-    //     })
-    //     .inSingletonScope();
+    container
+        .bind(Octokit)
+        .toDynamicValue((context) => {
+            const taskConfig = context.container.get(GHTaskConfig);
+
+            return new Octokit({ auth: taskConfig.getToken() });
+        })
+        .inSingletonScope();
 
     return container;
 }

--- a/packages/gh-action/src/pull-request/pull-request-comment-creator.spec.ts
+++ b/packages/gh-action/src/pull-request/pull-request-comment-creator.spec.ts
@@ -5,9 +5,8 @@ import 'reflect-metadata';
 import * as github from '@actions/github';
 import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-import { Logger } from '../../logger/logger';
-import { ReportMarkdownConvertor } from '../../mark-down/report-markdown-convertor';
-import { productTitle } from '../../mark-down/markdown-formatter';
+import { Logger, ReportMarkdownConvertor, productTitle } from '@accessibility-insights-action/shared';
+
 import { PullRequestCommentCreator } from './pull-request-comment-creator';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 

--- a/packages/gh-action/src/pull-request/pull-request-comment-creator.ts
+++ b/packages/gh-action/src/pull-request/pull-request-comment-creator.ts
@@ -5,11 +5,7 @@ import * as github from '@actions/github';
 import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
 import { inject, injectable } from 'inversify';
 import { isEmpty, isNil } from 'lodash';
-import { iocTypes } from '../../ioc/ioc-types';
-import { Logger } from '../../logger/logger';
-import { ReportMarkdownConvertor } from '../../mark-down/report-markdown-convertor';
-import { productTitle } from '../../mark-down/markdown-formatter';
-import { ProgressReporter } from '../progress-reporter';
+import { iocTypes, Logger, ProgressReporter, ReportMarkdownConvertor, productTitle } from '@accessibility-insights-action/shared';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 
 type ListCommentsResponseItem = RestEndpointMethodTypes['issues']['listComments']['response']['data'][0];

--- a/packages/gh-action/src/pull-request/pull-request-comment-creator.ts
+++ b/packages/gh-action/src/pull-request/pull-request-comment-creator.ts
@@ -5,8 +5,9 @@ import * as github from '@actions/github';
 import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
 import { inject, injectable } from 'inversify';
 import { isEmpty, isNil } from 'lodash';
-import { iocTypes, Logger, ProgressReporter, ReportMarkdownConvertor, productTitle } from '@accessibility-insights-action/shared';
+import { Logger, ProgressReporter, ReportMarkdownConvertor, productTitle } from '@accessibility-insights-action/shared';
 import { CombinedReportParameters } from 'accessibility-insights-report';
+import { GitHubIocTypes } from '../ioc/gh-ioc-types';
 
 type ListCommentsResponseItem = RestEndpointMethodTypes['issues']['listComments']['response']['data'][0];
 
@@ -15,7 +16,7 @@ export class PullRequestCommentCreator extends ProgressReporter {
     constructor(
         @inject(ReportMarkdownConvertor) private readonly reportMarkdownConvertor: ReportMarkdownConvertor,
         @inject(Octokit) private readonly octokit: Octokit,
-        @inject(iocTypes.Github) private readonly githubObj: typeof github,
+        @inject(GitHubIocTypes.Github) private readonly githubObj: typeof github,
         @inject(Logger) private readonly logger: Logger,
     ) {
         super();

--- a/packages/gh-action/src/task-config/gh-task-config.spec.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.spec.ts
@@ -6,19 +6,19 @@ import * as actionCore from '@actions/core';
 import normalizePath from 'normalize-path';
 import path from 'path';
 import { Mock, Times, IMock } from 'typemoq';
-import { TaskConfig } from './task-config';
+import { GHTaskConfig } from './gh-task-config';
 
-describe(TaskConfig, () => {
+describe(GHTaskConfig, () => {
     let processStub: any;
     let actionCoreMock: IMock<typeof actionCore>;
-    let taskConfig: TaskConfig;
+    let taskConfig: GHTaskConfig;
 
     beforeEach(() => {
         processStub = {
             env: {},
         } as any;
         actionCoreMock = Mock.ofType<typeof actionCore>();
-        taskConfig = new TaskConfig(processStub, actionCoreMock.object);
+        taskConfig = new GHTaskConfig(processStub, actionCoreMock.object);
     });
 
     afterEach(() => {
@@ -30,19 +30,19 @@ describe(TaskConfig, () => {
     }
 
     it.each`
-        inputOption                 | inputValue                | expectedValue                                          | getInputFunc
-        ${'repo-token'}             | ${'token'}                | ${'token'}                                             | ${() => taskConfig.getToken()}
-        ${'scan-url-relative-path'} | ${'path'}                 | ${'path'}                                              | ${() => taskConfig.getScanUrlRelativePath()}
-        ${'chrome-path'}            | ${'./../src/chrome-path'} | ${getPlatformAgnosticPath(__dirname + '/chrome-path')} | ${() => taskConfig.getChromePath()}
-        ${'input-file'}             | ${'./../src/input-file'}  | ${getPlatformAgnosticPath(__dirname + '/input-file')}  | ${() => taskConfig.getInputFile()}
-        ${'output-dir'}             | ${'./../src/output-dir'}  | ${getPlatformAgnosticPath(__dirname + '/output-dir')}  | ${() => taskConfig.getReportOutDir()}
-        ${'site-dir'}               | ${'path'}                 | ${'path'}                                              | ${() => taskConfig.getSiteDir()}
-        ${'url'}                    | ${'url'}                  | ${'url'}                                               | ${() => taskConfig.getUrl()}
-        ${'discovery-patterns'}     | ${'abc'}                  | ${'abc'}                                               | ${() => taskConfig.getDiscoveryPatterns()}
-        ${'input-urls'}             | ${'abc'}                  | ${'abc'}                                               | ${() => taskConfig.getInputUrls()}
-        ${'max-urls'}               | ${'20'}                   | ${20}                                                  | ${() => taskConfig.getMaxUrls()}
-        ${'scan-timeout'}           | ${'100000'}               | ${100000}                                              | ${() => taskConfig.getScanTimeout()}
-        ${'localhost-port'}         | ${'8080'}                 | ${8080}                                                | ${() => taskConfig.getLocalhostPort()}
+        inputOption                 | inputValue         | expectedValue                                          | getInputFunc
+        ${'repo-token'}             | ${'token'}         | ${'token'}                                             | ${() => taskConfig.getToken()}
+        ${'scan-url-relative-path'} | ${'path'}          | ${'path'}                                              | ${() => taskConfig.getScanUrlRelativePath()}
+        ${'chrome-path'}            | ${'./chrome-path'} | ${getPlatformAgnosticPath(__dirname + '/chrome-path')} | ${() => taskConfig.getChromePath()}
+        ${'input-file'}             | ${'./input-file'}  | ${getPlatformAgnosticPath(__dirname + '/input-file')}  | ${() => taskConfig.getInputFile()}
+        ${'output-dir'}             | ${'./output-dir'}  | ${getPlatformAgnosticPath(__dirname + '/output-dir')}  | ${() => taskConfig.getReportOutDir()}
+        ${'site-dir'}               | ${'path'}          | ${'path'}                                              | ${() => taskConfig.getSiteDir()}
+        ${'url'}                    | ${'url'}           | ${'url'}                                               | ${() => taskConfig.getUrl()}
+        ${'discovery-patterns'}     | ${'abc'}           | ${'abc'}                                               | ${() => taskConfig.getDiscoveryPatterns()}
+        ${'input-urls'}             | ${'abc'}           | ${'abc'}                                               | ${() => taskConfig.getInputUrls()}
+        ${'max-urls'}               | ${'20'}            | ${20}                                                  | ${() => taskConfig.getMaxUrls()}
+        ${'scan-timeout'}           | ${'100000'}        | ${100000}                                              | ${() => taskConfig.getScanTimeout()}
+        ${'localhost-port'}         | ${'8080'}          | ${8080}                                                | ${() => taskConfig.getLocalhostPort()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
@@ -66,7 +66,7 @@ describe(TaskConfig, () => {
             .setup((o) => o.getInput('chrome-path'))
             .returns(() => '')
             .verifiable(Times.once());
-        taskConfig = new TaskConfig(processStub, actionCoreMock.object);
+        taskConfig = new GHTaskConfig(processStub, actionCoreMock.object);
 
         const absolutePath = taskConfig.getChromePath();
 
@@ -84,7 +84,7 @@ describe(TaskConfig, () => {
             .setup((o) => o.getInput('input-file'))
             .returns(() => './file.txt')
             .verifiable(Times.once());
-        taskConfig = new TaskConfig(processStub, actionCoreMock.object);
+        taskConfig = new GHTaskConfig(processStub, actionCoreMock.object);
 
         const absolutePath = taskConfig.getInputFile();
 
@@ -98,7 +98,7 @@ describe(TaskConfig, () => {
                 GITHUB_RUN_ID: `${runId}`,
             },
         } as any;
-        taskConfig = new TaskConfig(processStub, actionCoreMock.object);
+        taskConfig = new GHTaskConfig(processStub, actionCoreMock.object);
 
         const actualRunId = taskConfig.getRunId();
 

--- a/packages/gh-action/src/task-config/gh-task-config.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.ts
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as actionCore from '@actions/core';
+import { inject, injectable } from 'inversify';
+import { isEmpty } from 'lodash';
+import * as process from 'process';
+import { iocTypes } from '@accessibility-insights-action/shared';
+import normalizePath from 'normalize-path';
+import { resolve } from 'path';
+import { TaskConfig } from '@accessibility-insights-action/shared/dist/task-config';
+
+@injectable()
+export class GHTaskConfig extends TaskConfig {
+    constructor(
+        @inject(iocTypes.Process) protected readonly processObj: typeof process,
+        private readonly actionCoreObj = actionCore,
+        private readonly resolvePath: typeof resolve = resolve,
+    ) {
+        super(processObj);
+    }
+
+    public getReportOutDir(): string {
+        return this.getAbsolutePath(this.actionCoreObj.getInput('output-dir'));
+    }
+
+    public getSiteDir(): string {
+        return this.actionCoreObj.getInput('site-dir');
+    }
+
+    public getScanUrlRelativePath(): string {
+        return this.actionCoreObj.getInput('scan-url-relative-path');
+    }
+
+    public getToken(): string {
+        return this.actionCoreObj.getInput('repo-token');
+    }
+
+    public getChromePath(): string {
+        let chromePath;
+        chromePath = this.getAbsolutePath(this.actionCoreObj.getInput('chrome-path'));
+
+        if (isEmpty(chromePath)) {
+            chromePath = this.processObj.env.CHROME_BIN;
+        }
+
+        return chromePath;
+    }
+
+    public getUrl(): string {
+        return this.actionCoreObj.getInput('url');
+    }
+
+    public getMaxUrls(): number {
+        return parseInt(this.actionCoreObj.getInput('max-urls'));
+    }
+
+    public getDiscoveryPatterns(): string {
+        const value = this.actionCoreObj.getInput('discovery-patterns');
+
+        return isEmpty(value) ? undefined : value;
+    }
+
+    public getInputFile(): string {
+        return this.getAbsolutePath(this.actionCoreObj.getInput('input-file'));
+    }
+
+    public getInputUrls(): string {
+        const value = this.actionCoreObj.getInput('input-urls');
+
+        return isEmpty(value) ? undefined : value;
+    }
+
+    public getScanTimeout(): number {
+        return parseInt(this.actionCoreObj.getInput('scan-timeout'));
+    }
+
+    public getLocalhostPort(): number {
+        const value = this.actionCoreObj.getInput('localhost-port');
+
+        return isEmpty(value) ? undefined : parseInt(value, 10);
+    }
+
+    private getAbsolutePath(path: string): string {
+        if (isEmpty(path)) {
+            return undefined;
+        }
+
+        const dirname = this.processObj.env.GITHUB_WORKSPACE ?? __dirname;
+
+        return normalizePath(this.resolvePath(dirname, normalizePath(path)));
+    }
+}

--- a/packages/gh-action/src/task-config/gh-task-config.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.ts
@@ -5,10 +5,9 @@ import * as actionCore from '@actions/core';
 import { inject, injectable } from 'inversify';
 import { isEmpty } from 'lodash';
 import * as process from 'process';
-import { iocTypes } from '@accessibility-insights-action/shared';
+import { iocTypes, TaskConfig } from '@accessibility-insights-action/shared';
 import normalizePath from 'normalize-path';
 import { resolve } from 'path';
-import { TaskConfig } from '@accessibility-insights-action/shared/dist/task-config';
 
 @injectable()
 export class GHTaskConfig extends TaskConfig {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -28,9 +28,6 @@
     "homepage": "https://github.com/microsoft/accessibility-insights-action#readme",
     "devDependencies": {},
     "dependencies": {
-        "@actions/core": "^1.4.0",
-        "@actions/github": "^5.0.0",
-        "@octokit/rest": "^18.9.0",
         "accessibility-insights-report": "4.1.2",
         "accessibility-insights-scan": "0.8.1",
         "axe-core": "4.2.1",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,3 +5,8 @@ export { setupSharedIocContainer } from './ioc/setup-ioc-container';
 export { Logger } from './logger/logger';
 export { Scanner } from './scanner/scanner';
 export { iocTypes } from './ioc/ioc-types';
+export { ProgressReporter } from './progress-reporter/progress-reporter';
+export { ReportMarkdownConvertor } from './mark-down/report-markdown-convertor';
+export { productTitle } from './mark-down/markdown-formatter';
+export { disclaimerText } from './content/mark-down-strings';
+export { checkRunDetailsTitle, checkRunName } from './content/strings';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,3 +10,4 @@ export { ReportMarkdownConvertor } from './mark-down/report-markdown-convertor';
 export { productTitle } from './mark-down/markdown-formatter';
 export { disclaimerText } from './content/mark-down-strings';
 export { checkRunDetailsTitle, checkRunName } from './content/strings';
+export { TaskConfig } from './task-config';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export { setupIocContainer } from './ioc/setup-ioc-container';
+export { setupSharedIocContainer } from './ioc/setup-ioc-container';
 export { Logger } from './logger/logger';
 export { Scanner } from './scanner/scanner';
+export { iocTypes } from './ioc/ioc-types';

--- a/packages/shared/src/ioc/ioc-types.ts
+++ b/packages/shared/src/ioc/ioc-types.ts
@@ -10,4 +10,5 @@ export const iocTypes = {
     ServeStatic: 'ServeStatic',
     Github: 'Github',
     TaskConfig: 'TaskConfig',
+    ProgressReporters: 'ProgressReporters',
 };

--- a/packages/shared/src/ioc/ioc-types.ts
+++ b/packages/shared/src/ioc/ioc-types.ts
@@ -8,7 +8,6 @@ export const iocTypes = {
     GetPort: 'GetPort',
     Express: 'Express',
     ServeStatic: 'ServeStatic',
-    Github: 'Github',
     TaskConfig: 'TaskConfig',
     ProgressReporters: 'ProgressReporters',
 };

--- a/packages/shared/src/ioc/ioc-types.ts
+++ b/packages/shared/src/ioc/ioc-types.ts
@@ -9,4 +9,5 @@ export const iocTypes = {
     Express: 'Express',
     ServeStatic: 'ServeStatic',
     Github: 'Github',
+    TaskConfig: 'TaskConfig',
 };

--- a/packages/shared/src/ioc/setup-ioc-container.spec.ts
+++ b/packages/shared/src/ioc/setup-ioc-container.spec.ts
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import 'reflect-metadata';
-
-import * as github from '@actions/github';
-import { Octokit } from '@octokit/rest';
 import { reporterFactory } from 'accessibility-insights-report';
 import express from 'express';
 import getPort from 'get-port';
@@ -12,17 +9,18 @@ import serveStatic from 'serve-static';
 import { Logger } from '../logger/logger';
 import { Scanner } from '../scanner/scanner';
 import { iocTypes } from './ioc-types';
-import { setupSharedIocContainer } from './setup-ioc-container';
+import { setupSharedIocContainer, setupIocContainer } from './setup-ioc-container';
 import { TaskConfig } from '../task-config';
+import { ProgressReporter } from '../progress-reporter/progress-reporter';
 
 describe(setupSharedIocContainer, () => {
     let testSubject: Container;
 
     beforeEach(() => {
-        testSubject = setupSharedIocContainer();
+        testSubject = setupIocContainer();
     });
 
-    test.each([Scanner, Octokit, Logger])('verify singleton resolution %p', (key: any) => {
+    test.each([Scanner, Logger])('verify singleton resolution %p', (key: any) => {
         verifySingletonDependencyResolution(testSubject, key);
     });
     test.each([
@@ -32,10 +30,10 @@ describe(setupSharedIocContainer, () => {
         { key: iocTypes.Express, value: express },
         { key: iocTypes.ServeStatic, value: serveStatic },
         { key: iocTypes.ReportFactory, value: reporterFactory },
-        { key: iocTypes.Github, value: github },
         { key: iocTypes.TaskConfig, value: TaskConfig },
+        { key: iocTypes.ProgressReporters, value: [ProgressReporter] },
     ])('verify constant value resolution %s', (pair: { key: string; value: any }) => {
-        expect(testSubject.get(pair.key)).toBe(pair.value);
+        expect(testSubject.get(pair.key)).toEqual(pair.value);
     });
 
     function verifySingletonDependencyResolution(container: Container, key: any): void {

--- a/packages/shared/src/ioc/setup-ioc-container.spec.ts
+++ b/packages/shared/src/ioc/setup-ioc-container.spec.ts
@@ -12,13 +12,14 @@ import serveStatic from 'serve-static';
 import { Logger } from '../logger/logger';
 import { Scanner } from '../scanner/scanner';
 import { iocTypes } from './ioc-types';
-import { setupIocContainer } from './setup-ioc-container';
+import { setupSharedIocContainer } from './setup-ioc-container';
+import { TaskConfig } from '../task-config';
 
-describe(setupIocContainer, () => {
+describe(setupSharedIocContainer, () => {
     let testSubject: Container;
 
     beforeEach(() => {
-        testSubject = setupIocContainer();
+        testSubject = setupSharedIocContainer();
     });
 
     test.each([Scanner, Octokit, Logger])('verify singleton resolution %p', (key: any) => {
@@ -32,6 +33,7 @@ describe(setupIocContainer, () => {
         { key: iocTypes.ServeStatic, value: serveStatic },
         { key: iocTypes.ReportFactory, value: reporterFactory },
         { key: iocTypes.Github, value: github },
+        { key: iocTypes.TaskConfig, value: TaskConfig },
     ])('verify constant value resolution %s', (pair: { key: string; value: any }) => {
         expect(testSubject.get(pair.key)).toBe(pair.value);
     });

--- a/packages/shared/src/ioc/setup-ioc-container.ts
+++ b/packages/shared/src/ioc/setup-ioc-container.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as github from '@actions/github';
-import { Octokit } from '@octokit/rest';
 import { reporterFactory } from 'accessibility-insights-report';
 import express from 'express';
 import getPort from 'get-port';
@@ -14,6 +12,16 @@ import { Scanner } from '../scanner/scanner';
 import { TaskConfig } from '../task-config';
 import { iocTypes } from './ioc-types';
 import { setupCliContainer } from 'accessibility-insights-scan';
+import { ProgressReporter } from '../progress-reporter/progress-reporter';
+
+export function setupIocContainer(container = new inversify.Container({ autoBindInjectable: true })): inversify.Container {
+    setupSharedIocContainer(container);
+
+    container.bind(iocTypes.TaskConfig).toConstantValue(TaskConfig);
+    container.bind(iocTypes.ProgressReporters).toConstantValue([ProgressReporter]);
+
+    return container;
+}
 
 export function setupSharedIocContainer(container = new inversify.Container({ autoBindInjectable: true })): inversify.Container {
     setupCliContainer(container);
@@ -25,14 +33,6 @@ export function setupSharedIocContainer(container = new inversify.Container({ au
     container.bind(iocTypes.Express).toConstantValue(express);
     container.bind(iocTypes.ServeStatic).toConstantValue(serveStatic);
     container.bind(iocTypes.ReportFactory).toConstantValue(reporterFactory);
-    container.bind(iocTypes.Github).toConstantValue(github);
-
-    container
-        .bind(Octokit)
-        .toDynamicValue(() => {
-            return new Octokit({ auth: '' });
-        })
-        .inSingletonScope();
 
     container
         .bind(Logger)

--- a/packages/shared/src/ioc/setup-ioc-container.ts
+++ b/packages/shared/src/ioc/setup-ioc-container.ts
@@ -15,8 +15,7 @@ import { TaskConfig } from '../task-config';
 import { iocTypes } from './ioc-types';
 import { setupCliContainer } from 'accessibility-insights-scan';
 
-export function setupIocContainer(): inversify.Container {
-    const container = new inversify.Container({ autoBindInjectable: true });
+export function setupSharedIocContainer(container = new inversify.Container({ autoBindInjectable: true })): inversify.Container {
     setupCliContainer(container);
 
     container.bind(Scanner).toSelf().inSingletonScope();
@@ -30,10 +29,8 @@ export function setupIocContainer(): inversify.Container {
 
     container
         .bind(Octokit)
-        .toDynamicValue((context) => {
-            const taskConfig = context.container.get(TaskConfig);
-
-            return new Octokit({ auth: taskConfig.getToken() });
+        .toDynamicValue(() => {
+            return new Octokit({ auth: '' });
         })
         .inSingletonScope();
 

--- a/packages/shared/src/local-file-server.spec.ts
+++ b/packages/shared/src/local-file-server.spec.ts
@@ -29,10 +29,49 @@ class MockableExpress implements ExpressInterface {
     }
 }
 
+class TaskConfigBase extends TaskConfig {
+    getReportOutDir(): string {
+        throw new Error('Method not implemented.');
+    }
+    getSiteDir(): string {
+        throw new Error('Method not implemented.');
+    }
+    getScanUrlRelativePath(): string {
+        throw new Error('Method not implemented.');
+    }
+    getToken(): string {
+        throw new Error('Method not implemented.');
+    }
+    getChromePath(): string {
+        throw new Error('Method not implemented.');
+    }
+    getUrl(): string {
+        throw new Error('Method not implemented.');
+    }
+    getMaxUrls(): number {
+        throw new Error('Method not implemented.');
+    }
+    getDiscoveryPatterns(): string {
+        throw new Error('Method not implemented.');
+    }
+    getInputFile(): string {
+        throw new Error('Method not implemented.');
+    }
+    getInputUrls(): string {
+        throw new Error('Method not implemented.');
+    }
+    getScanTimeout(): number {
+        throw new Error('Method not implemented.');
+    }
+    getLocalhostPort(): number {
+        throw new Error('Method not implemented.');
+    }
+}
+
 describe(LocalFileServer, () => {
     let localFileServer: LocalFileServer;
     let loggerMock: IMock<Logger>;
-    let taskConfigMock: IMock<TaskConfig>;
+    let taskConfigMock: IMock<TaskConfigBase>;
     let getPortMock: IMock<typeof getPort>;
     let expressMock: IMock<typeof express>;
     let serverStaticMock: IMock<typeof serveStatic>;
@@ -44,7 +83,7 @@ describe(LocalFileServer, () => {
 
     beforeEach(() => {
         loggerMock = Mock.ofType(Logger);
-        taskConfigMock = Mock.ofType(TaskConfig);
+        taskConfigMock = Mock.ofType(TaskConfigBase);
         getPortMock = Mock.ofType<typeof getPort>();
         serverStaticMock = Mock.ofType<typeof serveStatic>();
         expressMock = Mock.ofType<typeof express>();

--- a/packages/shared/src/local-file-server.spec.ts
+++ b/packages/shared/src/local-file-server.spec.ts
@@ -29,49 +29,10 @@ class MockableExpress implements ExpressInterface {
     }
 }
 
-class TaskConfigBase extends TaskConfig {
-    getReportOutDir(): string {
-        throw new Error('Method not implemented.');
-    }
-    getSiteDir(): string {
-        throw new Error('Method not implemented.');
-    }
-    getScanUrlRelativePath(): string {
-        throw new Error('Method not implemented.');
-    }
-    getToken(): string {
-        throw new Error('Method not implemented.');
-    }
-    getChromePath(): string {
-        throw new Error('Method not implemented.');
-    }
-    getUrl(): string {
-        throw new Error('Method not implemented.');
-    }
-    getMaxUrls(): number {
-        throw new Error('Method not implemented.');
-    }
-    getDiscoveryPatterns(): string {
-        throw new Error('Method not implemented.');
-    }
-    getInputFile(): string {
-        throw new Error('Method not implemented.');
-    }
-    getInputUrls(): string {
-        throw new Error('Method not implemented.');
-    }
-    getScanTimeout(): number {
-        throw new Error('Method not implemented.');
-    }
-    getLocalhostPort(): number {
-        throw new Error('Method not implemented.');
-    }
-}
-
 describe(LocalFileServer, () => {
     let localFileServer: LocalFileServer;
     let loggerMock: IMock<Logger>;
-    let taskConfigMock: IMock<TaskConfigBase>;
+    let taskConfigMock: IMock<TaskConfig>;
     let getPortMock: IMock<typeof getPort>;
     let expressMock: IMock<typeof express>;
     let serverStaticMock: IMock<typeof serveStatic>;
@@ -83,7 +44,7 @@ describe(LocalFileServer, () => {
 
     beforeEach(() => {
         loggerMock = Mock.ofType(Logger);
-        taskConfigMock = Mock.ofType(TaskConfigBase);
+        taskConfigMock = Mock.ofType<TaskConfig>();
         getPortMock = Mock.ofType<typeof getPort>();
         serverStaticMock = Mock.ofType<typeof serveStatic>();
         expressMock = Mock.ofType<typeof express>();

--- a/packages/shared/src/local-file-server.ts
+++ b/packages/shared/src/local-file-server.ts
@@ -17,7 +17,7 @@ export class LocalFileServer {
     private startServerPromise: Promise<string>;
 
     constructor(
-        @inject(TaskConfig) private readonly taskConfig: TaskConfig,
+        @inject(iocTypes.TaskConfig) private readonly taskConfig: TaskConfig,
         @inject(Logger) private readonly logger: Logger,
         @inject(iocTypes.GetPort) private readonly getPortFunc: typeof getPort,
         @inject(iocTypes.Express) private readonly expressFunc: typeof express,

--- a/packages/shared/src/progress-reporter/all-progress-reporter.spec.ts
+++ b/packages/shared/src/progress-reporter/all-progress-reporter.spec.ts
@@ -4,20 +4,15 @@ import 'reflect-metadata';
 
 import { IMock, Mock, Times } from 'typemoq';
 import { AllProgressReporter } from './all-progress-reporter';
-import { CheckRunCreator } from './check-run/check-run-creator';
 import { ProgressReporter } from './progress-reporter';
-import { PullRequestCommentCreator } from './pull-request/pull-request-comment-creator';
 
 describe(AllProgressReporter, () => {
     let testSubject: AllProgressReporter;
-    let pullRequestCommentCreator: IMock<PullRequestCommentCreator>;
-    let checkRunCreatorMock: IMock<CheckRunCreator>;
+    let progressReporterMock: IMock<ProgressReporter>;
 
     beforeEach(() => {
-        checkRunCreatorMock = Mock.ofType(CheckRunCreator);
-        pullRequestCommentCreator = Mock.ofType(PullRequestCommentCreator);
-
-        testSubject = new AllProgressReporter(pullRequestCommentCreator.object, checkRunCreatorMock.object);
+        progressReporterMock = Mock.ofType<ProgressReporter>();
+        testSubject = new AllProgressReporter([progressReporterMock.object]);
     });
 
     it('start should invoke all reporters', async () => {
@@ -56,12 +51,10 @@ describe(AllProgressReporter, () => {
     });
 
     afterEach(() => {
-        checkRunCreatorMock.verifyAll();
-        pullRequestCommentCreator.verifyAll();
+        progressReporterMock.verifyAll();
     });
 
     function executeOnReporter(callback: (reporter: IMock<ProgressReporter>) => void): void {
-        callback(checkRunCreatorMock);
-        callback(pullRequestCommentCreator);
+        callback(progressReporterMock);
     }
 });

--- a/packages/shared/src/progress-reporter/all-progress-reporter.ts
+++ b/packages/shared/src/progress-reporter/all-progress-reporter.ts
@@ -2,21 +2,14 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import { CheckRunCreator } from './check-run/check-run-creator';
 import { ProgressReporter } from './progress-reporter';
-import { PullRequestCommentCreator } from './pull-request/pull-request-comment-creator';
 import { CombinedReportParameters } from 'accessibility-insights-report';
+import { iocTypes } from '../ioc/ioc-types';
 
 @injectable()
 export class AllProgressReporter extends ProgressReporter {
-    private readonly progressReporters: ProgressReporter[];
-
-    constructor(
-        @inject(PullRequestCommentCreator) pullRequestCommentCreator: PullRequestCommentCreator,
-        @inject(CheckRunCreator) checkRunCreator: CheckRunCreator,
-    ) {
+    constructor(@inject(iocTypes.ProgressReporters) protected readonly progressReporters: ProgressReporter[]) {
         super();
-        this.progressReporters = [checkRunCreator, pullRequestCommentCreator];
     }
 
     public async start(): Promise<void> {

--- a/packages/shared/src/report/consolidated-report-generator.ts
+++ b/packages/shared/src/report/consolidated-report-generator.ts
@@ -11,7 +11,7 @@ import { TaskConfig } from '../task-config';
 @injectable()
 export class ConsolidatedReportGenerator {
     constructor(
-        @inject(TaskConfig) private readonly taskConfig: TaskConfig,
+        @inject(iocTypes.TaskConfig) private readonly taskConfig: TaskConfig,
         @inject(iocTypes.ReportFactory) private readonly reporterFactoryFunc: ReporterFactory,
         @inject(Logger) private readonly logger: Logger,
         private readonly fileSystemObj: typeof fs = fs,

--- a/packages/shared/src/scanner/crawl-argument-handler.ts
+++ b/packages/shared/src/scanner/crawl-argument-handler.ts
@@ -7,11 +7,12 @@ import { resolve } from 'path';
 import { TaskConfig } from '../task-config';
 import { isEmpty } from 'lodash';
 import { ScanUrlResolver } from './scan-url-resolver';
+import { iocTypes } from '../ioc/ioc-types';
 
 @injectable()
 export class CrawlArgumentHandler {
     constructor(
-        @inject(TaskConfig) private readonly taskConfig: TaskConfig,
+        @inject(iocTypes.TaskConfig) private readonly taskConfig: TaskConfig,
         @inject(ScanUrlResolver) private readonly scanUrlResolver: ScanUrlResolver,
         private readonly resolvePath: typeof resolve = resolve,
         private readonly validateScanArgumentsExt: typeof validateScanArguments = validateScanArguments,

--- a/packages/shared/src/scanner/scan-url-resolver.ts
+++ b/packages/shared/src/scanner/scan-url-resolver.ts
@@ -5,10 +5,14 @@ import { inject, injectable } from 'inversify';
 import { TaskConfig } from '../task-config';
 import { resolve } from 'url';
 import { ScanArguments } from 'accessibility-insights-scan';
+import { iocTypes } from '../ioc/ioc-types';
 
 @injectable()
 export class ScanUrlResolver {
-    constructor(@inject(TaskConfig) private readonly taskConfig: TaskConfig, private readonly resolveUrl: typeof resolve = resolve) {}
+    constructor(
+        @inject(iocTypes.TaskConfig) private readonly taskConfig: TaskConfig,
+        private readonly resolveUrl: typeof resolve = resolve,
+    ) {}
 
     public resolveLocallyHostedUrls(baseUrl: string): Partial<ScanArguments> {
         return {

--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -36,7 +36,7 @@ export class Scanner {
         @inject(iocTypes.Process) protected readonly currentProcess: typeof process,
         @inject(Logger) private readonly logger: Logger,
         @inject(CrawlArgumentHandler) private readonly crawlArgumentHandler: CrawlArgumentHandler,
-        @inject(TaskConfig) private readonly taskConfig: TaskConfig,
+        @inject(iocTypes.TaskConfig) private readonly taskConfig: TaskConfig,
         @inject(CrawlerParametersBuilder) private readonly crawlerParametersBuilder: CrawlerParametersBuilder,
     ) {}
 

--- a/packages/shared/src/task-config.ts
+++ b/packages/shared/src/task-config.ts
@@ -1,94 +1,26 @@
+import { iocTypes } from './ioc/ioc-types';
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as actionCore from '@actions/core';
 import { inject, injectable } from 'inversify';
-import { isEmpty } from 'lodash';
-import * as process from 'process';
-import { iocTypes } from './ioc/ioc-types';
-import normalizePath from 'normalize-path';
-import { resolve } from 'path';
 
 @injectable()
-export class TaskConfig {
-    constructor(
-        @inject(iocTypes.Process) private readonly processObj: typeof process,
-        private readonly actionCoreObj = actionCore,
-        private readonly resolvePath: typeof resolve = resolve,
-    ) {}
-
-    public getReportOutDir(): string {
-        return this.getAbsolutePath(this.actionCoreObj.getInput('output-dir'));
-    }
-
-    public getSiteDir(): string {
-        return this.actionCoreObj.getInput('site-dir');
-    }
-
-    public getScanUrlRelativePath(): string {
-        return this.actionCoreObj.getInput('scan-url-relative-path');
-    }
-
-    public getToken(): string {
-        return this.actionCoreObj.getInput('repo-token');
-    }
-
-    public getChromePath(): string {
-        let chromePath;
-        chromePath = this.getAbsolutePath(this.actionCoreObj.getInput('chrome-path'));
-
-        if (isEmpty(chromePath)) {
-            chromePath = this.processObj.env.CHROME_BIN;
-        }
-
-        return chromePath;
-    }
-
-    public getUrl(): string {
-        return this.actionCoreObj.getInput('url');
-    }
-
-    public getMaxUrls(): number {
-        return parseInt(this.actionCoreObj.getInput('max-urls'));
-    }
-
-    public getDiscoveryPatterns(): string {
-        const value = this.actionCoreObj.getInput('discovery-patterns');
-
-        return isEmpty(value) ? undefined : value;
-    }
-
-    public getInputFile(): string {
-        return this.getAbsolutePath(this.actionCoreObj.getInput('input-file'));
-    }
-
-    public getInputUrls(): string {
-        const value = this.actionCoreObj.getInput('input-urls');
-
-        return isEmpty(value) ? undefined : value;
-    }
-
-    public getScanTimeout(): number {
-        return parseInt(this.actionCoreObj.getInput('scan-timeout'));
-    }
-
+export abstract class TaskConfig {
+    constructor(@inject(iocTypes.Process) protected readonly processObj: typeof process) {}
+    abstract getReportOutDir(): string;
+    abstract getSiteDir(): string;
+    abstract getScanUrlRelativePath(): string;
+    abstract getToken(): string;
+    abstract getChromePath(): string;
+    abstract getUrl(): string;
+    abstract getMaxUrls(): number;
+    abstract getDiscoveryPatterns(): string;
+    abstract getInputFile(): string;
+    abstract getInputUrls(): string;
+    abstract getScanTimeout(): number;
+    abstract getLocalhostPort(): number;
     public getRunId(): number {
         return parseInt(this.processObj.env.GITHUB_RUN_ID, 10);
-    }
-
-    public getLocalhostPort(): number {
-        const value = this.actionCoreObj.getInput('localhost-port');
-
-        return isEmpty(value) ? undefined : parseInt(value, 10);
-    }
-
-    private getAbsolutePath(path: string): string {
-        if (isEmpty(path)) {
-            return undefined;
-        }
-
-        const dirname = this.processObj.env.GITHUB_WORKSPACE ?? __dirname;
-
-        return normalizePath(this.resolvePath(dirname, normalizePath(path)));
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,12 +1477,24 @@
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-9.4.0.tgz#31a76fb4c0f2e15af300edd880cedf4f75be212b"
   integrity sha512-rKRkXikOJgDNImPl49IJuECLVXjj+t4qOXHhl8SBjMQCGGp1w4m5Ud/0kfdUx+zCpTvBN8vaOUDF4nnboZoOtQ==
 
+"@octokit/openapi-types@^9.5.0":
+  version "9.7.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-9.7.0.tgz#9897cdefd629cd88af67b8dbe2e5fb19c63426b2"
+  integrity sha512-TUJ16DJU8mekne6+KVcMV5g6g/rJlrnIKn7aALG9QrNpnEipFc1xjoarh0PKaAWf2Hf+HwthRKYt+9mCm5RsRg==
+
 "@octokit/plugin-enterprise-rest@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-6.0.1.tgz#e07896739618dab8da7d4077c658003775f95437"
   integrity sha512-93uGjlhUD+iNg1iWhUENAtJata6w5nE+V4urXOAlIXdco6xNZtUSfYY8dzp3Udy74aqO/B5UZL80x/YMa5PKRw==
 
-"@octokit/plugin-paginate-rest@^2.13.3", "@octokit/plugin-paginate-rest@^2.6.2":
+"@octokit/plugin-paginate-rest@^2.13.3":
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.15.1.tgz#264189dd3ce881c6c33758824aac05a4002e056a"
+  integrity sha512-47r52KkhQDkmvUKZqXzA1lKvcyJEfYh3TKAIe5+EzMeyDM3d+/s5v11i2gTk8/n6No6DPi3k5Ind6wtDbo/AEg==
+  dependencies:
+    "@octokit/types" "^6.24.0"
+
+"@octokit/plugin-paginate-rest@^2.6.2":
   version "2.13.3"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz#f0f1792230805108762d87906fb02d573b9e070a"
   integrity sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==
@@ -1494,12 +1506,20 @@
   resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz#70a62be213e1edc04bb8897ee48c311482f9700d"
   integrity sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==
 
-"@octokit/plugin-rest-endpoint-methods@5.7.0", "@octokit/plugin-rest-endpoint-methods@^5.1.1":
+"@octokit/plugin-rest-endpoint-methods@5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.7.0.tgz#80b69452c17597738d4692c79829b72d9e72ccec"
   integrity sha512-G7sgccWRYQMwcHJXkDY/sDxbXeKiZkFQqUtzBCwmrzCNj2GQf3VygQ4T/BFL2crLVpIbenkE/c0ErhYOte2MPw==
   dependencies:
     "@octokit/types" "^6.24.0"
+    deprecation "^2.3.1"
+
+"@octokit/plugin-rest-endpoint-methods@5.8.0", "@octokit/plugin-rest-endpoint-methods@^5.1.1":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.8.0.tgz#33b342fe41f2603fdf8b958e6652103bb3ea3f3b"
+  integrity sha512-qeLZZLotNkoq+it6F+xahydkkbnvSK0iDjlXFo3jNTB+Ss0qIbYQb9V/soKLMkgGw8Q2sHjY5YEXiA47IVPp4A==
+  dependencies:
+    "@octokit/types" "^6.25.0"
     deprecation "^2.3.1"
 
 "@octokit/request-error@^2.0.0", "@octokit/request-error@^2.0.5":
@@ -1544,7 +1564,7 @@
     node-fetch "^2.6.1"
     universal-user-agent "^6.0.0"
 
-"@octokit/rest@^18.1.0", "@octokit/rest@^18.9.0":
+"@octokit/rest@^18.1.0":
   version "18.9.0"
   resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.9.0.tgz#e5cc23fa199a2bdeea9efbe6096f81d7d6156fe9"
   integrity sha512-VrmrE8gjpuOoDAGjrQq2j9ZhOE6LxaqxaQg0yMrrEnnQZy2ZcAnr5qbVfKsMF0up/48PRV/VFS/2GSMhA7nTdA==
@@ -1553,6 +1573,16 @@
     "@octokit/plugin-paginate-rest" "^2.6.2"
     "@octokit/plugin-request-log" "^1.0.2"
     "@octokit/plugin-rest-endpoint-methods" "5.7.0"
+
+"@octokit/rest@^18.9.0":
+  version "18.9.1"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.9.1.tgz#db1d7ac1d7b10e908f7d4b78fe35a392554ccb26"
+  integrity sha512-idZ3e5PqXVWOhtZYUa546IDHTHjkGZbj3tcJsN0uhCy984KD865e8GB2WbYDc2ZxFuJRiyd0AftpL2uPNhF+UA==
+  dependencies:
+    "@octokit/core" "^3.5.0"
+    "@octokit/plugin-paginate-rest" "^2.6.2"
+    "@octokit/plugin-request-log" "^1.0.2"
+    "@octokit/plugin-rest-endpoint-methods" "5.8.0"
 
 "@octokit/types@^6.0.3", "@octokit/types@^6.11.0", "@octokit/types@^6.7.1":
   version "6.16.2"
@@ -1574,6 +1604,13 @@
   integrity sha512-MfEimJeQ8AV1T2nI5kOfHqsqPHaAnG0Dw3MVoHSEsEq6iLKx2N91o+k2uAgXhPYeSE76LVBqjgTShnFFgNwe0A==
   dependencies:
     "@octokit/openapi-types" "^9.4.0"
+
+"@octokit/types@^6.25.0":
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.25.0.tgz#c8e37e69dbe7ce55ed98ee63f75054e7e808bf1a"
+  integrity sha512-bNvyQKfngvAd/08COlYIN54nRgxskmejgywodizQNyiKoXmWRAjKup2/LYwm+T9V0gsKH6tuld1gM0PzmOiB4Q==
+  dependencies:
+    "@octokit/openapi-types" "^9.5.0"
 
 "@sindresorhus/fnv1a@^2.0.1":
   version "2.0.1"


### PR DESCRIPTION
#### Details

Refactor the code to setup IoC using inversify and move all action related code out of shared in action.
##### Motivation
Make it easier to integrate and maintain the code so it'd be easy to integrate ADO code.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
