### PR TITLE
fix: Fix issues from strictNullChecks merge

### DIFF
--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
@@ -43,11 +43,22 @@ describe(ADOTaskConfig, () => {
             verifyAllMocks();
         });
 
+        it('should not initialize if missing required variable', () => {
+            const apitoken = 'token';
+            setupIsSupportedReturnsTrue();
+            setupInitializeWithServiceConnectionName(apitoken);
+            setupInitializeMissingVariable(apitoken);
+            
+            expect(() => buildPrCommentCreatorWithMocks()).toThrow('Unable to find System.TeamFoundationCollectionUri')
+
+            verifyAllMocks();
+        });
+
         it('should initialize if isSupported returns true and serviceConnectionName is set', () => {
             const apitoken = 'token';
             setupIsSupportedReturnsTrue();
             setupInitializeWithServiceConnectionName(apitoken);
-            setupInitializeSetConnection(apitoken);
+            setupInitializeSetConnection(apitoken, webApiMock.object);
 
             prCommentCreator = buildPrCommentCreatorWithMocks();
 
@@ -58,7 +69,7 @@ describe(ADOTaskConfig, () => {
             const apitoken = 'token';
             setupIsSupportedReturnsTrue();
             setupInitializeWithoutServiceConnectionName(apitoken);
-            setupInitializeSetConnection(apitoken);
+            setupInitializeSetConnection(apitoken, webApiMock.object);
 
             prCommentCreator = buildPrCommentCreatorWithMocks();
 
@@ -212,7 +223,7 @@ describe(ADOTaskConfig, () => {
             .returns(() => '')
             .verifiable(Times.once());
         adoTaskMock
-            .setup((o) => o.getEndpointAuthorizationParameter('SystemVssConnection', 'AccessToken', true))
+            .setup((o) => o.getEndpointAuthorizationParameter('SystemVssConnection', 'AccessToken', false))
             .returns(() => apitoken)
             .verifiable(Times.once());
     };
@@ -231,12 +242,12 @@ describe(ADOTaskConfig, () => {
             .returns(() => serviceConnection)
             .verifiable(Times.once());
         adoTaskMock
-            .setup((o) => o.getEndpointAuthorization(serviceConnection, true))
+            .setup((o) => o.getEndpointAuthorization(serviceConnection, false))
             .returns(() => endpointAuthorizationStub)
             .verifiable(Times.once());
     };
 
-    const setupInitializeSetConnection = (apitoken: string, connection?: nodeApi.WebApi) => {
+    const setupInitializeSetConnection = (apitoken: string, connection: nodeApi.WebApi) => {
         const url = 'url';
         const handlerStub = {
             prepareRequest: () => {
@@ -257,6 +268,25 @@ describe(ADOTaskConfig, () => {
         nodeApiMock
             .setup((o) => new o.WebApi(url, handlerStub))
             .returns(() => connection)
+            .verifiable(Times.once());
+    };
+
+    const setupInitializeMissingVariable = (apitoken: string) => {
+        const handlerStub = {
+            prepareRequest: () => {
+                return;
+            },
+            canHandleAuthentication: () => false,
+            handleAuthentication: () => Promise.reject(),
+        };
+
+        nodeApiMock
+            .setup((o) => o.getPersonalAccessTokenHandler(apitoken))
+            .returns(() => handlerStub)
+            .verifiable(Times.once());
+        adoTaskMock
+            .setup((o) => o.getVariable('System.TeamFoundationCollectionUri'))
+            .returns(() => undefined)
             .verifiable(Times.once());
     };
 

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
@@ -48,8 +48,8 @@ describe(ADOTaskConfig, () => {
             setupIsSupportedReturnsTrue();
             setupInitializeWithServiceConnectionName(apitoken);
             setupInitializeMissingVariable(apitoken);
-            
-            expect(() => buildPrCommentCreatorWithMocks()).toThrow('Unable to find System.TeamFoundationCollectionUri')
+
+            expect(() => buildPrCommentCreatorWithMocks()).toThrow('Unable to find System.TeamFoundationCollectionUri');
 
             verifyAllMocks();
         });

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
@@ -29,24 +29,37 @@ export class AdoPullRequestCommentCreator extends ProgressReporter {
             return;
         }
 
-        let token = '';
+        let token: string;
 
         const serviceConnectionName = adoTaskConfig.getRepoServiceConnectionName();
-        if (serviceConnectionName?.length > 0) {
-            const userProvidedServiceConnection = adoTask.getEndpointAuthorization(serviceConnectionName, true);
+        if (serviceConnectionName !== undefined && serviceConnectionName?.length > 0) {
+            // Will throw if no creds found
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const userProvidedServiceConnection = adoTask.getEndpointAuthorization(serviceConnectionName, false)!;
+
             // We should check the different schemes supported and access the appropriate params. Here we assume it's Token-based
             // https://docs.microsoft.com/en-us/azure/devops/extend/develop/auth-schemes?view=azure-devops
             token = userProvidedServiceConnection.parameters['apitoken'];
             console.log('Using token provided by service connection passed in by user');
         } else {
-            // falling back to build agent default creds
-            token = adoTask.getEndpointAuthorizationParameter('SystemVssConnection', 'AccessToken', true);
+            // falling back to build agent default creds. Will throw if no creds found
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            token = adoTask.getEndpointAuthorizationParameter('SystemVssConnection', 'AccessToken', false)!;
             console.log('Could not find a service connection passed in by the user. Trying to use default build agent creds');
         }
 
         const authHandler = nodeApi.getPersonalAccessTokenHandler(token);
-        const url = adoTask.getVariable('System.TeamFoundationCollectionUri');
+        const url = this.getVariableOrThrow('System.TeamFoundationCollectionUri');
         this.connection = new nodeApi.WebApi(url, authHandler);
+    }
+
+    private getVariableOrThrow(variableName: string): string {
+        const potentialVariable = this.adoTask.getVariable(variableName);
+        if (potentialVariable === undefined)
+        {
+            throw `Unable to find ${variableName}`;
+        }
+        return potentialVariable;
     }
 
     public async start(): Promise<void> {
@@ -61,14 +74,14 @@ export class AdoPullRequestCommentCreator extends ProgressReporter {
         const reportMarkdown = this.reportMarkdownConvertor.convert(combinedReportResult);
         this.traceMarkdown(reportMarkdown);
 
-        const prId = parseInt(this.adoTask.getVariable('System.PullRequest.PullRequestId'));
-        const repoId = this.adoTask.getVariable('Build.Repository.ID');
+        const prId = parseInt(this.getVariableOrThrow('System.PullRequest.PullRequestId'));
+        const repoId = this.getVariableOrThrow('Build.Repository.ID');
         this.logMessage(`PR is ${prId}, repo is ${repoId}`);
 
         const gitApiObject: GitApi.IGitApi = await this.connection.getGitApi();
         const prThreads = await gitApiObject.getThreads(repoId, prId);
-        const existingThread = prThreads.find((p) => p.comments.some((c) => c.content.includes('Accessibility Insights')));
-        if (existingThread == undefined) {
+        const existingThread = prThreads.find((p) => p.comments?.some((c) => c.content?.includes('Accessibility Insights')));
+        if (existingThread === undefined || existingThread.id === undefined) {
             this.logMessage(`Didn't find an existing thread, making a new thread`);
             await gitApiObject.createThread(
                 {

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
@@ -55,8 +55,7 @@ export class AdoPullRequestCommentCreator extends ProgressReporter {
 
     private getVariableOrThrow(variableName: string): string {
         const potentialVariable = this.adoTask.getVariable(variableName);
-        if (potentialVariable === undefined)
-        {
+        if (potentialVariable === undefined) {
             throw `Unable to find ${variableName}`;
         }
         return potentialVariable;


### PR DESCRIPTION
#### Details
Strict null checks were enabled in #829 but not in #828. They were merged at roughly the same, so the build broke. This PR fixes the build by adapting #829's changes to work with strictNullChecks.

##### Motivation
Fixes main

##### Context
n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
