### PR TITLE
docs(mvp-ado-extension-behavior): ADO extension usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ _This action is still in early development & we don't recommend its usage in pub
 
 ## About
 
-The Accessibility Insights Action helps integrate automated accessibility tests in your GitHub workflow. It can be configured to scan a single page or also crawl and scan pages accessed from links on the given page. This can work for static files in your repository or remote URLs.
+The Accessibility Insights Action helps integrate automated accessibility tests in your GitHub workflow and Azure pipeline. It can be configured to scan a single page or also crawl and scan pages accessed from links on the given page. This can work for static files in your repository or remote URLs.
 The Accessibility Insights Action uses the [axe-core](https://github.com/dequelabs/axe-core) rules engine to scan websites and web apps for common accessibility issues.
 
 Automated checks can detect some common accessibility problems such as missing or invalid properties. But most accessibility problems can only be discovered through manual testing. The best way to evaluate web accessibility compliance is to complete an assessment using [Accessibility Insights for Web](https://accessibilityinsights.io/docs/en/web/overview/).
 
-For more information, see [how to use the action](docs/usage.md).
+For more information, see [How to use the GitHub Action](docs/gh-action-usage.md) and [How to use the Azure DevOps extension](docs/ado-extension-usage.md).
 
 ## Contributing
 

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -17,7 +17,7 @@ Reference this extension in your Azure pipelines with the snippets on this page.
 
 ### Basic template
 
-Save this workflow file in your Azure DevOps repo as `azure-pipelines.yml` or in your GitHub repo as `/pipelines/accessibility-validation.yml`. This template saves results to `output-dir` (default: `_accessibility-reports`) and uploads an artifact to the build in Azure DevOps.
+Save this workflow file in your Azure DevOps repo as `azure-pipelines.yml` or in your GitHub repo as `/pipelines/accessibility-validation.yml`. This template saves results to `outputDir` (default: `_accessibility-reports`) and uploads an artifact to the build in Azure DevOps.
 
 When you push this file to your repository, you should see the task running in the build.
 
@@ -38,7 +38,7 @@ steps:
           # siteDir: '$(System.DefaultWorkingDirectory)/path-to-built-website'
           # url: 'your-website-url'
 
-    - publish: '$(System.DefaultWorkingDirectory)_accessibility-reports'
+    - publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports'
       artifact: 'accessibility-reports'
 ```
 
@@ -102,7 +102,7 @@ Examples:
 
 ## Viewing results
 
--   An HTML report containing detailed results is saved to disk. To view it, you need to have added the step to upload artifacts to your yml file (see [Basic template](#basic-template)). Navigate to Artifacts from the build. Under `_accessibility-reports`, you'll find the downloadable report labeled `index.html`.
+-   An HTML report containing detailed results is saved to disk. To view it, you need to have added the step to upload artifacts to your yml file (see [Basic template](#basic-template)). Navigate to Artifacts from the build. Under `accessibility-reports`, you'll find the downloadable report labeled `index.html`.
 
 -   If the workflow was triggered by a pull request, the action should leave a comment on the Azure DevOps pull request with results. The extension does not leave comments on repos in GitHub.
 
@@ -116,7 +116,7 @@ You can choose to block pull requests if the extension finds accessibility issue
 ## Troubleshooting
 
 -   If the action didn't trigger as you expected, check the `trigger` or `pr` sections of your yml file. Make sure any listed branch names are correct for your repository.
--   If the action fails to complete, you can check the build logs for execution errors.
+-   If the action fails to complete, you can check the build logs for execution errors. These logs will be in the `accessibilityinsights` step.
 -   If you can't find an artifact, note that your workflow must include a `publish` step to add the report folder to your check results. See the [Basic template](#basic-template) above and [Azure DevOps documentation on publishing artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#publish-artifacts).
 -   If you're running on a `windows-2019` agent we recommend `//` instead of `/` for `scanUrlRelativePath`.
 -   If the scan takes longer than 90 seconds, you can override the default timeout by providing a value for `scanTimeout`.

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -1,0 +1,124 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+
+# How to use the Azure DevOps extension
+
+## Adding the extension
+
+Install [Accessibility Insights for Azure DevOps - Production](https://marketplace.visualstudio.com/items?itemName=accessibility-insights.prod).
+
+-   See [Install extensions from Azure DevOps documentation](https://docs.microsoft.com/en-us/azure/devops/marketplace/install-extension?view=azure-devops&tabs=browser) for steps on how to install an extension to your organization.
+
+Reference this action in your Azure pipelines with the snippets on this page.
+
+-   See [action.yml](https://github.com/microsoft/accessibility-insights-action/blob/v2/action.yml) for option descriptions. Make sure you view the correct source file for your version (e.g. v2 in the URL)
+
+### Basic template
+
+Save this workflow file in your Azure DevOps repo as `azure-pipelines.yml` or in your GitHub repo as `/pipelines/accessibility-validation.yml`. This template saves results to `output-dir` (default: `_accessibility-reports`) and uploads an artifact to the build in Azure DevOps.
+
+When you push this file to your repository, you should see the action running in the build.
+
+```yml
+trigger:
+    - main
+
+pool:
+    vmImage: ubuntu-latest
+
+steps:
+    # Insert any jobs here required to build your website files
+
+    - task: accessibility-insights.prod.task.accessibility-insights@0
+      inputs:
+          # Provide either site-dir or url
+          # site-dir: ${{ github.workspace }}/path-to-built-website
+          # url: your-website-url
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+          pathToPublish: '$(System.DefaultWorkingDirectory)_accessibility-reports'
+          artifactName: 'accessibility-reports'
+```
+
+### Scan a URL
+
+Provide the website URL. The URL should already be hosted - something like `http://localhost:12345/` or `https://example.com`.
+
+```yml
+- task: accessibility-insights.prod.task.accessibility-insights@0
+  inputs:
+      url: 'http://localhost:12345/'
+```
+
+The `url` parameter takes priority over `site-dir`. If `url` is provided, static file options like `site-dir` and `scan-url-relative-path` are ignored.
+
+### Scan local HTML files
+
+Provide the location of your built HTML files using `site-dir` and (optionally) `scan-url-relative-path`. The action will serve the site for you using `express`.
+
+```yml
+- task: accessibility-insights.prod.task.accessibility-insights@0
+  inputs:
+      site-dir: '$(System.DefaultWorkingDirectory)/website/root'
+      scan-url-relative-path: '/' # use // if windows agent
+```
+
+The file server will host files inside `site-dir`. The action begins crawling from `http://localhost:port/scan-url-relative-path/`.
+
+Generally `/` on Ubuntu and `//` on Windows are good defaults for `scan-url-relative-path`. If you prefer to start crawling from a child directory, note that:
+
+-   the local file server can only host descendants of `site-dir`
+-   By default, the crawler only visits links prefixed with `http://localhost:port/scan-url-relative-path/`. If you want to crawl links outside `scan-url-relative-path`, provide something like `discovery-patterns: http://localhost:port/[.*]`
+
+### Modify crawling options
+
+The action supports several crawling options defined in [action.yml](https://github.com/microsoft/accessibility-insights-action/blob/v2/action.yml).
+
+For instance, you can:
+
+-   use `max-urls: 1` to turn off crawling
+-   include a list of additional URLs to scan (the crawler won't find pages that are unlinked from the base page)
+
+For `discovery-patterns`, `input-file`, and `input-urls`, note that these options expect resolved URLs. If you provide static HTML files via `site-dir`, you should also provide `localhost-port` so that you can anticipate the base URL of the file server (`http://localhost:localhost-port/`).
+
+Examples:
+
+```yml
+- task: accessibility-insights.prod.task.accessibility-insights@0
+  inputs:
+      url: 'http://localhost:12345/'
+      input-urls: 'http://localhost:12345/other-url http://localhost:12345/other-url2'
+```
+
+```yml
+- task: accessibility-insights.prod.task.accessibility-insights@0
+  inputs:
+      site-dir: '$(System.DefaultWorkingDirectory)/website/root'
+      localhost-port: '12345'
+      input-urls: 'http://localhost:12345/unlinked-page.html'
+```
+
+## Viewing results
+
+-   An HTML report containing detailed results is saved to disk. To view it, you need to have added the step to upload artifacts to your yml file (see [Basic template](#basic-template)). Navigate to Artifacts from the build. Under `_accessibility-reports`, you'll find the downloadable report labeled `index.html`.
+
+-   If the workflow was triggered by a pull request, the action should leave a comment on the Azure DevOps pull request with results. The extension does not leave comments on repos in GitHub.
+
+## Blocking pull requests
+
+You can choose to block pull requests if the action finds accessibility issues.
+
+1. Ensure the action is [triggered on each pull request](https://docs.microsoft.com/en-us/azure/devops/pipelines/customize-pipeline?view=azure-devops#customize-ci-triggers).
+2. Ensure that you have set the `failOnAccessibilityError` input variable to `true`.
+
+## Troubleshooting
+
+-   If the action didn't trigger as you expected, check the `trigger` or `pr` sections of your yml file. Make sure any listed branch names are correct for your repository.
+-   If the action fails to complete, you can check the build logs for execution errors.
+<!-- Using the template above, these logs will be in the `Scan for accessibility issues` step. -->
+-   If you can't find an artifact, note that your workflow must include a `PublishBuildArtifacts` step to add the report folder to your check results. See the "Basic template" above.
+-   If you're running on a `windows-2019` agent we recommend `//` instead of `/` for `scan-url-relative-path`.
+-   If the scan takes longer than 90 seconds, you can override the default timeout by providing a value for `scan-timeout`

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -19,7 +19,7 @@ Reference this extension in your Azure pipelines with the snippets on this page.
 
 Save this workflow file in your Azure DevOps repo as `azure-pipelines.yml` or in your GitHub repo as `/pipelines/accessibility-validation.yml`. This template saves results to `output-dir` (default: `_accessibility-reports`) and uploads an artifact to the build in Azure DevOps.
 
-When you push this file to your repository, you should see the action running in the build.
+When you push this file to your repository, you should see the task running in the build.
 
 ```yml
 trigger:
@@ -33,7 +33,7 @@ steps:
 
     - task: accessibility-insights.prod.task.accessibility-insights@0
       inputs:
-          repoServiceConnectionName: ''
+          repoServiceConnectionName: 'myRepoServiceConnection'
           # Provide either siteDir or url
           # siteDir: '$(System.DefaultWorkingDirectory)/path-to-built-website'
           # url: 'your-website-url'
@@ -61,8 +61,8 @@ Provide the location of your built HTML files using `siteDir` and (optionally) `
 ```yml
 - task: accessibility-insights.prod.task.accessibility-insights@0
   inputs:
-      site-dir: '$(System.DefaultWorkingDirectory)/website/root'
-      scan-url-relative-path: '/' # use '//' if windows agent
+      siteDir: '$(System.DefaultWorkingDirectory)/website/root'
+      scanUrlRelativePath: '/' # use '//' if Windows agent
 ```
 
 The file server will host files inside `siteDir`. The action begins crawling from `http://localhost:port/scanUrlRelativePath/`.
@@ -119,4 +119,4 @@ You can choose to block pull requests if the extension finds accessibility issue
 -   If the action fails to complete, you can check the build logs for execution errors.
 -   If you can't find an artifact, note that your workflow must include a `publish` step to add the report folder to your check results. See the [Basic template](#basic-template) above and [Azure DevOps documentation on publishing artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#publish-artifacts).
 -   If you're running on a `windows-2019` agent we recommend `//` instead of `/` for `scanUrlRelativePath`.
--   If the scan takes longer than 90 seconds, you can override the default timeout by providing a value for `scanTimeout`
+-   If the scan takes longer than 90 seconds, you can override the default timeout by providing a value for `scanTimeout`.

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -11,9 +11,9 @@ Install [Accessibility Insights for Azure DevOps - Production](https://marketpla
 
 -   See [Install extensions from Azure DevOps documentation](https://docs.microsoft.com/en-us/azure/devops/marketplace/install-extension?view=azure-devops&tabs=browser) for steps on how to install an extension to your organization.
 
-Reference this action in your Azure pipelines with the snippets on this page.
+Reference this extension in your Azure pipelines with the snippets on this page.
 
--   See [action.yml](https://github.com/microsoft/accessibility-insights-action/blob/v2/action.yml) for option descriptions. Make sure you view the correct source file for your version (e.g. v2 in the URL)
+-   See [task.json](https://github.com/microsoft/accessibility-insights-action/blob/main/packages/ado-extension/task.json) for option descriptions.
 
 ### Basic template
 
@@ -33,9 +33,10 @@ steps:
 
     - task: accessibility-insights.prod.task.accessibility-insights@0
       inputs:
-          # Provide either site-dir or url
-          # site-dir: ${{ github.workspace }}/path-to-built-website
-          # url: your-website-url
+          repoServiceConnectionName: ''
+          # Provide either siteDir or url
+          # siteDir: '$(System.DefaultWorkingDirectory)/path-to-built-website'
+          # url: 'your-website-url'
 
     - publish: '$(System.DefaultWorkingDirectory)_accessibility-reports'
       artifact: 'accessibility-reports'
@@ -51,36 +52,36 @@ Provide the website URL. The URL should already be hosted - something like `http
       url: 'http://localhost:12345/'
 ```
 
-The `url` parameter takes priority over `site-dir`. If `url` is provided, static file options like `site-dir` and `scan-url-relative-path` are ignored.
+The `url` parameter takes priority over `siteDir`. If `url` is provided, static file options like `siteDir` and `scanUrlRelativePath` are ignored.
 
 ### Scan local HTML files
 
-Provide the location of your built HTML files using `site-dir` and (optionally) `scan-url-relative-path`. The action will serve the site for you using `express`.
+Provide the location of your built HTML files using `siteDir` and (optionally) `scanUrlRelativePath`. The action will serve the site for you using `express`.
 
 ```yml
 - task: accessibility-insights.prod.task.accessibility-insights@0
   inputs:
       site-dir: '$(System.DefaultWorkingDirectory)/website/root'
-      scan-url-relative-path: '/' # use // if windows agent
+      scan-url-relative-path: '/' # use '//' if windows agent
 ```
 
-The file server will host files inside `site-dir`. The action begins crawling from `http://localhost:port/scan-url-relative-path/`.
+The file server will host files inside `siteDir`. The action begins crawling from `http://localhost:port/scanUrlRelativePath/`.
 
-Generally `/` on Ubuntu and `//` on Windows are good defaults for `scan-url-relative-path`. If you prefer to start crawling from a child directory, note that:
+Generally `/` on Ubuntu and `//` on Windows are good defaults for `scanUrlRelativePath`. If you prefer to start crawling from a child directory, note that:
 
--   the local file server can only host descendants of `site-dir`
--   By default, the crawler only visits links prefixed with `http://localhost:port/scan-url-relative-path/`. If you want to crawl links outside `scan-url-relative-path`, provide something like `discovery-patterns: http://localhost:port/[.*]`
+-   the local file server can only host descendants of `siteDir`
+-   By default, the crawler only visits links prefixed with `http://localhost:port/scanUrlRelativePath/`. If you want to crawl links outside `scanUrlRelativePath`, provide something like `discoveryPatterns: 'http://localhost:port/[.*]'`
 
 ### Modify crawling options
 
-The action supports several crawling options defined in [action.yml](https://github.com/microsoft/accessibility-insights-action/blob/v2/action.yml).
+The action supports several crawling options defined in [task.json](https://github.com/microsoft/accessibility-insights-action/blob/main/packages/ado-extension/task.json).
 
 For instance, you can:
 
--   use `max-urls: 1` to turn off crawling
+-   use `maxUrls: 1` to turn off crawling
 -   include a list of additional URLs to scan (the crawler won't find pages that are unlinked from the base page)
 
-For `discovery-patterns`, `input-file`, and `input-urls`, note that these options expect resolved URLs. If you provide static HTML files via `site-dir`, you should also provide `localhost-port` so that you can anticipate the base URL of the file server (`http://localhost:localhost-port/`).
+For `discoveryPatterns`, `inputFile`, and `inputUrls`, note that these options expect resolved URLs. If you provide static HTML files via `siteDir`, you should also provide `localhostPort` so that you can anticipate the base URL of the file server (`http://localhost:localhostPort/`).
 
 Examples:
 
@@ -88,15 +89,15 @@ Examples:
 - task: accessibility-insights.prod.task.accessibility-insights@0
   inputs:
       url: 'http://localhost:12345/'
-      input-urls: 'http://localhost:12345/other-url http://localhost:12345/other-url2'
+      inputUrls: 'http://localhost:12345/other-url http://localhost:12345/other-url2'
 ```
 
 ```yml
 - task: accessibility-insights.prod.task.accessibility-insights@0
   inputs:
-      site-dir: '$(System.DefaultWorkingDirectory)/website/root'
-      localhost-port: '12345'
-      input-urls: 'http://localhost:12345/unlinked-page.html'
+      siteDir: '$(System.DefaultWorkingDirectory)/website/root'
+      localhostPort: '12345'
+      inputUrls: 'http://localhost:12345/unlinked-page.html'
 ```
 
 ## Viewing results
@@ -107,16 +108,15 @@ Examples:
 
 ## Blocking pull requests
 
-You can choose to block pull requests if the action finds accessibility issues.
+You can choose to block pull requests if the extension finds accessibility issues.
 
-1. Ensure the action is [triggered on each pull request](https://docs.microsoft.com/en-us/azure/devops/pipelines/customize-pipeline?view=azure-devops#customize-ci-triggers).
+1. Ensure the extension is [triggered on each pull request](https://docs.microsoft.com/en-us/azure/devops/pipelines/customize-pipeline?view=azure-devops#customize-ci-triggers).
 2. Ensure that you have set the `failOnAccessibilityError` input variable to `true`.
 
 ## Troubleshooting
 
 -   If the action didn't trigger as you expected, check the `trigger` or `pr` sections of your yml file. Make sure any listed branch names are correct for your repository.
 -   If the action fails to complete, you can check the build logs for execution errors.
-<!-- Using the template above, these logs will be in the `Scan for accessibility issues` step. -->
--   If you can't find an artifact, note that your workflow must include a `publish` step to add the report folder to your check results. See the "Basic template" above and [Azure DevOps documentation on publishing artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#publish-artifacts).
--   If you're running on a `windows-2019` agent we recommend `//` instead of `/` for `scan-url-relative-path`.
--   If the scan takes longer than 90 seconds, you can override the default timeout by providing a value for `scan-timeout`
+-   If you can't find an artifact, note that your workflow must include a `publish` step to add the report folder to your check results. See the [Basic template](#basic-template) above and [Azure DevOps documentation on publishing artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#publish-artifacts).
+-   If you're running on a `windows-2019` agent we recommend `//` instead of `/` for `scanUrlRelativePath`.
+-   If the scan takes longer than 90 seconds, you can override the default timeout by providing a value for `scanTimeout`

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -37,10 +37,8 @@ steps:
           # site-dir: ${{ github.workspace }}/path-to-built-website
           # url: your-website-url
 
-    - task: PublishBuildArtifacts@1
-      inputs:
-          pathToPublish: '$(System.DefaultWorkingDirectory)_accessibility-reports'
-          artifactName: 'accessibility-reports'
+    - publish: '$(System.DefaultWorkingDirectory)_accessibility-reports'
+      artifact: 'accessibility-reports'
 ```
 
 ### Scan a URL
@@ -119,6 +117,6 @@ You can choose to block pull requests if the action finds accessibility issues.
 -   If the action didn't trigger as you expected, check the `trigger` or `pr` sections of your yml file. Make sure any listed branch names are correct for your repository.
 -   If the action fails to complete, you can check the build logs for execution errors.
 <!-- Using the template above, these logs will be in the `Scan for accessibility issues` step. -->
--   If you can't find an artifact, note that your workflow must include a `PublishBuildArtifacts` step to add the report folder to your check results. See the "Basic template" above.
+-   If you can't find an artifact, note that your workflow must include a `publish` step to add the report folder to your check results. See the "Basic template" above and [Azure DevOps documentation on publishing artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#publish-artifacts).
 -   If you're running on a `windows-2019` agent we recommend `//` instead of `/` for `scan-url-relative-path`.
 -   If the scan takes longer than 90 seconds, you can override the default timeout by providing a value for `scan-timeout`

--- a/docs/gh-action-usage.md
+++ b/docs/gh-action-usage.md
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 -->
 
-# How to use the action
+# How to use the GitHub Action
 
 To use this action in your workflow (which, again, we don't yet recommend at all for any production projects), we recommend referring to a version tag:
 


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
* Added documentation for using the ADO extension, `docs/ado-extension-usage.md`
* Renamed the GitHub Action usage document for consistency, `docs/usage.md` to `docs/gh-action-usage.md`

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Addresses WI 1871864

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: WI 1871864
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
