### PR TITLE
feat(ado/behavior): Add scanner/crawler inputs to the ADO task.json config

### DIFF
--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -30,19 +30,19 @@ describe(ADOTaskConfig, () => {
     }
 
     it.each`
-        inputOption                 | inputValue         | expectedValue                                          | getInputFunc
-        ${'repo-token'}             | ${'token'}         | ${'token'}                                             | ${() => taskConfig.getToken()}
-        ${'scan-url-relative-path'} | ${'path'}          | ${'path'}                                              | ${() => taskConfig.getScanUrlRelativePath()}
-        ${'chrome-path'}            | ${'./chrome-path'} | ${getPlatformAgnosticPath(__dirname + '/chrome-path')} | ${() => taskConfig.getChromePath()}
-        ${'input-file'}             | ${'./input-file'}  | ${getPlatformAgnosticPath(__dirname + '/input-file')}  | ${() => taskConfig.getInputFile()}
-        ${'output-dir'}             | ${'./output-dir'}  | ${getPlatformAgnosticPath(__dirname + '/output-dir')}  | ${() => taskConfig.getReportOutDir()}
-        ${'site-dir'}               | ${'path'}          | ${'path'}                                              | ${() => taskConfig.getSiteDir()}
-        ${'url'}                    | ${'url'}           | ${'url'}                                               | ${() => taskConfig.getUrl()}
-        ${'discovery-patterns'}     | ${'abc'}           | ${'abc'}                                               | ${() => taskConfig.getDiscoveryPatterns()}
-        ${'input-urls'}             | ${'abc'}           | ${'abc'}                                               | ${() => taskConfig.getInputUrls()}
-        ${'max-urls'}               | ${'20'}            | ${20}                                                  | ${() => taskConfig.getMaxUrls()}
-        ${'scan-timeout'}           | ${'100000'}        | ${100000}                                              | ${() => taskConfig.getScanTimeout()}
-        ${'localhost-port'}         | ${'8080'}          | ${8080}                                                | ${() => taskConfig.getLocalhostPort()}
+        inputOption              | inputValue        | expectedValue                                         | getInputFunc
+        ${'repoToken'}           | ${'token'}        | ${'token'}                                            | ${() => taskConfig.getToken()}
+        ${'scanUrlRelativePath'} | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getScanUrlRelativePath()}
+        ${'chromePath'}          | ${'./chromePath'} | ${getPlatformAgnosticPath(__dirname + '/chromePath')} | ${() => taskConfig.getChromePath()}
+        ${'inputFile'}           | ${'./inputFile'}  | ${getPlatformAgnosticPath(__dirname + '/inputFile')}  | ${() => taskConfig.getInputFile()}
+        ${'outputDir'}           | ${'./outputDir'}  | ${getPlatformAgnosticPath(__dirname + '/outputDir')}  | ${() => taskConfig.getReportOutDir()}
+        ${'siteDir'}             | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getSiteDir()}
+        ${'url'}                 | ${'url'}          | ${'url'}                                              | ${() => taskConfig.getUrl()}
+        ${'discoveryPatterns'}   | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getDiscoveryPatterns()}
+        ${'inputUrls'}           | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getInputUrls()}
+        ${'maxUrls'}             | ${'20'}           | ${20}                                                 | ${() => taskConfig.getMaxUrls()}
+        ${'scanTimeout'}         | ${'100000'}       | ${100000}                                             | ${() => taskConfig.getScanTimeout()}
+        ${'localhostPort'}       | ${'8080'}         | ${8080}                                               | ${() => taskConfig.getLocalhostPort()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
@@ -63,7 +63,7 @@ describe(ADOTaskConfig, () => {
             },
         } as any;
         adoTaskMock
-            .setup((o) => o.getInput('chrome-path'))
+            .setup((o) => o.getInput('chromePath'))
             .returns(() => '')
             .verifiable(Times.once());
         taskConfig = new ADOTaskConfig(processStub, adoTaskMock.object);
@@ -81,7 +81,7 @@ describe(ADOTaskConfig, () => {
             },
         } as any;
         adoTaskMock
-            .setup((o) => o.getInput('input-file'))
+            .setup((o) => o.getInput('inputFile'))
             .returns(() => './file.txt')
             .verifiable(Times.once());
         taskConfig = new ADOTaskConfig(processStub, adoTaskMock.object);

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -20,24 +20,24 @@ export class ADOTaskConfig extends TaskConfig {
     }
 
     public getReportOutDir(): string {
-        return this.getAbsolutePath(this.adoTaskObj.getInput('output-dir'));
+        return this.getAbsolutePath(this.adoTaskObj.getInput('outputDir'));
     }
 
     public getSiteDir(): string {
-        return this.adoTaskObj.getInput('site-dir');
+        return this.adoTaskObj.getInput('siteDir');
     }
 
     public getScanUrlRelativePath(): string {
-        return this.adoTaskObj.getInput('scan-url-relative-path');
+        return this.adoTaskObj.getInput('scanUrlRelativePath');
     }
 
     public getToken(): string {
-        return this.adoTaskObj.getInput('repo-token');
+        return this.adoTaskObj.getInput('repoToken');
     }
 
     public getChromePath(): string {
         let chromePath;
-        chromePath = this.getAbsolutePath(this.adoTaskObj.getInput('chrome-path'));
+        chromePath = this.getAbsolutePath(this.adoTaskObj.getInput('chromePath'));
 
         if (isEmpty(chromePath)) {
             chromePath = this.processObj.env.CHROME_BIN;
@@ -51,31 +51,31 @@ export class ADOTaskConfig extends TaskConfig {
     }
 
     public getMaxUrls(): number {
-        return parseInt(this.adoTaskObj.getInput('max-urls'));
+        return parseInt(this.adoTaskObj.getInput('maxUrls'));
     }
 
     public getDiscoveryPatterns(): string {
-        const value = this.adoTaskObj.getInput('discovery-patterns');
+        const value = this.adoTaskObj.getInput('discoveryPatterns');
 
         return isEmpty(value) ? undefined : value;
     }
 
     public getInputFile(): string {
-        return this.getAbsolutePath(this.adoTaskObj.getInput('input-file'));
+        return this.getAbsolutePath(this.adoTaskObj.getInput('inputFile'));
     }
 
     public getInputUrls(): string {
-        const value = this.adoTaskObj.getInput('input-urls');
+        const value = this.adoTaskObj.getInput('inputUrls');
 
         return isEmpty(value) ? undefined : value;
     }
 
     public getScanTimeout(): number {
-        return parseInt(this.adoTaskObj.getInput('scan-timeout'));
+        return parseInt(this.adoTaskObj.getInput('scanTimeout'));
     }
 
     public getLocalhostPort(): number {
-        const value = this.adoTaskObj.getInput('localhost-port');
+        const value = this.adoTaskObj.getInput('localhostPort');
 
         return isEmpty(value) ? undefined : parseInt(value, 10);
     }

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -15,18 +15,100 @@
     "instanceNameFormat": "Run accessibility testing",
     "inputs": [
         {
-            "name": "url",
-            "type": "string",
-            "label": "website URL",
-            "required": false,
-            "helpMarkDown": "URL to scan"
-        },
-        {
             "name": "repoServiceConnectionName",
             "type": "connectedService:externaltfs",
             "label": "Azure Repos Connection",
             "required": false,
             "helpMarkDown": "This extension makes comments on pull requests. Provide a service connection with permissions to contribute to the target repo."
+        },
+        {
+            "name": "outputDir",
+            "type": "string",
+            "label": "Output Directory",
+            "required": true,
+            "defaultValue": "_accessibility-reports",
+            "helpMarkDown": "Folder containing the scan report."
+        },
+        {
+            "name": "siteDir",
+            "type": "string",
+            "label": "Site Directory",
+            "required": true,
+            "defaultValue": ".",
+            "helpMarkDown": "Folder containing website content."
+        },
+        {
+            "name": "scanUrlRelativePath",
+            "type": "string",
+            "label": "Scan URL Relative Path",
+            "required": true,
+            "defaultValue": "/",
+            "helpMarkDown": "Relative path to directory used to construct base scan url. e.g. / on Ubuntu and // on Windows."
+        },
+        {
+            "name": "chromePath",
+            "type": "string",
+            "label": "Chrome Path",
+            "required": false,
+            "helpMarkDown": "Path to Chrome executable."
+        },
+        {
+            "name": "repoToken",
+            "type": "string",
+            "label": "Repo Token",
+            "required": false,
+            "helpMarkDown": "GitHub API access token."
+        },
+        {
+            "name": "url",
+            "type": "string",
+            "label": "Website URL",
+            "required": false,
+            "helpMarkDown": "The hosted URL to scan/crawl for accessibility issues."
+        },
+        {
+            "name": "maxUrls",
+            "type": "int",
+            "label": "Maximum number of URLs",
+            "defaultValue": "100",
+            "required": false,
+            "helpMarkDown": "Maximum number of pages opened by crawler. The crawl will stop when this limit is reached."
+        },
+        {
+            "name": "discoveryPatterns",
+            "type": "string",
+            "label": "Discovery Patterns",
+            "required": false,
+            "helpMarkDown": "List of RegEx patterns to crawl in addition to the provided URL, separated by space."
+        },
+        {
+            "name": "inputFile",
+            "type": "string",
+            "label": "Input File",
+            "required": false,
+            "helpMarkDown": "File path that contains list of URLs (each separated by a new line) to scan in addition to URLs discovered from crawling the provided URL."
+        },
+        {
+            "name": "inputUrls",
+            "type": "string",
+            "label": "Input URLs",
+            "required": false,
+            "helpMarkDown": "List of URLs to crawl in addition to URLs discovered from crawling the provided URL, separated by space."
+        },
+        {
+            "name": "localhostPort",
+            "type": "int",
+            "label": "Localhost Port",
+            "required": false,
+            "helpMarkDown": "The preferred local website TCP port to use when scanning local website content."
+        },
+        {
+            "name": "scanTimeout",
+            "type": "int",
+            "label": "Scan Timeout",
+            "defaultValue": "90000",
+            "required": false,
+            "helpMarkDown": "The maximum timeout in milliseconds for the scan (excluding dependency setup)."
         }
     ],
     "execution": {


### PR DESCRIPTION
#### Details

Add the scanner/crawler inputs to the task config inputs.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
