### PR TITLE
feat(mvp-ado-extension-behavior): Disable e2e/ Remove the GH repo token from the task inputs

### DIFF
--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -53,13 +53,6 @@
             "helpMarkDown": "Path to Chrome executable."
         },
         {
-            "name": "repoToken",
-            "type": "string",
-            "label": "Repo Token",
-            "required": false,
-            "helpMarkDown": "GitHub API access token."
-        },
-        {
             "name": "url",
             "type": "string",
             "label": "Website URL",

--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -41,9 +41,6 @@ jobs:
             env:
                 NODE_OPTIONS: --max_old_space_size=4096
 
-          - script: yarn test:e2e
-            displayName: 'Run e2e tests'
-
           - script: yarn publish-code-coverage -t $(CODECOV_TOKEN)
             displayName: Publish code coverage to codecov
 


### PR DESCRIPTION
#### Details

This PR disables e2e and removes the GitHub repo token from the task inputs.

##### Motivation

Get the pipeline to work till 'azure-pipeline-task-lib' team reply to the webpack [issue](https://github.com/microsoft/azure-pipelines-task-lib/issues/794).

Remove the GH repo token from user interface till we add its functionality.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
