### PR TITLE
feat(mvp-ado-extension-behavior): enable strictNullChecks in ado-extension

### DIFF
--- a/packages/ado-extension/src/ado-extension.ts
+++ b/packages/ado-extension/src/ado-extension.ts
@@ -5,8 +5,10 @@ import * as adoTask from 'azure-pipelines-task-lib/task';
 
 export function runScan() {
     try {
-        const url = adoTask.getInput('url', true) || 'url';
-        console.log(`Scanning ${url}`);
+        const url = adoTask.getInput('url', true);
+        if (url) {
+            console.log(`Scanning ${url}`);
+        }
     } catch (error) {
         console.log('Exception thrown in action: ', error);
         process.exit(1);

--- a/packages/ado-extension/src/ado-extension.ts
+++ b/packages/ado-extension/src/ado-extension.ts
@@ -6,9 +6,8 @@ import * as adoTask from 'azure-pipelines-task-lib/task';
 export function runScan() {
     try {
         const url = adoTask.getInput('url', true);
-        if (url) {
-            console.log(`Scanning ${url}`);
-        }
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        console.log(`Scanning ${url!}`);
     } catch (error) {
         console.log('Exception thrown in action: ', error);
         process.exit(1);

--- a/packages/ado-extension/src/ado-extension.ts
+++ b/packages/ado-extension/src/ado-extension.ts
@@ -5,7 +5,7 @@ import * as adoTask from 'azure-pipelines-task-lib/task';
 
 export function runScan() {
     try {
-        const url = adoTask.getInput('url', true);
+        const url = adoTask.getInput('url', true) || 'url';
         console.log(`Scanning ${url}`);
     } catch (error) {
         console.log('Exception thrown in action: ', error);

--- a/packages/ado-extension/src/ado-extension.ts
+++ b/packages/ado-extension/src/ado-extension.ts
@@ -5,9 +5,9 @@ import * as adoTask from 'azure-pipelines-task-lib/task';
 
 export function runScan() {
     try {
-        const url = adoTask.getInput('url', true);
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        console.log(`Scanning ${url!}`);
+        const url = adoTask.getInput('url', true)!;
+        console.log(`Scanning ${url}`);
     } catch (error) {
         console.log('Exception thrown in action: ', error);
         process.exit(1);

--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -72,9 +72,10 @@ describe(ADOTaskConfig, () => {
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
             adoTaskMock
                 .setup((am) => am.getBoolInput(inputOption))
-                .returns(() => inputValue)
+                .returns(() => inputValue as boolean)
                 .verifiable(Times.once());
-            const retrievedOption = getInputFunc();
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            const retrievedOption: unknown = getInputFunc();
             expect(retrievedOption).toStrictEqual(expectedValue);
         },
     );

--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -30,27 +30,27 @@ describe(ADOTaskConfig, () => {
     }
 
     it.each`
-        inputOption              | inputValue        | expectedValue                                         | getInputFunc
-        ${'repoToken'}           | ${'token'}        | ${'token'}                                            | ${() => taskConfig.getToken()}
-        ${'repoToken'}           | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getToken()}
-        ${'scanUrlRelativePath'} | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getScanUrlRelativePath()}
-        ${'chromePath'}          | ${'./chromePath'} | ${getPlatformAgnosticPath(__dirname + '/chromePath')} | ${() => taskConfig.getChromePath()}
-        ${'chromePath'}          | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getChromePath()}
-        ${'inputFile'}           | ${'./inputFile'}  | ${getPlatformAgnosticPath(__dirname + '/inputFile')}  | ${() => taskConfig.getInputFile()}
-        ${'inputFile'}           | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getInputFile()}
-        ${'outputDir'}           | ${'./outputDir'}  | ${getPlatformAgnosticPath(__dirname + '/outputDir')}  | ${() => taskConfig.getReportOutDir()}
-        ${'siteDir'}             | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getSiteDir()}
-        ${'url'}                 | ${'url'}          | ${'url'}                                              | ${() => taskConfig.getUrl()}
-        ${'url'}                 | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getUrl()}
-        ${'discoveryPatterns'}   | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getDiscoveryPatterns()}
-        ${'discoveryPatterns'}   | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getDiscoveryPatterns()}
-        ${'inputUrls'}           | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getInputUrls()}
-        ${'inputUrls'}           | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getInputUrls()}
-        ${'maxUrls'}             | ${'20'}           | ${20}                                                 | ${() => taskConfig.getMaxUrls()}
-        ${'scanTimeout'}         | ${'100000'}       | ${100000}                                             | ${() => taskConfig.getScanTimeout()}
-        ${'localhostPort'}       | ${'8080'}         | ${8080}                                               | ${() => taskConfig.getLocalhostPort()}
-        ${'localhostPort'}       | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getLocalhostPort()}
-        ${'repoServiceConnectionName'} | ${'testName'}     | ${'testName'}                                   | ${() => taskConfig.getRepoServiceConnectionName()}
+        inputOption                    | inputValue        | expectedValue                                         | getInputFunc
+        ${'repoToken'}                 | ${'token'}        | ${'token'}                                            | ${() => taskConfig.getToken()}
+        ${'repoToken'}                 | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getToken()}
+        ${'scanUrlRelativePath'}       | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getScanUrlRelativePath()}
+        ${'chromePath'}                | ${'./chromePath'} | ${getPlatformAgnosticPath(__dirname + '/chromePath')} | ${() => taskConfig.getChromePath()}
+        ${'chromePath'}                | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getChromePath()}
+        ${'inputFile'}                 | ${'./inputFile'}  | ${getPlatformAgnosticPath(__dirname + '/inputFile')}  | ${() => taskConfig.getInputFile()}
+        ${'inputFile'}                 | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getInputFile()}
+        ${'outputDir'}                 | ${'./outputDir'}  | ${getPlatformAgnosticPath(__dirname + '/outputDir')}  | ${() => taskConfig.getReportOutDir()}
+        ${'siteDir'}                   | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getSiteDir()}
+        ${'url'}                       | ${'url'}          | ${'url'}                                              | ${() => taskConfig.getUrl()}
+        ${'url'}                       | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getUrl()}
+        ${'discoveryPatterns'}         | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getDiscoveryPatterns()}
+        ${'discoveryPatterns'}         | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getDiscoveryPatterns()}
+        ${'inputUrls'}                 | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getInputUrls()}
+        ${'inputUrls'}                 | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getInputUrls()}
+        ${'maxUrls'}                   | ${'20'}           | ${20}                                                 | ${() => taskConfig.getMaxUrls()}
+        ${'scanTimeout'}               | ${'100000'}       | ${100000}                                             | ${() => taskConfig.getScanTimeout()}
+        ${'localhostPort'}             | ${'8080'}         | ${8080}                                               | ${() => taskConfig.getLocalhostPort()}
+        ${'localhostPort'}             | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getLocalhostPort()}
+        ${'repoServiceConnectionName'} | ${'testName'}     | ${'testName'}                                         | ${() => taskConfig.getRepoServiceConnectionName()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {

--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -9,14 +9,14 @@ import { Mock, Times, IMock } from 'typemoq';
 import { ADOTaskConfig } from './ado-task-config';
 
 describe(ADOTaskConfig, () => {
-    let processStub: any;
+    let processStub: NodeJS.Process;
     let adoTaskMock: IMock<typeof adoTask>;
     let taskConfig: ADOTaskConfig;
 
     beforeEach(() => {
         processStub = {
             env: {},
-        } as any;
+        } as NodeJS.Process;
         adoTaskMock = Mock.ofType<typeof adoTask>();
         taskConfig = new ADOTaskConfig(processStub, adoTaskMock.object);
     });
@@ -32,25 +32,33 @@ describe(ADOTaskConfig, () => {
     it.each`
         inputOption              | inputValue        | expectedValue                                         | getInputFunc
         ${'repoToken'}           | ${'token'}        | ${'token'}                                            | ${() => taskConfig.getToken()}
+        ${'repoToken'}           | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getToken()}
         ${'scanUrlRelativePath'} | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getScanUrlRelativePath()}
         ${'chromePath'}          | ${'./chromePath'} | ${getPlatformAgnosticPath(__dirname + '/chromePath')} | ${() => taskConfig.getChromePath()}
+        ${'chromePath'}          | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getChromePath()}
         ${'inputFile'}           | ${'./inputFile'}  | ${getPlatformAgnosticPath(__dirname + '/inputFile')}  | ${() => taskConfig.getInputFile()}
+        ${'inputFile'}           | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getInputFile()}
         ${'outputDir'}           | ${'./outputDir'}  | ${getPlatformAgnosticPath(__dirname + '/outputDir')}  | ${() => taskConfig.getReportOutDir()}
         ${'siteDir'}             | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getSiteDir()}
         ${'url'}                 | ${'url'}          | ${'url'}                                              | ${() => taskConfig.getUrl()}
+        ${'url'}                 | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getUrl()}
         ${'discoveryPatterns'}   | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getDiscoveryPatterns()}
+        ${'discoveryPatterns'}   | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getDiscoveryPatterns()}
         ${'inputUrls'}           | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getInputUrls()}
