### PR TITLE
feat(ado/infra): Refactor ADO prod publish pipeline

### DIFF
--- a/pipelines/prod-release.yaml
+++ b/pipelines/prod-release.yaml
@@ -43,26 +43,26 @@ stages:
           - template: release-template.yaml
             parameters:
                 environment: ado-extension-prod
-                
-          - job: 'CreateReleaseTag'
-          steps:
-              - task: DownloadPipelineArtifact@2
-                inputs:
-                    source: 'specific'
-                    runVersion: 'specific'
-                    project: $(resources.pipeline.accessibility-insights-action-ci.projectID)
-                    pipeline: $(resources.pipeline.accessibility-insights-action-ci.pipelineID)
-                    runId: $(resources.pipeline.accessibility-insights-action-ci.runID)
-                    artifact: ado-extension-drop
-                    path: '$(System.DefaultWorkingDirectory)/ado-extension-drop'
 
-              - task: GitHubRelease@1
-                displayName: 'GitHub release'
-                inputs:
-                    tag: '$(tag)'
-                    action: edit
-                    tagSource: userSpecifiedTag
-                    gitHubConnection: 'ada-cat-github-repo-access'
-                    isPreRelease: true
-                    target: $(resources.pipeline.accessibility-insights-action-ci.sourceCommit)
-                    assets: '$(System.DefaultWorkingDirectory)/ado-extension-drop/NOTICE.html'
+          - job: 'CreateReleaseTag'
+            steps:
+                - task: DownloadPipelineArtifact@2
+                  inputs:
+                      source: 'specific'
+                      runVersion: 'specific'
+                      project: $(resources.pipeline.accessibility-insights-action-ci.projectID)
+                      pipeline: $(resources.pipeline.accessibility-insights-action-ci.pipelineID)
+                      runId: $(resources.pipeline.accessibility-insights-action-ci.runID)
+                      artifact: ado-extension-drop
+                      path: '$(System.DefaultWorkingDirectory)/ado-extension-drop'
+
+                - task: GitHubRelease@1
+                  displayName: 'GitHub release'
+                  inputs:
+                      tag: '$(tag)'
+                      action: edit
+                      tagSource: userSpecifiedTag
+                      gitHubConnection: 'ada-cat-github-repo-access'
+                      isPreRelease: true
+                      target: $(resources.pipeline.accessibility-insights-action-ci.sourceCommit)
+                      assets: '$(System.DefaultWorkingDirectory)/ado-extension-drop/NOTICE.html'

--- a/pipelines/prod-release.yaml
+++ b/pipelines/prod-release.yaml
@@ -36,31 +36,6 @@ stages:
             parameters:
                 environment: ado-extension-staging
 
-    - stage: create_release_tag
-      jobs:
-          - job: 'CreateReleaseTag'
-            steps:
-                - task: DownloadPipelineArtifact@2
-                  inputs:
-                      source: 'specific'
-                      runVersion: 'specific'
-                      project: $(resources.pipeline.accessibility-insights-action-ci.projectID)
-                      pipeline: $(resources.pipeline.accessibility-insights-action-ci.pipelineID)
-                      runId: $(resources.pipeline.accessibility-insights-action-ci.runID)
-                      artifact: ado-extension-drop
-                      path: '$(System.DefaultWorkingDirectory)/ado-extension-drop'
-
-                - task: GitHubRelease@1
-                  displayName: 'GitHub release'
-                  inputs:
-                      tag: '$(tag)'
-                      action: edit
-                      tagSource: userSpecifiedTag
-                      gitHubConnection: 'ada-cat-github-repo-access'
-                      isPreRelease: true
-                      target: $(resources.pipeline.accessibility-insights-action-ci.sourceCommit)
-                      assets: '$(System.DefaultWorkingDirectory)/ado-extension-drop/NOTICE.html'
-
     - stage: package_publish_prod
       variables:
           - group: ado-extension-prod
@@ -68,3 +43,26 @@ stages:
           - template: release-template.yaml
             parameters:
                 environment: ado-extension-prod
+                
+          - job: 'CreateReleaseTag'
+          steps:
+              - task: DownloadPipelineArtifact@2
+                inputs:
+                    source: 'specific'
+                    runVersion: 'specific'
+                    project: $(resources.pipeline.accessibility-insights-action-ci.projectID)
+                    pipeline: $(resources.pipeline.accessibility-insights-action-ci.pipelineID)
+                    runId: $(resources.pipeline.accessibility-insights-action-ci.runID)
+                    artifact: ado-extension-drop
+                    path: '$(System.DefaultWorkingDirectory)/ado-extension-drop'
+
+              - task: GitHubRelease@1
+                displayName: 'GitHub release'
+                inputs:
+                    tag: '$(tag)'
+                    action: edit
+                    tagSource: userSpecifiedTag
+                    gitHubConnection: 'ada-cat-github-repo-access'
+                    isPreRelease: true
+                    target: $(resources.pipeline.accessibility-insights-action-ci.sourceCommit)
+                    assets: '$(System.DefaultWorkingDirectory)/ado-extension-drop/NOTICE.html'


### PR DESCRIPTION
#### Details

Move the create GitHub release job to be inside the publish so it'd need an approval to run.

##### Motivation

Guard the prod tasks by an approval request before running.
##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
