### PR TITLE
feat(mvp-ado-extension-behavior): Wire Up ADO extension

### DIFF
--- a/packages/ado-extension/package.json
+++ b/packages/ado-extension/package.json
@@ -5,7 +5,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a\r Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us\r the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.",
     "main": "dist/pkg/index.js",
     "scripts": {
-        "build": "tsc && node prepare-package-dir.js",
+        "build": "webpack --config ./webpack.config.js && node prepare-package-dir.js",
         "cbuild": "npm-run-all --serial clean build",
         "clean": "rimraf dist",
         "lint:check": "eslint -c ../../.eslintrc.js \"src/**/*.{js,ts}\"",

--- a/packages/ado-extension/prepare-package-dir.js
+++ b/packages/ado-extension/prepare-package-dir.js
@@ -2,13 +2,16 @@
 // Licensed under the MIT License.
 // run from root folder, this scripts prepares the dist folder
 
-const fs = require('fs-extra');
+const fs = require('fs');
+const path = require('path');
+const packageJson = require(process.cwd() + '/package.json');
+const sharedPackageJson = require(path.resolve(process.cwd(), '../shared/package.json'));
+const getWebpackConfig = require(process.cwd() + '/webpack.config');
 
 // We allow overrides of extension/task identifiers so we can deploy
 // different versions of the extension with the same YAML
 const taskJson = JSON.parse(fs.readFileSync('task.json'));
 const extensionJson = JSON.parse(fs.readFileSync('ado-extension.json'));
-const packageJson = JSON.parse(fs.readFileSync('package.json'));
 
 const overrideExtensionName = process.env.ADO_EXTENSION_NAME;
 if (overrideExtensionName && overrideExtensionName.length > 0) {
@@ -27,28 +30,37 @@ if (overrideTaskId && overrideTaskId.length > 0) {
     taskJson.id = overrideTaskId;
 }
 
-var newDependencies = {};
+const packageDependencies = packageJson.dependencies;
+const webpackConfig = getWebpackConfig();
+const webpackExternals = webpackConfig.externals ? webpackConfig.externals : [];
+const imagePackageDependencies = {};
 
-for (var packageName in packageJson['dependencies']) {
-    if (!packageName.startsWith('@accessibility-insights-action')) {
-        newDependencies[packageName] = packageJson['dependencies'][packageName];
+webpackExternals.forEach((packageName) => {
+    if (packageDependencies.hasOwnProperty(packageName)) {
+        imagePackageDependencies[packageName] = packageDependencies[packageName];
+    } else if (sharedPackageJson.dependencies.hasOwnProperty(packageName)) {
+        imagePackageDependencies[packageName] = sharedPackageJson.dependencies[packageName];
+    } else {
+        throw new Error(`Package '${packageName}' is not declared in package.json dependencies{} section.`);
     }
-}
+});
 
 const newPackageJson = {
     ...packageJson,
-    dependencies: newDependencies,
+    scripts: undefined,
+    dependencies: imagePackageDependencies,
+    devDependencies: undefined,
 };
 
 fs.writeFileSync('dist/pkg/package.json', JSON.stringify(newPackageJson, undefined, 4));
 console.log('copied package.json to dist/pkg/package.json');
 
 console.log(JSON.stringify(extensionJson, null, 4));
-fs.writeJSONSync('dist/ado-extension.json', extensionJson);
+fs.writeFileSync('dist/ado-extension.json', JSON.stringify(extensionJson));
 console.log('copied ado-extension.json to dist/pkg/ado-extension.json with any overrides');
 
 console.log(JSON.stringify(taskJson, null, 4));
-fs.writeJSONSync('dist/pkg/task.json', taskJson);
+fs.writeFileSync('dist/pkg/task.json', JSON.stringify(taskJson));
 console.log('copied task.json to dist/pkg/task.json with any overrides');
 
 fs.copyFileSync('../../yarn.lock', 'dist/pkg/yarn.lock');

--- a/packages/ado-extension/src/ado-extension.ts
+++ b/packages/ado-extension/src/ado-extension.ts
@@ -1,15 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as adoTask from 'azure-pipelines-task-lib/task';
+import 'reflect-metadata';
+import './module-name-mapper';
+
+import { Logger } from '@accessibility-insights-action/shared';
+import { Scanner } from '@accessibility-insights-action/shared';
+import { setupIocContainer } from './ioc/setup-ioc-container';
 
 export function runScan() {
-    try {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const url = adoTask.getInput('url', true)!;
-        console.log(`Scanning ${url}`);
-    } catch (error) {
-        console.log('Exception thrown in action: ', error);
+    (async () => {
+        const container = setupIocContainer();
+        const logger = container.get(Logger);
+        await logger.setup();
+
+        const scanner = container.get(Scanner);
+        await scanner.scan();
+    })().catch((error) => {
+        console.log('Exception thrown in extension: ', error);
         process.exit(1);
-    }
+    });
 }

--- a/packages/ado-extension/src/module-name-mapper.ts
+++ b/packages/ado-extension/src/module-name-mapper.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/* eslint-disable
+@typescript-eslint/no-var-requires,
+@typescript-eslint/no-unsafe-call,
+@typescript-eslint/no-unsafe-member-access,
+@typescript-eslint/no-unsafe-assignment,
+@typescript-eslint/no-explicit-any
+*/
+
+export {};
+
+const moduleRef = require('module');
+moduleRef._resolveFilename = new Proxy(moduleRef._resolveFilename, {
+    apply(target: any, thisArg: any, argumentsList: any): any {
+        const moduleName = argumentsList[0] as string;
+        let path = Reflect.apply(target, thisArg, argumentsList) as string;
+        if (moduleName.startsWith('@uifabric/styling')) {
+            if (require('os').type() === 'Windows_NT') {
+                path = path.replace('\\lib\\', '\\lib-commonjs\\');
+            } else {
+                path = path.replace('/lib/', '/lib-commonjs/');
+            }
+        }
+
+        return path;
+    },
+});

--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -102,7 +102,7 @@ describe(ADOTaskConfig, () => {
         const workspace = '/home/user/workspace';
         processStub = {
             env: {
-                PIPELINE_WORKSPACE: workspace,
+                SYSTEM_DEFAULTWORKINGDIRECTORY: workspace,
             },
         } as unknown as NodeJS.Process;
         adoTaskMock

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -108,7 +108,7 @@ export class ADOTaskConfig extends TaskConfig {
             return undefined;
         }
 
-        const dirname = this.processObj.env.PIPELINE_WORKSPACE ?? __dirname;
+        const dirname = this.processObj.env.SYSTEM_DEFAULTWORKINGDIRECTORY ?? __dirname;
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return normalizePath(this.resolvePath(dirname, normalizePath(path!)));

--- a/packages/ado-extension/webpack.config.js
+++ b/packages/ado-extension/webpack.config.js
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const path = require('path');
+const webpack = require('webpack');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
+
+module.exports = (env) => {
+    const version = env ? env.version : 'dev';
+    console.log(`Building for version : ${version}`);
+    return {
+        devtool: 'cheap-source-map',
+        entry: {
+            ['index']: path.resolve('./src/index.ts'),
+        },
+        // We special case MPL-licensed dependencies ('axe-core', '@axe-core/puppeteer') because we want to avoid including their source in the same file as non-MPL code.
+        externals: ['axe-core', 'accessibility-insights-report', 'accessibility-insights-scan'],
+        mode: 'development',
+        module: {
+            rules: [
+                {
+                    test: /\.ts$/,
+                    use: [
+                        {
+                            loader: 'ts-loader',
+                            options: {
+                                transpileOnly: true,
+                                experimentalWatchApi: true,
+                            },
+                        },
+                    ],
+                    exclude: ['/node_modules/', /\.(spec|e2e)\.ts$/],
+                },
+            ],
+        },
+        name: 'scan-action',
+        node: {
+            __dirname: false,
+        },
+        output: {
+            path: path.resolve('./dist/pkg'),
+            filename: '[name].js',
+            libraryTarget: 'commonjs2',
+        },
+        plugins: [
+            new webpack.DefinePlugin({
+                __IMAGE_VERSION__: JSON.stringify(version),
+            }),
+            new ForkTsCheckerWebpackPlugin(),
+            new CaseSensitivePathsPlugin(),
+            // we ignore encoding because of https://github.com/microsoft/accessibility-insights-action/pull/752#issuecomment-893026690
+            new webpack.IgnorePlugin({ resourceRegExp: /^encoding$/, contextRegExp: /node_modules\\node-fetch\\lib$/ }),
+        ],
+        resolve: {
+            extensions: ['.ts', '.js', '.json'],
+            mainFields: ['main'], //This is fix for this issue https://www.gitmemory.com/issue/bitinn/node-fetch/450/494475397
+        },
+        target: 'node',
+    };
+};


### PR DESCRIPTION
#### Details

This PR wires up the ADO extension parts.
This was tested in ADO for both comments and report generation.
In this PR i had to switch to webpack because the shared library wasn't found while running the action.

##### Motivation

Get the extension to work in ADO PRs/CI

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