+        ${'inputUrls'}           | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getInputUrls()}
         ${'maxUrls'}             | ${'20'}           | ${20}                                                 | ${() => taskConfig.getMaxUrls()}
         ${'scanTimeout'}         | ${'100000'}       | ${100000}                                             | ${() => taskConfig.getScanTimeout()}
         ${'localhostPort'}       | ${'8080'}         | ${8080}                                               | ${() => taskConfig.getLocalhostPort()}
+        ${'localhostPort'}       | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getLocalhostPort()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
             adoTaskMock
                 .setup((am) => am.getInput(inputOption))
-                .returns(() => inputValue)
+                .returns(() => inputValue as string)
                 .verifiable(Times.once());
-            const retrievedOption = getInputFunc();
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            const retrievedOption: unknown = getInputFunc();
             expect(retrievedOption).toStrictEqual(expectedValue);
         },
     );
@@ -61,7 +69,7 @@ describe(ADOTaskConfig, () => {
             env: {
                 CHROME_BIN: chromePath,
             },
-        } as any;
+        } as unknown as NodeJS.Process;
         adoTaskMock
             .setup((o) => o.getInput('chromePath'))
             .returns(() => '')
@@ -79,7 +87,7 @@ describe(ADOTaskConfig, () => {
             env: {
                 PIPELINE_WORKSPACE: workspace,
             },
-        } as any;
+        } as unknown as NodeJS.Process;
         adoTaskMock
             .setup((o) => o.getInput('inputFile'))
             .returns(() => './file.txt')
