### PR TITLE
feat(mvp-ado-extension-behavior): Add support for basic auth in AdoPullRequestCommentCreator 

### DIFF
--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
@@ -24,6 +24,14 @@ describe(ADOTaskConfig, () => {
     let webApiMock: IMock<nodeApi.WebApi>;
     let prCommentCreator: ADOPullRequestCommentCreator;
 
+    const handlerStub = {
+        prepareRequest: () => {
+            return;
+        },
+        canHandleAuthentication: () => false,
+        handleAuthentication: () => Promise.reject(),
+    };
+
     beforeEach(() => {
         adoTaskMock = Mock.ofType<typeof adoTask>(undefined, MockBehavior.Strict);
         adoTaskConfigMock = Mock.ofType<ADOTaskConfig>(undefined, MockBehavior.Strict);
@@ -44,21 +52,38 @@ describe(ADOTaskConfig, () => {
         });
 
         it('should not initialize if missing required variable', () => {
-            const apitoken = 'token';
             setupIsSupportedReturnsTrue();
-            setupInitializeWithServiceConnectionName(apitoken);
-            setupInitializeMissingVariable(apitoken);
+            setupInitializeWithTokenServiceConnection();
+            setupInitializeMissingVariable();
 
             expect(() => buildPrCommentCreatorWithMocks()).toThrow('Unable to find System.TeamFoundationCollectionUri');
 
             verifyAllMocks();
         });
 
-        it('should initialize if isSupported returns true and serviceConnectionName is set', () => {
-            const apitoken = 'token';
+        it('should not initialize if serviceConnection uses unsupported auth', () => {
             setupIsSupportedReturnsTrue();
-            setupInitializeWithServiceConnectionName(apitoken);
-            setupInitializeSetConnection(apitoken, webApiMock.object);
+            setupInitializeWithUnsupportedServiceConnection();
+
+            expect(() => buildPrCommentCreatorWithMocks()).toThrow('Unsupported auth scheme. Please use token or basic auth.');
+
+            verifyAllMocks();
+        });
+
+        it('should initialize if isSupported returns true and serviceConnection uses basic auth', () => {
+            setupIsSupportedReturnsTrue();
+            setupInitializeWithBasicServiceConnection();
+            setupInitializeSetConnection(webApiMock.object);
+
+            prCommentCreator = buildPrCommentCreatorWithMocks();
+
+            verifyAllMocks();
+        });
+
+        it('should initialize if isSupported returns true and serviceConnection uses token auth', () => {
+            setupIsSupportedReturnsTrue();
+            setupInitializeWithTokenServiceConnection();
+            setupInitializeSetConnection(webApiMock.object);
 
             prCommentCreator = buildPrCommentCreatorWithMocks();
 
@@ -66,10 +91,9 @@ describe(ADOTaskConfig, () => {
         });
 
         it('should initialize if isSupported returns true and serviceConnectionName is not set', () => {
-            const apitoken = 'token';
             setupIsSupportedReturnsTrue();
-            setupInitializeWithoutServiceConnectionName(apitoken);
-            setupInitializeSetConnection(apitoken, webApiMock.object);
+            setupInitializeWithoutServiceConnectionName();
+            setupInitializeSetConnection(webApiMock.object);
 
             prCommentCreator = buildPrCommentCreatorWithMocks();
 
@@ -89,7 +113,6 @@ describe(ADOTaskConfig, () => {
             verifyAllMocks();
         });
 
-        const apitoken = 'token';
         const reportMd = '#markdown';
         const prId = 11; // arbitrary number
         const repoId = 'repo-id';
@@ -149,8 +172,8 @@ describe(ADOTaskConfig, () => {
             loggerMock.setup((o) => o.logInfo(`Didn't find an existing thread, making a new thread`)).verifiable(Times.once());
             gitApiMock.setup((o) => o.createThread(newThread, repoId, prId)).verifiable(Times.once());
             setupIsSupportedReturnsTrue();
-            setupInitializeWithoutServiceConnectionName(apitoken);
-            setupInitializeSetConnection(apitoken, webApiMock.object);
+            setupInitializeWithoutServiceConnectionName();
+            setupInitializeSetConnection(webApiMock.object);
             prCommentCreator = buildPrCommentCreatorWithMocks();
 
             await prCommentCreator.completeRun(reportStub);
@@ -172,8 +195,8 @@ describe(ADOTaskConfig, () => {
             gitApiMock.setup((o) => o.updateComment(expectedComment, repoId, prId, threadId, commentId)).verifiable(Times.once());
             gitApiMock.setup((o) => o.createComment(newComment, repoId, prId, threadId)).verifiable(Times.once());
             setupIsSupportedReturnsTrue();
-            setupInitializeWithoutServiceConnectionName(apitoken);
-            setupInitializeSetConnection(apitoken, webApiMock.object);
+            setupInitializeWithoutServiceConnectionName();
+            setupInitializeSetConnection(webApiMock.object);
             prCommentCreator = buildPrCommentCreatorWithMocks();
 
             await prCommentCreator.completeRun(reportStub);
@@ -184,10 +207,9 @@ describe(ADOTaskConfig, () => {
 
     describe('failRun', () => {
         it('do nothing if isSupported returns false', async () => {
-            const apitoken = 'token';
             setupIsSupportedReturnsTrue();
-            setupInitializeWithoutServiceConnectionName(apitoken);
-            setupInitializeSetConnection(apitoken, webApiMock.object);
+            setupInitializeWithoutServiceConnectionName();
+            setupInitializeSetConnection(webApiMock.object);
             setupIsSupportedReturnsFalse();
 
             prCommentCreator = buildPrCommentCreatorWithMocks();
@@ -197,10 +219,9 @@ describe(ADOTaskConfig, () => {
         });
 
         it('reject promise with matching error', async () => {
-            const apitoken = 'token';
             setupIsSupportedReturnsTrue();
-            setupInitializeWithoutServiceConnectionName(apitoken);
-            setupInitializeSetConnection(apitoken, webApiMock.object);
+            setupInitializeWithoutServiceConnectionName();
+            setupInitializeSetConnection(webApiMock.object);
             setupIsSupportedReturnsTrue();
 
             prCommentCreator = buildPrCommentCreatorWithMocks();
@@ -241,7 +262,9 @@ describe(ADOTaskConfig, () => {
             .verifiable(Times.atLeastOnce());
     };
 
-    const setupInitializeWithoutServiceConnectionName = (apitoken: string) => {
+    const setupInitializeWithoutServiceConnectionName = () => {
+        const apitoken = 'token';
+
         adoTaskConfigMock
             .setup((o) => o.getRepoServiceConnectionName())
             .returns(() => '')
@@ -250,9 +273,15 @@ describe(ADOTaskConfig, () => {
             .setup((o) => o.getEndpointAuthorizationParameter('SystemVssConnection', 'AccessToken', false))
             .returns(() => apitoken)
             .verifiable(Times.once());
+        nodeApiMock
+            .setup((o) => o.getPersonalAccessTokenHandler(apitoken))
+            .returns(() => handlerStub)
+            .verifiable(Times.once());
     };
 
-    const setupInitializeWithServiceConnectionName = (apitoken: string) => {
+    const setupInitializeWithTokenServiceConnection = () => {
+        const apitoken = 'token';
+
         const serviceConnection = 'service-connection';
         const endpointAuthorizationStub: adoTask.EndpointAuthorization = {
             parameters: {
@@ -269,22 +298,71 @@ describe(ADOTaskConfig, () => {
             .setup((o) => o.getEndpointAuthorization(serviceConnection, false))
             .returns(() => endpointAuthorizationStub)
             .verifiable(Times.once());
-    };
-
-    const setupInitializeSetConnection = (apitoken: string, connection: nodeApi.WebApi) => {
-        const url = 'url';
-        const handlerStub = {
-            prepareRequest: () => {
-                return;
-            },
-            canHandleAuthentication: () => false,
-            handleAuthentication: () => Promise.reject(),
-        };
-
+        adoTaskMock
+            .setup((o) => o.getEndpointAuthorizationScheme(serviceConnection, true))
+            .returns(() => 'token')
+            .verifiable(Times.once());
         nodeApiMock
             .setup((o) => o.getPersonalAccessTokenHandler(apitoken))
             .returns(() => handlerStub)
             .verifiable(Times.once());
+    };
+
+    const setupInitializeWithBasicServiceConnection = () => {
+        const serviceConnection = 'service-connection',
+            username = 'user',
+            password = 'secret';
+        const endpointAuthorizationStub: adoTask.EndpointAuthorization = {
+            parameters: {
+                username,
+                password,
+            },
+            scheme: '',
+        };
+
+        adoTaskConfigMock
+            .setup((o) => o.getRepoServiceConnectionName())
+            .returns(() => serviceConnection)
+            .verifiable(Times.once());
+        adoTaskMock
+            .setup((o) => o.getEndpointAuthorization(serviceConnection, false))
+            .returns(() => endpointAuthorizationStub)
+            .verifiable(Times.once());
+        adoTaskMock
+            .setup((o) => o.getEndpointAuthorizationScheme(serviceConnection, true))
+            .returns(() => 'usernamepassword')
+            .verifiable(Times.once());
+
+        nodeApiMock
+            .setup((o) => o.getBasicHandler(username, password))
+            .returns(() => handlerStub)
+            .verifiable(Times.once());
+    };
+
+    const setupInitializeWithUnsupportedServiceConnection = () => {
+        const serviceConnection = 'service-connection';
+        const endpointAuthorizationStub: adoTask.EndpointAuthorization = {
+            parameters: {},
+            scheme: '',
+        };
+
+        adoTaskConfigMock
+            .setup((o) => o.getRepoServiceConnectionName())
+            .returns(() => serviceConnection)
+            .verifiable(Times.once());
+        adoTaskMock
+            .setup((o) => o.getEndpointAuthorization(serviceConnection, false))
+            .returns(() => endpointAuthorizationStub)
+            .verifiable(Times.once());
+        adoTaskMock
+            .setup((o) => o.getEndpointAuthorizationScheme(serviceConnection, true))
+            .returns(() => 'other')
+            .verifiable(Times.once());
+    };
+
+    const setupInitializeSetConnection = (connection: nodeApi.WebApi) => {
+        const url = 'url';
+
         adoTaskMock
             .setup((o) => o.getVariable('System.TeamFoundationCollectionUri'))
             .returns(() => url)
@@ -295,19 +373,7 @@ describe(ADOTaskConfig, () => {
             .verifiable(Times.once());
     };
 
-    const setupInitializeMissingVariable = (apitoken: string) => {
-        const handlerStub = {
-            prepareRequest: () => {
-                return;
-            },
-            canHandleAuthentication: () => false,
-            handleAuthentication: () => Promise.reject(),
-        };
-
-        nodeApiMock
-            .setup((o) => o.getPersonalAccessTokenHandler(apitoken))
-            .returns(() => handlerStub)
-            .verifiable(Times.once());
+    const setupInitializeMissingVariable = () => {
         adoTaskMock
             .setup((o) => o.getVariable('System.TeamFoundationCollectionUri'))
             .returns(() => undefined)

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
@@ -12,6 +12,7 @@ import * as AdoTask from 'azure-pipelines-task-lib/task';
 import * as NodeApi from 'azure-devops-node-api';
 import * as GitApi from 'azure-devops-node-api/GitApi';
 import * as GitInterfaces from 'azure-devops-node-api/interfaces/GitInterfaces';
+import * as VsoBaseInterfaces from 'azure-devops-node-api/interfaces/common/VsoBaseInterfaces';
 
 @injectable()
 export class AdoPullRequestCommentCreator extends ProgressReporter {
@@ -22,35 +23,54 @@ export class AdoPullRequestCommentCreator extends ProgressReporter {
         @inject(ReportMarkdownConvertor) private readonly reportMarkdownConvertor: ReportMarkdownConvertor,
         @inject(Logger) private readonly logger: Logger,
         @inject(AdoIocTypes.AdoTask) private readonly adoTask: typeof AdoTask,
-        @inject(AdoIocTypes.NodeApi) nodeApi: typeof NodeApi,
+        @inject(AdoIocTypes.NodeApi) private readonly nodeApi: typeof NodeApi,
     ) {
         super();
         if (!this.isSupported()) {
             return;
         }
 
-        let token: string;
+        const authHandler = this.getAuthHandler();
+        const url = this.getVariableOrThrow('System.TeamFoundationCollectionUri');
+        this.connection = new nodeApi.WebApi(url, authHandler);
+    }
 
-        const serviceConnectionName = adoTaskConfig.getRepoServiceConnectionName();
+    private getAuthHandler(): VsoBaseInterfaces.IRequestHandler {
+        const serviceConnectionName = this.adoTaskConfig.getRepoServiceConnectionName();
+
         if (serviceConnectionName !== undefined && serviceConnectionName?.length > 0) {
-            // Will throw if no creds found
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const userProvidedServiceConnection = adoTask.getEndpointAuthorization(serviceConnectionName, false)!;
-
-            // We should check the different schemes supported and access the appropriate params. Here we assume it's Token-based
-            // https://docs.microsoft.com/en-us/azure/devops/extend/develop/auth-schemes?view=azure-devops
-            token = userProvidedServiceConnection.parameters['apitoken'];
-            console.log('Using token provided by service connection passed in by user');
+            return this.getAuthHandlerForServiceConnection(serviceConnectionName);
         } else {
             // falling back to build agent default creds. Will throw if no creds found
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            token = adoTask.getEndpointAuthorizationParameter('SystemVssConnection', 'AccessToken', false)!;
+            const token = this.adoTask.getEndpointAuthorizationParameter('SystemVssConnection', 'AccessToken', false)!;
             console.log('Could not find a service connection passed in by the user. Trying to use default build agent creds');
+            return this.nodeApi.getPersonalAccessTokenHandler(token);
         }
+    }
 
-        const authHandler = nodeApi.getPersonalAccessTokenHandler(token);
-        const url = this.getVariableOrThrow('System.TeamFoundationCollectionUri');
-        this.connection = new nodeApi.WebApi(url, authHandler);
+    private getAuthHandlerForServiceConnection(serviceConnectionName: string): VsoBaseInterfaces.IRequestHandler {
+        // Will throw if no creds found
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const endpointAuth = this.adoTask.getEndpointAuthorization(serviceConnectionName, false)!;
+        let token: string, username: string, password: string;
+        const authScheme = this.adoTask.getEndpointAuthorizationScheme(serviceConnectionName, true);
+
+        switch (authScheme) {
+            case 'token':
+                token = endpointAuth.parameters['apitoken'];
+                console.log('Using token provided by service connection passed in by user');
+                return this.nodeApi.getPersonalAccessTokenHandler(token);
+            case 'usernamepassword':
+                username = endpointAuth.parameters['username'];
+                password = endpointAuth.parameters['password'];
+                console.log('Using credentials provided by service connection passed in by user');
+                return this.nodeApi.getBasicHandler(username, password);
+            default:
+                // we only expect basic or token auth:
+                // https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#azure-repos
+                throw 'Unsupported auth scheme. Please use token or basic auth.';
+        }
     }
 
     private getVariableOrThrow(variableName: string): string {

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
@@ -53,19 +53,20 @@ export class AdoPullRequestCommentCreator extends ProgressReporter {
         // Will throw if no creds found
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const endpointAuth = this.adoTask.getEndpointAuthorization(serviceConnectionName, false)!;
-        let token: string, username: string, password: string;
         const authScheme = this.adoTask.getEndpointAuthorizationScheme(serviceConnectionName, true);
 
         switch (authScheme) {
-            case 'token':
-                token = endpointAuth.parameters['apitoken'];
+            case 'token': {
+                const token = endpointAuth.parameters['apitoken'];
                 console.log('Using token provided by service connection passed in by user');
                 return this.nodeApi.getPersonalAccessTokenHandler(token);
-            case 'usernamepassword':
-                username = endpointAuth.parameters['username'];
-                password = endpointAuth.parameters['password'];
+            }
+            case 'usernamepassword': {
+                const username = endpointAuth.parameters['username'];
+                const password = endpointAuth.parameters['password'];
                 console.log('Using credentials provided by service connection passed in by user');
                 return this.nodeApi.getBasicHandler(username, password);
+            }
             default:
                 // we only expect basic or token auth:
                 // https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#azure-repos


### PR DESCRIPTION
#### Details
This PR adds support for service connections using basic auth to `AdoPullRequestCommentCreator`. Based on [this documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#azure-repos), I don't believe that we need to support certificate based auth.

##### Motivation
Follows up on #828 to support necessary auth schemes

##### Context
Modelled after the [service connection handler in the ado pipelines tasks sample repo](https://github.com/microsoft/azure-pipelines-tasks/blob/master/common-npm-packages/artifacts-common/serviceConnectionUtils.ts).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
