### PR TITLE
feat(ado/behavior): Add ADOTaskConfig

### DIFF
--- a/packages/ado-extension/src/ioc/setup-ioc-container.spec.ts
+++ b/packages/ado-extension/src/ioc/setup-ioc-container.spec.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { setupIocContainer } from './setup-ioc-container';
+import { iocTypes } from '@accessibility-insights-action/shared';
+
+describe(setupIocContainer, () => {
+    let testSubject: Container;
+
+    beforeEach(() => {
+        testSubject = setupIocContainer();
+    });
+
+    test.each([iocTypes.TaskConfig])('verify singleton resolution %p', (key: any) => {
+        verifySingletonDependencyResolution(testSubject, key);
+    });
+
+    function verifySingletonDependencyResolution(container: Container, key: any): void {
+        expect(container.get(key)).toBeDefined();
+        expect(container.get(key)).toBe(container.get(key));
+    }
+});

--- a/packages/ado-extension/src/ioc/setup-ioc-container.ts
+++ b/packages/ado-extension/src/ioc/setup-ioc-container.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as inversify from 'inversify';
+import { iocTypes, setupSharedIocContainer } from '@accessibility-insights-action/shared';
+import { ADOTaskConfig } from '../task-config/ado-task-config';
+
+export function setupIocContainer(container = new inversify.Container({ autoBindInjectable: true })): inversify.Container {
+    container = setupSharedIocContainer(container);
+    container.bind(iocTypes.TaskConfig).to(ADOTaskConfig).inSingletonScope();
+    return container;
+}

