### PR TITLE
feat(ado/infra): modify release pipeline to allow separate staging/prod versions

### DIFF
--- a/pipelines/prod-release.yaml
+++ b/pipelines/prod-release.yaml
@@ -25,9 +25,9 @@ stages:
     - stage: package_publish_staging
       variables:
           - group: ado-extension-staging
-      ${{ if ne(parameters.stagingVersionOverride, 'increment') }}:
-          - name: extensionVersionOverride
-            value: ${{ parameters.stagingVersionOverride }}
+          - ${{ if ne(parameters.stagingVersionOverride, 'increment') }}:
+                - name: extensionVersionOverride
+                  value: ${{ parameters.stagingVersionOverride }}
       jobs:
           - template: release-template.yaml
             parameters:

--- a/pipelines/prod-release.yaml
+++ b/pipelines/prod-release.yaml
@@ -2,14 +2,14 @@
 # Licensed under the MIT License.
 
 parameters:
-    - name: versionOverride
-      displayName: Version to deploy
+    - name: prodVersionOverride
+      displayName: Production version to deploy
       type: string
       default: ''
-    - name: tag
-      displayName: release tag
+    - name: stagingVersionOverride
+      displayName: Override staging version
       type: string
-      default: ''
+      default: 'increment'
 
 trigger: none
 
@@ -21,16 +21,13 @@ resources:
         - pipeline: accessibility-insights-action-ci
           source: accessibility-insights-action-ci
 
-variables:
-    - name: extensionVersionOverride
-      value: ${{ parameters.versionOverride }}
-    - name: tag
-      value: ${{ parameters.tag }}
-
 stages:
     - stage: package_publish_staging
       variables:
           - group: ado-extension-staging
+      ${{ if ne(${{ parameters.stagingVersionOverride }}, 'increment') }}:
+          - name: extensionVersionOverride
+            value: ${{ parameters.stagingVersionOverride }}
       jobs:
           - template: release-template.yaml
             parameters:
@@ -39,6 +36,10 @@ stages:
     - stage: package_publish_prod
       variables:
           - group: ado-extension-prod
+          - name: extensionVersionOverride
+            value: ${{ parameters.prodVersionOverride }}
+          - name: tag
+            value: v${{ parameters.prodVersionOverride }}-sources-ado
       jobs:
           - template: release-template.yaml
             parameters:

--- a/pipelines/prod-release.yaml
+++ b/pipelines/prod-release.yaml
@@ -65,5 +65,6 @@ stages:
                       tagSource: userSpecifiedTag
                       gitHubConnection: 'ada-cat-github-repo-access'
                       isPreRelease: true
+                      isDraft: true
                       target: $(resources.pipeline.accessibility-insights-action-ci.sourceCommit)
                       assets: '$(System.DefaultWorkingDirectory)/ado-extension-drop/NOTICE.html'

--- a/pipelines/prod-release.yaml
+++ b/pipelines/prod-release.yaml
@@ -25,7 +25,7 @@ stages:
     - stage: package_publish_staging
       variables:
           - group: ado-extension-staging
-      ${{ if ne(${{ parameters.stagingVersionOverride }}, 'increment') }}:
+      ${{ if ne(parameters.stagingVersionOverride, 'increment') }}:
           - name: extensionVersionOverride
             value: ${{ parameters.stagingVersionOverride }}
       jobs:

--- a/pipelines/prod-release.yaml
+++ b/pipelines/prod-release.yaml
@@ -46,6 +46,7 @@ stages:
                 environment: ado-extension-prod
 
           - job: 'CreateReleaseTag'
+            dependsOn: publish_vsix_file
             steps:
                 - task: DownloadPipelineArtifact@2
                   inputs:


### PR DESCRIPTION
#### Details

This PR allows us to override the staging / prod versions separately in the ADO extension release. I encountered a situation in which the staging version was x.0.1 but the production version was x.0.0 (the production release had been abandoned). In this scenario releasing to x.0.1 fails because staging already had that version (the pipeline used the same version for both).

Now only production requires explicit version numbers - staging can simply increment if not specified. It means that the version numbers for staging/production might be different; the alternative is to unlist old versions if needed, or skip version numbers if one was abandoned.

This PR also changes the GitHub releases to be drafts. This gives us time to review formatting before publishing.

##### Motivation

simplify release process

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
