### PR TITLE
feat(mvp-ado-extension-behavior): Add optional inputs to task.json and config

### DIFF
--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -30,20 +30,20 @@ describe(ADOTaskConfig, () => {
     }
 
     it.each`
-        inputOption                     | inputValue        | expectedValue                                         | getInputFunc
-        ${'repoToken'}                  | ${'token'}        | ${'token'}                                            | ${() => taskConfig.getToken()}
-        ${'scanUrlRelativePath'}        | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getScanUrlRelativePath()}
-        ${'chromePath'}                 | ${'./chromePath'} | ${getPlatformAgnosticPath(__dirname + '/chromePath')} | ${() => taskConfig.getChromePath()}
-        ${'inputFile'}                  | ${'./inputFile'}  | ${getPlatformAgnosticPath(__dirname + '/inputFile')}  | ${() => taskConfig.getInputFile()}
-        ${'outputDir'}                  | ${'./outputDir'}  | ${getPlatformAgnosticPath(__dirname + '/outputDir')}  | ${() => taskConfig.getReportOutDir()}
-        ${'siteDir'}                    | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getSiteDir()}
-        ${'url'}                        | ${'url'}          | ${'url'}                                              | ${() => taskConfig.getUrl()}
-        ${'discoveryPatterns'}          | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getDiscoveryPatterns()}
-        ${'inputUrls'}                  | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getInputUrls()}
-        ${'maxUrls'}                    | ${'20'}           | ${20}                                                 | ${() => taskConfig.getMaxUrls()}
-        ${'scanTimeout'}                | ${'100000'}       | ${100000}                                             | ${() => taskConfig.getScanTimeout()}
-        ${'localhostPort'}              | ${'8080'}         | ${8080}                                               | ${() => taskConfig.getLocalhostPort()}
-        ${'repoServiceConnectionName'}  | ${'testName'}     | ${'testName'}                                         | ${() => taskConfig.getRepoServiceConnectionName()}
+        inputOption                    | inputValue        | expectedValue                                         | getInputFunc
+        ${'repoToken'}                 | ${'token'}        | ${'token'}                                            | ${() => taskConfig.getToken()}
+        ${'scanUrlRelativePath'}       | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getScanUrlRelativePath()}
+        ${'chromePath'}                | ${'./chromePath'} | ${getPlatformAgnosticPath(__dirname + '/chromePath')} | ${() => taskConfig.getChromePath()}
+        ${'inputFile'}                 | ${'./inputFile'}  | ${getPlatformAgnosticPath(__dirname + '/inputFile')}  | ${() => taskConfig.getInputFile()}
+        ${'outputDir'}                 | ${'./outputDir'}  | ${getPlatformAgnosticPath(__dirname + '/outputDir')}  | ${() => taskConfig.getReportOutDir()}
+        ${'siteDir'}                   | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getSiteDir()}
+        ${'url'}                       | ${'url'}          | ${'url'}                                              | ${() => taskConfig.getUrl()}
+        ${'discoveryPatterns'}         | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getDiscoveryPatterns()}
+        ${'inputUrls'}                 | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getInputUrls()}
+        ${'maxUrls'}                   | ${'20'}           | ${20}                                                 | ${() => taskConfig.getMaxUrls()}
+        ${'scanTimeout'}               | ${'100000'}       | ${100000}                                             | ${() => taskConfig.getScanTimeout()}
+        ${'localhostPort'}             | ${'8080'}         | ${8080}                                               | ${() => taskConfig.getLocalhostPort()}
+        ${'repoServiceConnectionName'} | ${'testName'}     | ${'testName'}                                         | ${() => taskConfig.getRepoServiceConnectionName()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
@@ -57,8 +57,8 @@ describe(ADOTaskConfig, () => {
     );
 
     it.each`
-        inputOption                    | inputValue        | expectedValue | getInputFunc
-        ${'failOnAccessibilityError'}  | ${true}           | ${true}       | ${() => taskConfig.getFailOnAccessibilityError()}
+        inputOption                   | inputValue | expectedValue | getInputFunc
+        ${'failOnAccessibilityError'} | ${true}    | ${true}       | ${() => taskConfig.getFailOnAccessibilityError()}
     `(
         `bool input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {

--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -42,6 +42,7 @@ describe(ADOTaskConfig, () => {
         ${'inputUrls'}                  | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getInputUrls()}
         ${'maxUrls'}                    | ${'20'}           | ${20}                                                 | ${() => taskConfig.getMaxUrls()}
         ${'scanTimeout'}                | ${'100000'}       | ${100000}                                             | ${() => taskConfig.getScanTimeout()}
+        ${'localhostPort'}              | ${'8080'}         | ${8080}                                               | ${() => taskConfig.getLocalhostPort()}
         ${'repoServiceConnectionName'}  | ${'testName'}     | ${'testName'}                                         | ${() => taskConfig.getRepoServiceConnectionName()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,

--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -30,24 +30,39 @@ describe(ADOTaskConfig, () => {
     }
 
     it.each`
-        inputOption              | inputValue        | expectedValue                                         | getInputFunc
-        ${'repoToken'}           | ${'token'}        | ${'token'}                                            | ${() => taskConfig.getToken()}
-        ${'scanUrlRelativePath'} | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getScanUrlRelativePath()}
-        ${'chromePath'}          | ${'./chromePath'} | ${getPlatformAgnosticPath(__dirname + '/chromePath')} | ${() => taskConfig.getChromePath()}
-        ${'inputFile'}           | ${'./inputFile'}  | ${getPlatformAgnosticPath(__dirname + '/inputFile')}  | ${() => taskConfig.getInputFile()}
-        ${'outputDir'}           | ${'./outputDir'}  | ${getPlatformAgnosticPath(__dirname + '/outputDir')}  | ${() => taskConfig.getReportOutDir()}
-        ${'siteDir'}             | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getSiteDir()}
-        ${'url'}                 | ${'url'}          | ${'url'}                                              | ${() => taskConfig.getUrl()}
-        ${'discoveryPatterns'}   | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getDiscoveryPatterns()}
-        ${'inputUrls'}           | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getInputUrls()}
-        ${'maxUrls'}             | ${'20'}           | ${20}                                                 | ${() => taskConfig.getMaxUrls()}
-        ${'scanTimeout'}         | ${'100000'}       | ${100000}                                             | ${() => taskConfig.getScanTimeout()}
-        ${'localhostPort'}       | ${'8080'}         | ${8080}                                               | ${() => taskConfig.getLocalhostPort()}
+        inputOption                     | inputValue        | expectedValue                                         | getInputFunc
+        ${'repoToken'}                  | ${'token'}        | ${'token'}                                            | ${() => taskConfig.getToken()}
+        ${'scanUrlRelativePath'}        | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getScanUrlRelativePath()}
+        ${'chromePath'}                 | ${'./chromePath'} | ${getPlatformAgnosticPath(__dirname + '/chromePath')} | ${() => taskConfig.getChromePath()}
+        ${'inputFile'}                  | ${'./inputFile'}  | ${getPlatformAgnosticPath(__dirname + '/inputFile')}  | ${() => taskConfig.getInputFile()}
+        ${'outputDir'}                  | ${'./outputDir'}  | ${getPlatformAgnosticPath(__dirname + '/outputDir')}  | ${() => taskConfig.getReportOutDir()}
+        ${'siteDir'}                    | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getSiteDir()}
+        ${'url'}                        | ${'url'}          | ${'url'}                                              | ${() => taskConfig.getUrl()}
+        ${'discoveryPatterns'}          | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getDiscoveryPatterns()}
+        ${'inputUrls'}                  | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getInputUrls()}
+        ${'maxUrls'}                    | ${'20'}           | ${20}                                                 | ${() => taskConfig.getMaxUrls()}
+        ${'scanTimeout'}                | ${'100000'}       | ${100000}                                             | ${() => taskConfig.getScanTimeout()}
+        ${'repoServiceConnectionName'}  | ${'testName'}     | ${'testName'}                                         | ${() => taskConfig.getRepoServiceConnectionName()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
             adoTaskMock
                 .setup((am) => am.getInput(inputOption))
+                .returns(() => inputValue)
+                .verifiable(Times.once());
+            const retrievedOption = getInputFunc();
+            expect(retrievedOption).toStrictEqual(expectedValue);
+        },
+    );
+
+    it.each`
+        inputOption                    | inputValue        | expectedValue | getInputFunc
+        ${'failOnAccessibilityError'}  | ${true}           | ${true}       | ${() => taskConfig.getFailOnAccessibilityError()}
+    `(
+        `bool input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
+        ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
+            adoTaskMock
+                .setup((am) => am.getBoolInput(inputOption))
                 .returns(() => inputValue)
                 .verifiable(Times.once());
             const retrievedOption = getInputFunc();

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -85,7 +85,7 @@ export class ADOTaskConfig extends TaskConfig {
     }
 
     public getRepoServiceConnectionName(): string {
-        return this.adoTaskObj.getInput('repoServiceConnectionName')
+        return this.adoTaskObj.getInput('repoServiceConnectionName');
     }
 
     public getFailOnAccessibilityError(): boolean {

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -84,6 +84,14 @@ export class ADOTaskConfig extends TaskConfig {
         return parseInt(this.processObj.env.BUILD_BUILDID, 10);
     }
 
+    public getRepoServiceConnectionName(): string {
+        return this.adoTaskObj.getInput('repoServiceConnectionName')
+    }
+
+    public getFailOnAccessibilityError(): boolean {
+        return this.adoTaskObj.getBoolInput('failOnAccessibilityError');
+    }
+
     private getAbsolutePath(path: string): string {
         if (isEmpty(path)) {
             return undefined;

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -114,7 +114,7 @@
             "name": "failOnAccessibilityError",
             "type": "boolean",
             "label": "Fail on Accessibility Error",
-            "defaultValue": "false",
+            "defaultValue": false,
             "required": false,
             "helpMarkDown": "Fail the task if there are accessibility issues."
         }

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -109,6 +109,14 @@
             "defaultValue": "90000",
             "required": false,
             "helpMarkDown": "The maximum timeout in milliseconds for the scan (excluding dependency setup)."
+        },
+        {
+            "name": "failOnAccessibilityError",
+            "type": "boolean",
+            "label": "Fail on Accessibility Error",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Fail the task if there are accessibility issues."
         }
     ],
     "execution": {


### PR DESCRIPTION
#### Details
This PR adds the optional `failOnAccessibilityError` and `repoServiceConnectionName` inputs to our task.json and task-config files.

##### Motivation
We'll use these in future PRs for this feature. 

##### Context
n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