--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import * as adoTask from 'azure-pipelines-task-lib/task';
+import normalizePath from 'normalize-path';
+import path from 'path';
+import { Mock, Times, IMock } from 'typemoq';
+import { ADOTaskConfig } from './ado-task-config';
+
+describe(ADOTaskConfig, () => {
+    let processStub: any;
+    let adoTaskMock: IMock<typeof adoTask>;
+    let taskConfig: ADOTaskConfig;
+
+    beforeEach(() => {
+        processStub = {
+            env: {},
+        } as any;
+        adoTaskMock = Mock.ofType<typeof adoTask>();
+        taskConfig = new ADOTaskConfig(processStub, adoTaskMock.object);
+    });
+
+    afterEach(() => {
+        adoTaskMock.verifyAll();
+    });
+
+    function getPlatformAgnosticPath(inputPath: string): string {
+        return normalizePath(path.resolve(inputPath));
+    }
+
+    it.each`
+        inputOption                 | inputValue         | expectedValue                                          | getInputFunc
+        ${'repo-token'}             | ${'token'}         | ${'token'}                                             | ${() => taskConfig.getToken()}
+        ${'scan-url-relative-path'} | ${'path'}          | ${'path'}                                              | ${() => taskConfig.getScanUrlRelativePath()}
+        ${'chrome-path'}            | ${'./chrome-path'} | ${getPlatformAgnosticPath(__dirname + '/chrome-path')} | ${() => taskConfig.getChromePath()}
+        ${'input-file'}             | ${'./input-file'}  | ${getPlatformAgnosticPath(__dirname + '/input-file')}  | ${() => taskConfig.getInputFile()}
+        ${'output-dir'}             | ${'./output-dir'}  | ${getPlatformAgnosticPath(__dirname + '/output-dir')}  | ${() => taskConfig.getReportOutDir()}
+        ${'site-dir'}               | ${'path'}          | ${'path'}                                              | ${() => taskConfig.getSiteDir()}
+        ${'url'}                    | ${'url'}           | ${'url'}                                               | ${() => taskConfig.getUrl()}
+        ${'discovery-patterns'}     | ${'abc'}           | ${'abc'}                                               | ${() => taskConfig.getDiscoveryPatterns()}
+        ${'input-urls'}             | ${'abc'}           | ${'abc'}                                               | ${() => taskConfig.getInputUrls()}
+        ${'max-urls'}               | ${'20'}            | ${20}                                                  | ${() => taskConfig.getMaxUrls()}
+        ${'scan-timeout'}           | ${'100000'}        | ${100000}                                              | ${() => taskConfig.getScanTimeout()}
+        ${'localhost-port'}         | ${'8080'}          | ${8080}                                                | ${() => taskConfig.getLocalhostPort()}
+    `(
+        `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
+        ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
+            adoTaskMock
+                .setup((am) => am.getInput(inputOption))
+                .returns(() => inputValue)
+                .verifiable(Times.once());
+            const retrievedOption = getInputFunc();
+            expect(retrievedOption).toStrictEqual(expectedValue);
+        },
+    );
+
+    it('should use environment value when chrome-path input is undefined', () => {
+        const chromePath = 'some path';
+        processStub = {
+            env: {
+                CHROME_BIN: chromePath,
+            },
+        } as any;
+        adoTaskMock
+            .setup((o) => o.getInput('chrome-path'))
+            .returns(() => '')
+            .verifiable(Times.once());
+        taskConfig = new ADOTaskConfig(processStub, adoTaskMock.object);
+
+        const absolutePath = taskConfig.getChromePath();
+
+        expect(absolutePath).toBe(chromePath);
+    });
+
+    it('should use workspace to build absolute file path', () => {
+        const workspace = '/home/user/workspace';
+        processStub = {
+            env: {
+                PIPELINE_WORKSPACE: workspace,
+            },
+        } as any;
+        adoTaskMock
+            .setup((o) => o.getInput('input-file'))
+            .returns(() => './file.txt')
+            .verifiable(Times.once());
+        taskConfig = new ADOTaskConfig(processStub, adoTaskMock.object);
+
+        const absolutePath = taskConfig.getInputFile();
+
+        expect(absolutePath).toBe(getPlatformAgnosticPath(`${workspace}/file.txt`));
+    });
+
+    it('should return run id from environment', () => {
+        const runId = 789;
+        processStub = {
+            env: {
+                BUILD_BUILDID: `${runId}`,
+            },
+        } as any;
+        taskConfig = new ADOTaskConfig(processStub, adoTaskMock.object);
+
+        const actualRunId = taskConfig.getRunId();
+
+        expect(actualRunId).toBe(runId);
+    });
+});

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as actionCore from '@actions/core';
+import * as adoTask from 'azure-pipelines-task-lib/task';
 import { inject, injectable } from 'inversify';
 import { isEmpty } from 'lodash';
 import * as process from 'process';
@@ -10,34 +10,34 @@ import normalizePath from 'normalize-path';
 import { resolve } from 'path';
 
 @injectable()
-export class GHTaskConfig extends TaskConfig {
+export class ADOTaskConfig extends TaskConfig {
     constructor(
         @inject(iocTypes.Process) protected readonly processObj: typeof process,
-        private readonly actionCoreObj = actionCore,
+        private readonly adoTaskObj = adoTask,
         private readonly resolvePath: typeof resolve = resolve,
     ) {
         super(processObj);
     }
 
     public getReportOutDir(): string {
-        return this.getAbsolutePath(this.actionCoreObj.getInput('output-dir'));
+        return this.getAbsolutePath(this.adoTaskObj.getInput('output-dir'));
     }
 
     public getSiteDir(): string {
-        return this.actionCoreObj.getInput('site-dir');
+        return this.adoTaskObj.getInput('site-dir');
     }
 
     public getScanUrlRelativePath(): string {
-        return this.actionCoreObj.getInput('scan-url-relative-path');
+        return this.adoTaskObj.getInput('scan-url-relative-path');
     }
 
     public getToken(): string {
-        return this.actionCoreObj.getInput('repo-token');
+        return this.adoTaskObj.getInput('repo-token');
     }
 
     public getChromePath(): string {
         let chromePath;
-        chromePath = this.getAbsolutePath(this.actionCoreObj.getInput('chrome-path'));
+        chromePath = this.getAbsolutePath(this.adoTaskObj.getInput('chrome-path'));
 
         if (isEmpty(chromePath)) {
             chromePath = this.processObj.env.CHROME_BIN;
@@ -47,41 +47,41 @@ export class GHTaskConfig extends TaskConfig {
     }
 
     public getUrl(): string {
-        return this.actionCoreObj.getInput('url');
+        return this.adoTaskObj.getInput('url');
     }
 
     public getMaxUrls(): number {
-        return parseInt(this.actionCoreObj.getInput('max-urls'));
+        return parseInt(this.adoTaskObj.getInput('max-urls'));
     }
 
     public getDiscoveryPatterns(): string {
-        const value = this.actionCoreObj.getInput('discovery-patterns');
+        const value = this.adoTaskObj.getInput('discovery-patterns');
 
         return isEmpty(value) ? undefined : value;
     }
 
     public getInputFile(): string {
-        return this.getAbsolutePath(this.actionCoreObj.getInput('input-file'));
+        return this.getAbsolutePath(this.adoTaskObj.getInput('input-file'));
     }
 
     public getInputUrls(): string {
-        const value = this.actionCoreObj.getInput('input-urls');
+        const value = this.adoTaskObj.getInput('input-urls');
 
         return isEmpty(value) ? undefined : value;
     }
 
     public getScanTimeout(): number {
-        return parseInt(this.actionCoreObj.getInput('scan-timeout'));
+        return parseInt(this.adoTaskObj.getInput('scan-timeout'));
     }
 
     public getLocalhostPort(): number {
-        const value = this.actionCoreObj.getInput('localhost-port');
+        const value = this.adoTaskObj.getInput('localhost-port');
 
         return isEmpty(value) ? undefined : parseInt(value, 10);
     }
 
     public getRunId(): number {
-        return parseInt(this.processObj.env.GITHUB_RUN_ID, 10);
+        return parseInt(this.processObj.env.BUILD_BUILDID, 10);
     }
 
     private getAbsolutePath(path: string): string {
@@ -89,7 +89,7 @@ export class GHTaskConfig extends TaskConfig {
             return undefined;
         }
 
-        const dirname = this.processObj.env.GITHUB_WORKSPACE ?? __dirname;
+        const dirname = this.processObj.env.PIPELINE_WORKSPACE ?? __dirname;
 
         return normalizePath(this.resolvePath(dirname, normalizePath(path)));
     }

--- a/packages/shared/src/task-config.ts
+++ b/packages/shared/src/task-config.ts
@@ -20,7 +20,5 @@ export abstract class TaskConfig {
     abstract getInputUrls(): string;
     abstract getScanTimeout(): number;
     abstract getLocalhostPort(): number;
-    public getRunId(): number {
-        return parseInt(this.processObj.env.GITHUB_RUN_ID, 10);
-    }
+    abstract getRunId(): number;
 }


### PR DESCRIPTION
#### Details

This PR adds ado-task-config to add TaskConfig class for the ADO extension and sets up the IoC for it.
Next PR should add those task configs to the task.json

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
