### PR TITLE
feat(ado/infra): modify release pipeline to create release draft before publishing to Prod

### DIFF
--- a/pipelines/prod-release.yaml
+++ b/pipelines/prod-release.yaml
@@ -39,7 +39,6 @@ stages:
             value: v${{ parameters.prodVersionOverride }}-sources-ado
       jobs:
           - job: 'CreateReleaseTag'
-            dependsOn: publish_vsix_file
             steps:
                 - task: DownloadPipelineArtifact@2
                   inputs:

--- a/pipelines/prod-release.yaml
+++ b/pipelines/prod-release.yaml
@@ -33,18 +33,11 @@ stages:
             parameters:
                 environment: ado-extension-staging
 
-    - stage: package_publish_prod
+    - stage: create_release_tag
       variables:
-          - group: ado-extension-prod
-          - name: extensionVersionOverride
-            value: ${{ parameters.prodVersionOverride }}
           - name: tag
             value: v${{ parameters.prodVersionOverride }}-sources-ado
       jobs:
-          - template: release-template.yaml
-            parameters:
-                environment: ado-extension-prod
-
           - job: 'CreateReleaseTag'
             dependsOn: publish_vsix_file
             steps:
@@ -69,3 +62,13 @@ stages:
                       isDraft: true
                       target: $(resources.pipeline.accessibility-insights-action-ci.sourceCommit)
                       assets: '$(System.DefaultWorkingDirectory)/ado-extension-drop/NOTICE.html'
+
+    - stage: package_publish_prod
+      variables:
+          - group: ado-extension-prod
+          - name: extensionVersionOverride
+            value: ${{ parameters.prodVersionOverride }}
+      jobs:
+          - template: release-template.yaml
+            parameters:
+                environment: ado-extension-prod


### PR DESCRIPTION
#### Details

This PR allows us to create a release draft before publishing the ADO extension to prod, the tag won't be created before the user publish the draft manually.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