@@ -97,7 +105,7 @@ describe(ADOTaskConfig, () => {
             env: {
                 BUILD_BUILDID: `${runId}`,
             },
-        } as any;
+        } as unknown as NodeJS.Process;
         taskConfig = new ADOTaskConfig(processStub, adoTaskMock.object);
 
         const actualRunId = taskConfig.getRunId();

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -20,24 +20,27 @@ export class ADOTaskConfig extends TaskConfig {
     }
 
     public getReportOutDir(): string {
-        return this.getAbsolutePath(this.adoTaskObj.getInput('outputDir'));
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return this.getAbsolutePath(this.adoTaskObj.getInput('outputDir'))!;
     }
 
     public getSiteDir(): string {
-        return this.adoTaskObj.getInput('siteDir');
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return this.adoTaskObj.getInput('siteDir')!;
     }
 
     public getScanUrlRelativePath(): string {
-        return this.adoTaskObj.getInput('scanUrlRelativePath');
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return this.adoTaskObj.getInput('scanUrlRelativePath')!;
     }
 
-    public getToken(): string {
-        return this.adoTaskObj.getInput('repoToken');
+    public getToken(): string | undefined {
+        return this.adoTaskObj.getInput('repoToken') || undefined;
     }
 
-    public getChromePath(): string {
-        let chromePath;
-        chromePath = this.getAbsolutePath(this.adoTaskObj.getInput('chromePath'));
+    public getChromePath(): string | undefined {
+        let chromePath = this.adoTaskObj.getInput('chromePath') || undefined;
+        chromePath = this.getAbsolutePath(chromePath);
 
         if (isEmpty(chromePath)) {
             chromePath = this.processObj.env.CHROME_BIN;
@@ -46,51 +49,60 @@ export class ADOTaskConfig extends TaskConfig {
         return chromePath;
     }
 
-    public getUrl(): string {
-        return this.adoTaskObj.getInput('url');
+    public getUrl(): string | undefined {
+        const value = this.adoTaskObj.getInput('url');
+
+        return isEmpty(value) ? undefined : value;
     }
 
     public getMaxUrls(): number {
-        return parseInt(this.adoTaskObj.getInput('maxUrls'));
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return parseInt(this.adoTaskObj.getInput('maxUrls')!);
     }
 
-    public getDiscoveryPatterns(): string {
+    public getDiscoveryPatterns(): string | undefined{
         const value = this.adoTaskObj.getInput('discoveryPatterns');
 
         return isEmpty(value) ? undefined : value;
     }
 
-    public getInputFile(): string {
-        return this.getAbsolutePath(this.adoTaskObj.getInput('inputFile'));
+    public getInputFile(): string | undefined {
+        return this.getAbsolutePath(this.adoTaskObj.getInput('inputFile') ?? undefined);
     }
 
-    public getInputUrls(): string {
+    public getInputUrls(): string | undefined {
         const value = this.adoTaskObj.getInput('inputUrls');
 
         return isEmpty(value) ? undefined : value;
     }
 
     public getScanTimeout(): number {
-        return parseInt(this.adoTaskObj.getInput('scanTimeout'));
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return parseInt(this.adoTaskObj.getInput('scanTimeout')!);
     }
 
-    public getLocalhostPort(): number {
+    public getLocalhostPort(): number | undefined {
         const value = this.adoTaskObj.getInput('localhostPort');
 
-        return isEmpty(value) ? undefined : parseInt(value, 10);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return isEmpty(value) ? undefined : parseInt(value!, 10);
     }
 
-    public getRunId(): number {
-        return parseInt(this.processObj.env.BUILD_BUILDID, 10);
+    public getRunId(): number | undefined {
+        const value = this.processObj.env.BUILD_BUILDID;
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return isEmpty(value) ? undefined : parseInt(value!, 10);
     }
 
-    private getAbsolutePath(path: string): string {
+    private getAbsolutePath(path: string | undefined): string | undefined {
         if (isEmpty(path)) {
             return undefined;
         }
 
         const dirname = this.processObj.env.PIPELINE_WORKSPACE ?? __dirname;
 
-        return normalizePath(this.resolvePath(dirname, normalizePath(path)));
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return normalizePath(this.resolvePath(dirname, normalizePath(path!)));
     }
 }

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -60,7 +60,7 @@ export class ADOTaskConfig extends TaskConfig {
         return parseInt(this.adoTaskObj.getInput('maxUrls')!);
     }
 
-    public getDiscoveryPatterns(): string | undefined{
+    public getDiscoveryPatterns(): string | undefined {
         const value = this.adoTaskObj.getInput('discoveryPatterns');
 
         return isEmpty(value) ? undefined : value;

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -95,8 +95,8 @@ export class ADOTaskConfig extends TaskConfig {
         return isEmpty(value) ? undefined : parseInt(value!, 10);
     }
 
-    public getRepoServiceConnectionName(): string {
-        return this.adoTaskObj.getInput('repoServiceConnectionName');
+    public getRepoServiceConnectionName(): string | undefined {
+        return this.adoTaskObj.getInput('repoServiceConnectionName') ?? undefined;
     }
 
     public getFailOnAccessibilityError(): boolean {

--- a/packages/ado-extension/tsconfig.json
+++ b/packages/ado-extension/tsconfig.json
@@ -3,6 +3,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "./dist/pkg/"
+        "outDir": "./dist/pkg/",
+        "strictNullChecks": true,
     }
 }

--- a/packages/ado-extension/tsconfig.json
+++ b/packages/ado-extension/tsconfig.json
@@ -4,6 +4,6 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "outDir": "./dist/pkg/",
-        "strictNullChecks": true,
+        "strictNullChecks": true
     }
 }

--- a/packages/shared/src/task-config.ts
+++ b/packages/shared/src/task-config.ts
@@ -11,14 +11,14 @@ export abstract class TaskConfig {
     abstract getReportOutDir(): string;
     abstract getSiteDir(): string;
     abstract getScanUrlRelativePath(): string;
-    abstract getToken(): string;
-    abstract getChromePath(): string;
-    abstract getUrl(): string;
+    abstract getToken(): string | undefined;
+    abstract getChromePath(): string | undefined;
+    abstract getUrl(): string | undefined;
     abstract getMaxUrls(): number;
-    abstract getDiscoveryPatterns(): string;
-    abstract getInputFile(): string;
-    abstract getInputUrls(): string;
+    abstract getDiscoveryPatterns(): string | undefined;
+    abstract getInputFile(): string | undefined;
+    abstract getInputUrls(): string | undefined;
     abstract getScanTimeout(): number;
-    abstract getLocalhostPort(): number;
-    abstract getRunId(): number;
+    abstract getLocalhostPort(): number | undefined;
+    abstract getRunId(): number | undefined;
 }


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Enable `strictNullChecks` in ado-extension

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
WI 1871859

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
Left out enabling strictNullChecks for shared and gh-action to reduce size of PR
<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: WI 1871859
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
