### PR TITLE
feat(mvp-ado-extension-behavior): Introduce AdoPullRequestCommentCreator

### DIFF
--- a/packages/ado-extension/src/ioc/ado-ioc-types.ts
+++ b/packages/ado-extension/src/ioc/ado-ioc-types.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export const AdoIocTypes = {
+    AdoTask: 'AdoTask',
+    NodeApi: 'NodeApi',
+};

--- a/packages/ado-extension/src/ioc/setup-ioc-container.spec.ts
+++ b/packages/ado-extension/src/ioc/setup-ioc-container.spec.ts
@@ -2,9 +2,13 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
+import * as AdoTask from 'azure-pipelines-task-lib/task';
+import * as NodeApi from 'azure-devops-node-api';
 import { Container } from 'inversify';
 import { setupIocContainer } from './setup-ioc-container';
 import { iocTypes } from '@accessibility-insights-action/shared';
+import { AdoPullRequestCommentCreator } from '../progress-reporter/pull-request/ado-pull-request-comment-creator';
+import { AdoIocTypes } from './ado-ioc-types';
 
 describe(setupIocContainer, () => {
     let testSubject: Container;
@@ -13,8 +17,18 @@ describe(setupIocContainer, () => {
         testSubject = setupIocContainer();
     });
 
-    test.each([iocTypes.TaskConfig])('verify singleton resolution %p', (key: any) => {
-        verifySingletonDependencyResolution(testSubject, key);
+    test.each([iocTypes.TaskConfig, AdoPullRequestCommentCreator, iocTypes.ProgressReporters])(
+        'verify singleton resolution %p',
+        (key: any) => {
+            verifySingletonDependencyResolution(testSubject, key);
+        },
+    );
+
+    test.each([
+        { key: AdoIocTypes.AdoTask, value: AdoTask },
+        { key: AdoIocTypes.NodeApi, value: NodeApi },
+    ])('verify constant value resolution %s', (pair: { key: string; value: any }) => {
+        expect(testSubject.get(pair.key)).toEqual(pair.value);
     });
 
     function verifySingletonDependencyResolution(container: Container, key: any): void {

--- a/packages/ado-extension/src/ioc/setup-ioc-container.ts
+++ b/packages/ado-extension/src/ioc/setup-ioc-container.ts
@@ -1,12 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import * as AdoTask from 'azure-pipelines-task-lib/task';
 import * as inversify from 'inversify';
+import * as NodeApi from 'azure-devops-node-api';
 import { iocTypes, setupSharedIocContainer } from '@accessibility-insights-action/shared';
 import { ADOTaskConfig } from '../task-config/ado-task-config';
+import { AdoPullRequestCommentCreator } from '../progress-reporter/pull-request/ado-pull-request-comment-creator';
+import { AdoIocTypes } from './ado-ioc-types';
 
 export function setupIocContainer(container = new inversify.Container({ autoBindInjectable: true })): inversify.Container {
     container = setupSharedIocContainer(container);
+    container.bind(AdoIocTypes.AdoTask).toConstantValue(AdoTask);
+    container.bind(AdoIocTypes.NodeApi).toConstantValue(NodeApi);
     container.bind(iocTypes.TaskConfig).to(ADOTaskConfig).inSingletonScope();
+    container.bind(AdoPullRequestCommentCreator).toSelf().inSingletonScope();
+    container
+        .bind(iocTypes.ProgressReporters)
+        .toDynamicValue((context) => {
+            const pullRequestCommentCreator = context.container.get(AdoPullRequestCommentCreator);
+
+            return [pullRequestCommentCreator];
+        })
+        .inSingletonScope();
+
     return container;
 }

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
@@ -1,0 +1,301 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import * as adoTask from 'azure-pipelines-task-lib/task';
+import * as GitApi from 'azure-devops-node-api/GitApi';
+import * as nodeApi from 'azure-devops-node-api';
+import * as GitInterfaces from 'azure-devops-node-api/interfaces/GitInterfaces';
+
+import { Mock, Times, IMock, MockBehavior } from 'typemoq';
+import { AdoPullRequestCommentCreator as ADOPullRequestCommentCreator } from './ado-pull-request-comment-creator';
+import { ADOTaskConfig } from '../../task-config/ado-task-config';
+import { CombinedReportParameters } from 'accessibility-insights-report';
+
+import { Logger, ReportMarkdownConvertor } from '@accessibility-insights-action/shared';
+
+describe(ADOTaskConfig, () => {
+    let adoTaskMock: IMock<typeof adoTask>;
+    let adoTaskConfigMock: IMock<ADOTaskConfig>;
+    let gitApiMock: IMock<GitApi.IGitApi>;
+    let loggerMock: IMock<Logger>;
+    let nodeApiMock: IMock<typeof nodeApi>;
+    let reportMarkdownConvertorMock: IMock<ReportMarkdownConvertor>;
+    let webApiMock: IMock<nodeApi.WebApi>;
+    let prCommentCreator: ADOPullRequestCommentCreator;
+
+    beforeEach(() => {
+        adoTaskMock = Mock.ofType<typeof adoTask>(undefined, MockBehavior.Strict);
+        adoTaskConfigMock = Mock.ofType<ADOTaskConfig>(undefined, MockBehavior.Strict);
+        gitApiMock = Mock.ofType<GitApi.IGitApi>(undefined, MockBehavior.Strict);
+        loggerMock = Mock.ofType<Logger>(undefined, MockBehavior.Strict);
+        nodeApiMock = Mock.ofType<typeof nodeApi>(undefined, MockBehavior.Strict);
+        webApiMock = Mock.ofType<nodeApi.WebApi>(undefined, MockBehavior.Strict);
+        reportMarkdownConvertorMock = Mock.ofType<ReportMarkdownConvertor>(undefined, MockBehavior.Strict);
+    });
+
+    describe('constructor', () => {
+        it('should not initialize if isSupported returns false', () => {
+            setupIsSupportedReturnsFalse();
+
+            prCommentCreator = buildPrCommentCreatorWithMocks();
+
+            verifyAllMocks();
+        });
+
+        it('should initialize if isSupported returns true and serviceConnectionName is set', () => {
+            const apitoken = 'token';
+            setupIsSupportedReturnsTrue();
+            setupInitializeWithServiceConnectionName(apitoken);
+            setupInitializeSetConnection(apitoken);
+
+            prCommentCreator = buildPrCommentCreatorWithMocks();
+
+            verifyAllMocks();
+        });
+
+        it('should initialize if isSupported returns true and serviceConnectionName is not set', () => {
+            const apitoken = 'token';
+            setupIsSupportedReturnsTrue();
+            setupInitializeWithoutServiceConnectionName(apitoken);
+            setupInitializeSetConnection(apitoken);
+
+            prCommentCreator = buildPrCommentCreatorWithMocks();
+
+            verifyAllMocks();
+        });
+    });
+
+    describe('completeRun', () => {
+        it('should do nothing if isSupported returns false', async () => {
+            const reportStub: CombinedReportParameters = {} as CombinedReportParameters;
+
+            setupIsSupportedReturnsFalse();
+
+            prCommentCreator = buildPrCommentCreatorWithMocks();
+            await prCommentCreator.completeRun(reportStub);
+
+            verifyAllMocks();
+        });
+
+        it('should create a new thread if none exists', async () => {
+            const apitoken = 'token';
+            const reportMd = '#markdown';
+            const prId = 11; // arbitrary number
+            const repoId = 'repo-id';
+            const reportStub: CombinedReportParameters = {} as CombinedReportParameters;
+            const threadsStub: GitInterfaces.GitPullRequestCommentThread[] = [];
+            const newThread = {
+                comments: [
+                    {
+                        parentCommentId: 0,
+                        content: reportMd,
+                        commentType: GitInterfaces.CommentType.Text,
+                    },
+                ],
+                status: GitInterfaces.CommentThreadStatus.Active,
+            };
+
+            setupReturnPrThread(repoId, prId, reportStub, reportMd, threadsStub);
+            loggerMock.setup((o) => o.logInfo(`Didn't find an existing thread, making a new thread`)).verifiable(Times.once());
+            gitApiMock.setup((o) => o.createThread(newThread, repoId, prId)).verifiable(Times.once());
+            setupIsSupportedReturnsTrue();
+            setupInitializeWithoutServiceConnectionName(apitoken);
+            setupInitializeSetConnection(apitoken, webApiMock.object);
+            prCommentCreator = buildPrCommentCreatorWithMocks();
+
+            await prCommentCreator.completeRun(reportStub);
+
+            verifyAllMocks();
+        });
+
+        it('should comment on an existing thread if one exists', async () => {
+            const apitoken = 'token';
+            const reportMd = '#markdown';
+            const prId = 11; // arbitrary number
+            const threadId = 9; // arbitrary number
+            const repoId = 'repo-id';
+            const reportStub: CombinedReportParameters = {} as CombinedReportParameters;
+            const threadsStub: GitInterfaces.GitPullRequestCommentThread[] = [
+                {
+                    comments: [
+                        {
+                            content: 'A comment from Accessibility Insights',
+                        },
+                    ],
+                    id: threadId,
+                },
+            ];
+            const newComment = {
+                parentCommentId: 0,
+                content: 'Ran again',
+                commentType: GitInterfaces.CommentType.Text,
+            };
+
+            setupReturnPrThread(repoId, prId, reportStub, reportMd, threadsStub);
+            loggerMock.setup((o) => o.logInfo('Already found a thread from us')).verifiable(Times.once());
+
+            gitApiMock.setup((o) => o.createComment(newComment, repoId, prId, threadId)).verifiable(Times.once());
+            setupIsSupportedReturnsTrue();
+            setupInitializeWithoutServiceConnectionName(apitoken);
+            setupInitializeSetConnection(apitoken, webApiMock.object);
+            prCommentCreator = buildPrCommentCreatorWithMocks();
+
+            await prCommentCreator.completeRun(reportStub);
+
+            verifyAllMocks();
+        });
+    });
+
+    describe('failRun', () => {
+        it('do nothing if isSupported returns false', async () => {
+            const apitoken = 'token';
+            setupIsSupportedReturnsTrue();
+            setupInitializeWithoutServiceConnectionName(apitoken);
+            setupInitializeSetConnection(apitoken, webApiMock.object);
+            setupIsSupportedReturnsFalse();
+
+            prCommentCreator = buildPrCommentCreatorWithMocks();
+            await prCommentCreator.failRun('message');
+
+            verifyAllMocks();
+        });
+
+        it('reject promise with matching error', async () => {
+            const apitoken = 'token';
+            setupIsSupportedReturnsTrue();
+            setupInitializeWithoutServiceConnectionName(apitoken);
+            setupInitializeSetConnection(apitoken, webApiMock.object);
+            setupIsSupportedReturnsTrue();
+
+            prCommentCreator = buildPrCommentCreatorWithMocks();
+
+            await expect(prCommentCreator.failRun('message')).rejects.toMatch('message');
+            verifyAllMocks();
+        });
+    });
+
+    const buildPrCommentCreatorWithMocks = () =>
+        new ADOPullRequestCommentCreator(
+            adoTaskConfigMock.object,
+            reportMarkdownConvertorMock.object,
+            loggerMock.object,
+            adoTaskMock.object,
+            nodeApiMock.object,
+        );
+
+    const verifyAllMocks = () => {
+        adoTaskMock.verifyAll();
+        adoTaskConfigMock.verifyAll();
+        loggerMock.verifyAll();
+        reportMarkdownConvertorMock.verifyAll();
+        webApiMock.verifyAll();
+    };
+
+    const setupIsSupportedReturnsTrue = () => {
+        adoTaskMock
+            .setup((o) => o.getVariable('Build.Reason'))
+            .returns(() => 'PullRequest')
+            .verifiable(Times.atLeastOnce());
+    };
+
+    const setupIsSupportedReturnsFalse = () => {
+        adoTaskMock
+            .setup((o) => o.getVariable('Build.Reason'))
+            .returns(() => 'CI')
+            .verifiable(Times.atLeastOnce());
+    };
+
+    const setupInitializeWithoutServiceConnectionName = (apitoken: string) => {
+        adoTaskConfigMock
+            .setup((o) => o.getRepoServiceConnectionName())
+            .returns(() => '')
+            .verifiable(Times.once());
+        adoTaskMock
+            .setup((o) => o.getEndpointAuthorizationParameter('SystemVssConnection', 'AccessToken', true))
+            .returns(() => apitoken)
+            .verifiable(Times.once());
+    };
+
+    const setupInitializeWithServiceConnectionName = (apitoken: string) => {
+        const serviceConnection = 'service-connection';
+        const endpointAuthorizationStub: adoTask.EndpointAuthorization = {
+            parameters: {
+                apitoken,
+            },
+            scheme: '',
+        };
+
+        adoTaskConfigMock
+            .setup((o) => o.getRepoServiceConnectionName())
+            .returns(() => serviceConnection)
+            .verifiable(Times.once());
+        adoTaskMock
+            .setup((o) => o.getEndpointAuthorization(serviceConnection, true))
+            .returns(() => endpointAuthorizationStub)
+            .verifiable(Times.once());
+    };
+
+    const setupInitializeSetConnection = (apitoken: string, connection?: nodeApi.WebApi) => {
+        const url = 'url';
+        const handlerStub = {
+            prepareRequest: () => {
+                return;
+            },
+            canHandleAuthentication: () => false,
+            handleAuthentication: () => Promise.reject(),
+        };
+
+        nodeApiMock
+            .setup((o) => o.getPersonalAccessTokenHandler(apitoken))
+            .returns(() => handlerStub)
+            .verifiable(Times.once());
+        adoTaskMock
+            .setup((o) => o.getVariable('System.TeamFoundationCollectionUri'))
+            .returns(() => url)
+            .verifiable(Times.once());
+        nodeApiMock
+            .setup((o) => new o.WebApi(url, handlerStub))
+            .returns(() => connection)
+            .verifiable(Times.once());
+    };
+
+    const makeGitApiMockThenable = () => {
+        // Configuration to allow returning mock from a promise
+        // see https://github.com/florinn/typemoq#dynamic-mocks
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+        gitApiMock.setup((o: any) => o.then).returns(() => undefined);
+    };
+
+    const setupReturnPrThread = (
+        repoId: string,
+        prId: number,
+        reportStub: CombinedReportParameters,
+        reportMd: string,
+        threadsStub: GitInterfaces.GitPullRequestCommentThread[],
+    ) => {
+        makeGitApiMockThenable();
+        reportMarkdownConvertorMock
+            .setup((o) => o.convert(reportStub))
+            .returns(() => reportMd)
+            .verifiable(Times.once());
+        adoTaskMock
+            .setup((o) => o.getVariable('System.PullRequest.PullRequestId'))
+            .returns(() => prId.toString())
+            .verifiable(Times.once());
+        adoTaskMock
+            .setup((o) => o.getVariable('Build.Repository.ID'))
+            .returns(() => repoId)
+            .verifiable(Times.once());
+        loggerMock.setup((o) => o.logInfo(`PR is ${prId}, repo is ${repoId}`)).verifiable(Times.once());
+
+        webApiMock
+            .setup((o) => o.getGitApi())
+            .returns(() => Promise.resolve(gitApiMock.object))
+            .verifiable(Times.once());
+        gitApiMock
+            .setup((o) => o.getThreads(repoId, prId))
+            .returns(() => Promise.resolve(threadsStub))
+            .verifiable(Times.once());
+    };
+});

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { AdoIocTypes } from '../../ioc/ado-ioc-types';
 import { ADOTaskConfig } from '../../task-config/ado-task-config';
 import { inject, injectable } from 'inversify';
 import { Logger } from '@accessibility-insights-action/shared';
@@ -20,8 +21,8 @@ export class AdoPullRequestCommentCreator extends ProgressReporter {
         @inject(ADOTaskConfig) private readonly adoTaskConfig: ADOTaskConfig,
         @inject(ReportMarkdownConvertor) private readonly reportMarkdownConvertor: ReportMarkdownConvertor,
         @inject(Logger) private readonly logger: Logger,
-        private readonly adoTask: typeof AdoTask,
-        nodeApi: typeof NodeApi,
+        @inject(AdoIocTypes.AdoTask) private readonly adoTask: typeof AdoTask,
+        @inject(AdoIocTypes.NodeApi) nodeApi: typeof NodeApi,
     ) {
         super();
         if (!this.isSupported()) {

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ADOTaskConfig } from '../../task-config/ado-task-config';
+import { inject, injectable } from 'inversify';
+import { Logger } from '@accessibility-insights-action/shared';
+import { ReportMarkdownConvertor } from '@accessibility-insights-action/shared';
+import { ProgressReporter } from '@accessibility-insights-action/shared';
+import { CombinedReportParameters } from 'accessibility-insights-report';
+import * as AdoTask from 'azure-pipelines-task-lib/task';
+import * as NodeApi from 'azure-devops-node-api';
+import * as GitApi from 'azure-devops-node-api/GitApi';
+import * as GitInterfaces from 'azure-devops-node-api/interfaces/GitInterfaces';
+
+@injectable()
+export class AdoPullRequestCommentCreator extends ProgressReporter {
+    private connection: NodeApi.WebApi;
+
+    constructor(
+        @inject(ADOTaskConfig) private readonly adoTaskConfig: ADOTaskConfig,
+        @inject(ReportMarkdownConvertor) private readonly reportMarkdownConvertor: ReportMarkdownConvertor,
+        @inject(Logger) private readonly logger: Logger,
+        private readonly adoTask: typeof AdoTask,
+        nodeApi: typeof NodeApi,
+    ) {
+        super();
+        if (!this.isSupported()) {
+            return;
+        }
+
+        let token = '';
+
+        const serviceConnectionName = adoTaskConfig.getRepoServiceConnectionName();
+        if (serviceConnectionName?.length > 0) {
+            const userProvidedServiceConnection = adoTask.getEndpointAuthorization(serviceConnectionName, true);
+            // We should check the different schemes supported and access the appropriate params. Here we assume it's Token-based
+            // https://docs.microsoft.com/en-us/azure/devops/extend/develop/auth-schemes?view=azure-devops
+            token = userProvidedServiceConnection.parameters['apitoken'];
+            console.log('Using token provided by service connection passed in by user');
+        } else {
+            // falling back to build agent default creds
+            token = adoTask.getEndpointAuthorizationParameter('SystemVssConnection', 'AccessToken', true);
+            console.log('Could not find a service connection passed in by the user. Trying to use default build agent creds');
+        }
+
+        const authHandler = nodeApi.getPersonalAccessTokenHandler(token);
+        const url = adoTask.getVariable('System.TeamFoundationCollectionUri');
+        this.connection = new nodeApi.WebApi(url, authHandler);
+    }
+
+    public async start(): Promise<void> {
+        // We don't do anything for pull request flow
+    }
+
+    public async completeRun(combinedReportResult: CombinedReportParameters): Promise<void> {
+        if (!this.isSupported()) {
+            return;
+        }
+
+        const reportMarkdown = this.reportMarkdownConvertor.convert(combinedReportResult);
+        this.traceMarkdown(reportMarkdown);
+
+        const prId = parseInt(this.adoTask.getVariable('System.PullRequest.PullRequestId'));
+        const repoId = this.adoTask.getVariable('Build.Repository.ID');
+        this.logMessage(`PR is ${prId}, repo is ${repoId}`);
+
+        const gitApiObject: GitApi.IGitApi = await this.connection.getGitApi();
+        const prThreads = await gitApiObject.getThreads(repoId, prId);
+        const existingThread = prThreads.find((p) => p.comments.some((c) => c.content.includes('Accessibility Insights')));
+        if (existingThread == undefined) {
+            this.logMessage(`Didn't find an existing thread, making a new thread`);
+            await gitApiObject.createThread(
+                {
+                    comments: [
+                        {
+                            parentCommentId: 0,
+                            content: reportMarkdown,
+                            commentType: GitInterfaces.CommentType.Text,
+                        },
+                    ],
+                    status: GitInterfaces.CommentThreadStatus.Active,
+                },
+                repoId,
+                prId,
+            );
+        } else {
+            this.logMessage(`Already found a thread from us`);
+            await gitApiObject.createComment(
+                {
+                    parentCommentId: 0,
+                    content: 'Ran again', // TODO: maybe edit parent comment with markdown?
+                    commentType: GitInterfaces.CommentType.Text,
+                },
+                repoId,
+                prId,
+                existingThread.id,
+            );
+        }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public async failRun(message: string): Promise<void> {
+        if (!this.isSupported()) {
+            return;
+        }
+
+        throw message;
+    }
+
+    private isSupported(): boolean {
+        return this.adoTask.getVariable('Build.Reason') == 'PullRequest';
+    }
+
+    private logMessage(message: string): void {
+        this.logger.logInfo(`${message}`);
+    }
+}


### PR DESCRIPTION
#### Details
This PR introduces `AdoPullRequestCommentCreator`, ported over from the prototype, and sets it up with the IoC container. 

##### Motivation
We'll need this to comment on ADO pull requests.

##### Context
Future PRs in this feature will add:
- Handling for the different auth schemes supported and access the appropriate params
- Improving the comment detection logic
- Updating the existing comment
- Wiring this up

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
