### PR TITLE
feat(mvp-ado-extension-behavior): Show previous comment

### DIFF
--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
@@ -210,32 +210,32 @@ describe(ADOTaskConfig, () => {
             verifyAllMocks();
         });
 
-    it('should comment on an existing thread if one exists, previous runs', async () => {
-        const threadsStub: GitInterfaces.GitPullRequestCommentThread[] = [
-            makeThreadWithId([commentWithIdWithMatch, prevCommentWithIdWithMatch]),
-        ];
+        it('should comment on an existing thread if one exists, previous runs', async () => {
+            const threadsStub: GitInterfaces.GitPullRequestCommentThread[] = [
+                makeThreadWithId([commentWithIdWithMatch, prevCommentWithIdWithMatch]),
+            ];
 
-        const newPrevComment = {
-            parentCommentId: prevCommentWithIdWithMatch.parentCommentId,
-            content: commentWithIdWithMatch.content?.replace('Results from Current Run', 'Results from Previous Run'),
-            commentType: GitInterfaces.CommentType.Text,
-        };
+            const newPrevComment = {
+                parentCommentId: prevCommentWithIdWithMatch.parentCommentId,
+                content: commentWithIdWithMatch.content?.replace('Results from Current Run', 'Results from Previous Run'),
+                commentType: GitInterfaces.CommentType.Text,
+            };
 
-        setupReturnPrThread(repoId, prId, reportStub, reportMd, threadsStub);
-        loggerMock.setup((o) => o.logInfo('Already found a thread from us, found previous runs')).verifiable(Times.once());
+            setupReturnPrThread(repoId, prId, reportStub, reportMd, threadsStub);
+            loggerMock.setup((o) => o.logInfo('Already found a thread from us, found previous runs')).verifiable(Times.once());
 
-        gitApiMock.setup((o) => o.updateComment(newPrevComment, repoId, prId, threadId, commentId + 1)).verifiable(Times.once());
-        gitApiMock.setup((o) => o.updateComment(expectedComment, repoId, prId, threadId, commentId)).verifiable(Times.once());
-        setupIsSupportedReturnsTrue();
-        setupInitializeWithoutServiceConnectionName();
+            gitApiMock.setup((o) => o.updateComment(newPrevComment, repoId, prId, threadId, commentId + 1)).verifiable(Times.once());
+            gitApiMock.setup((o) => o.updateComment(expectedComment, repoId, prId, threadId, commentId)).verifiable(Times.once());
+            setupIsSupportedReturnsTrue();
+            setupInitializeWithoutServiceConnectionName();
             setupInitializeSetConnection(webApiMock.object);
-        prCommentCreator = buildPrCommentCreatorWithMocks();
+            prCommentCreator = buildPrCommentCreatorWithMocks();
 
-        await prCommentCreator.completeRun(reportStub);
+            await prCommentCreator.completeRun(reportStub);
 
-        verifyAllMocks();
+            verifyAllMocks();
+        });
     });
-});
 
     describe('failRun', () => {
         it('do nothing if isSupported returns false', async () => {

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
@@ -144,7 +144,6 @@ describe(ADOTaskConfig, () => {
             commentType: GitInterfaces.CommentType.Text,
             id: commentId,
         };
-
         const prevCommentWithIdWithMatch = {
             parentCommentId: commentId,
             content: contentWithMatchingString.replace('Results from Current Run', 'Results from Previous Run'),
@@ -211,32 +210,32 @@ describe(ADOTaskConfig, () => {
             verifyAllMocks();
         });
 
-        it('should comment on an existing thread if one exists, previous runs', async () => {
-            const threadsStub: GitInterfaces.GitPullRequestCommentThread[] = [
-                makeThreadWithId([commentWithIdWithMatch, prevCommentWithIdWithMatch]),
-            ];
+    it('should comment on an existing thread if one exists, previous runs', async () => {
+        const threadsStub: GitInterfaces.GitPullRequestCommentThread[] = [
+            makeThreadWithId([commentWithIdWithMatch, prevCommentWithIdWithMatch]),
+        ];
 
-            const newPrevComment = {
-                parentCommentId: prevCommentWithIdWithMatch.parentCommentId,
-                content: commentWithIdWithMatch.content?.replace('Results from Current Run', 'Results from Previous Run'),
-                commentType: GitInterfaces.CommentType.Text,
-            };
+        const newPrevComment = {
+            parentCommentId: prevCommentWithIdWithMatch.parentCommentId,
+            content: commentWithIdWithMatch.content?.replace('Results from Current Run', 'Results from Previous Run'),
+            commentType: GitInterfaces.CommentType.Text,
+        };
 
-            setupReturnPrThread(repoId, prId, reportStub, reportMd, threadsStub);
-            loggerMock.setup((o) => o.logInfo('Already found a thread from us, found previous runs')).verifiable(Times.once());
+        setupReturnPrThread(repoId, prId, reportStub, reportMd, threadsStub);
+        loggerMock.setup((o) => o.logInfo('Already found a thread from us, found previous runs')).verifiable(Times.once());
 
-            gitApiMock.setup((o) => o.updateComment(newPrevComment, repoId, prId, threadId, commentId + 1)).verifiable(Times.once());
-            gitApiMock.setup((o) => o.updateComment(expectedComment, repoId, prId, threadId, commentId)).verifiable(Times.once());
-            setupIsSupportedReturnsTrue();
-            setupInitializeWithoutServiceConnectionName(apitoken);
-            setupInitializeSetConnection(apitoken, webApiMock.object);
-            prCommentCreator = buildPrCommentCreatorWithMocks();
+        gitApiMock.setup((o) => o.updateComment(newPrevComment, repoId, prId, threadId, commentId + 1)).verifiable(Times.once());
+        gitApiMock.setup((o) => o.updateComment(expectedComment, repoId, prId, threadId, commentId)).verifiable(Times.once());
+        setupIsSupportedReturnsTrue();
+        setupInitializeWithoutServiceConnectionName();
+            setupInitializeSetConnection(webApiMock.object);
+        prCommentCreator = buildPrCommentCreatorWithMocks();
 
-            await prCommentCreator.completeRun(reportStub);
+        await prCommentCreator.completeRun(reportStub);
 
-            verifyAllMocks();
-        });
+        verifyAllMocks();
     });
+});
 
     describe('failRun', () => {
         it('do nothing if isSupported returns false', async () => {

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
@@ -97,10 +97,10 @@ describe(ADOTaskConfig, () => {
         const threadId = 9; // arbitrary number
         const commentId = 7; // arbitrary number
         const contentWithMatchingString =
-            '![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action: A comment from Accessibility Insights';
+            '### Results from Current Run\n![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action: A comment from Accessibility Insights';
         const expectedComment = {
             parentCommentId: 0,
-            content: reportMd,
+            content: '### Results from Current Run\n' + reportMd,
             commentType: GitInterfaces.CommentType.Text,
         };
 
@@ -121,23 +121,30 @@ describe(ADOTaskConfig, () => {
             commentType: GitInterfaces.CommentType.Text,
             id: commentId,
         };
-        const makeThreadWithoutId = (comment: GitInterfaces.Comment) => {
+
+        const prevCommentWithIdWithMatch = {
+            parentCommentId: commentId,
+            content: contentWithMatchingString.replace('Results from Current Run', 'Results from Previous Run'),
+            commentType: GitInterfaces.CommentType.Text,
+            id: commentId + 1,
+        };
+        const makeThreadWithoutId = (comments: GitInterfaces.Comment[]) => {
             return {
-                comments: [comment],
+                comments: comments,
             };
         };
-        const makeThreadWithId = (comment: GitInterfaces.Comment) => {
+        const makeThreadWithId = (comments: GitInterfaces.Comment[]) => {
             return {
-                comments: [comment],
+                comments: comments,
                 id: threadId,
             };
         };
 
         it.each`
-            thread                                            | condition
-            ${makeThreadWithId(commentWithIdWithoutMatch)}    | ${`no matching comment found`}
-            ${makeThreadWithoutId(commentWithoutIdWithMatch)} | ${`matching comment missing id`}
-            ${makeThreadWithoutId(commentWithIdWithMatch)}    | ${`matching thread missing id`}
+            thread                                              | condition
+            ${makeThreadWithId([commentWithIdWithoutMatch])}    | ${`no matching comment found`}
+            ${makeThreadWithoutId([commentWithoutIdWithMatch])} | ${`matching comment missing id`}
+            ${makeThreadWithoutId([commentWithIdWithMatch])}    | ${`matching thread missing id`}
         `(`should create new thread if $condition`, async ({ thread }) => {
             const threadsStub: GitInterfaces.GitPullRequestCommentThread[] = [thread as GitInterfaces.GitPullRequestCommentThread];
             const newThread = {
@@ -158,19 +165,45 @@ describe(ADOTaskConfig, () => {
             verifyAllMocks();
         });
 
-        it('should comment on an existing thread if one exists', async () => {
-            const threadsStub: GitInterfaces.GitPullRequestCommentThread[] = [makeThreadWithId(commentWithIdWithMatch)];
+        it('should comment on an existing thread if one exists, no previous runs', async () => {
+            const threadsStub: GitInterfaces.GitPullRequestCommentThread[] = [makeThreadWithId([commentWithIdWithMatch])];
             const newComment = {
                 parentCommentId: 0,
-                content: 'Ran again, results comment updated',
+                content: commentWithIdWithMatch.content?.replace('Results from Current Run', 'Results from Previous Run'),
                 commentType: GitInterfaces.CommentType.Text,
             };
 
             setupReturnPrThread(repoId, prId, reportStub, reportMd, threadsStub);
-            loggerMock.setup((o) => o.logInfo('Already found a thread from us')).verifiable(Times.once());
+            loggerMock.setup((o) => o.logInfo('Already found a thread from us, no previous runs')).verifiable(Times.once());
 
             gitApiMock.setup((o) => o.updateComment(expectedComment, repoId, prId, threadId, commentId)).verifiable(Times.once());
             gitApiMock.setup((o) => o.createComment(newComment, repoId, prId, threadId)).verifiable(Times.once());
+            setupIsSupportedReturnsTrue();
+            setupInitializeWithoutServiceConnectionName(apitoken);
+            setupInitializeSetConnection(apitoken, webApiMock.object);
+            prCommentCreator = buildPrCommentCreatorWithMocks();
+
+            await prCommentCreator.completeRun(reportStub);
+
+            verifyAllMocks();
+        });
+
+        it('should comment on an existing thread if one exists, previous runs', async () => {
+            const threadsStub: GitInterfaces.GitPullRequestCommentThread[] = [
+                makeThreadWithId([commentWithIdWithMatch, prevCommentWithIdWithMatch]),
+            ];
+
+            const newPrevComment = {
+                parentCommentId: prevCommentWithIdWithMatch.parentCommentId,
+                content: commentWithIdWithMatch.content?.replace('Results from Current Run', 'Results from Previous Run'),
+                commentType: GitInterfaces.CommentType.Text,
+            };
+
+            setupReturnPrThread(repoId, prId, reportStub, reportMd, threadsStub);
+            loggerMock.setup((o) => o.logInfo('Already found a thread from us, found previous runs')).verifiable(Times.once());
+
+            gitApiMock.setup((o) => o.updateComment(newPrevComment, repoId, prId, threadId, commentId + 1)).verifiable(Times.once());
+            gitApiMock.setup((o) => o.updateComment(expectedComment, repoId, prId, threadId, commentId)).verifiable(Times.once());
             setupIsSupportedReturnsTrue();
             setupInitializeWithoutServiceConnectionName(apitoken);
             setupInitializeSetConnection(apitoken, webApiMock.object);

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
@@ -80,36 +80,51 @@ export class AdoPullRequestCommentCreator extends ProgressReporter {
         const gitApiObject: GitApi.IGitApi = await this.connection.getGitApi();
         const prThreads = await gitApiObject.getThreads(repoId, prId);
         const existingThread = prThreads.find((p) => p.comments?.some((c) => c.content?.includes(productTitle())));
-        const existingComment = existingThread?.comments?.find((c) => c.content?.includes(productTitle()));
-        const newComment = {
+        const existingCurrentComment = existingThread?.comments?.find(
+            (c) => c.content?.includes(productTitle()) && c.content?.includes('Results from Current Run'),
+        );
+        const existingPreviousComment = existingThread?.comments?.find(
+            (c) => c.content?.includes(productTitle()) && c.content?.includes('Results from Previous Run'),
+        );
+        const newCurrentComment = {
             parentCommentId: 0,
-            content: reportMarkdown,
+            content: '### Results from Current Run\n' + reportMarkdown,
             commentType: GitInterfaces.CommentType.Text,
         };
 
-        if (existingThread === undefined || existingThread.id === undefined || existingComment?.id === undefined) {
+        if (existingThread === undefined || existingThread.id === undefined || existingCurrentComment?.id === undefined) {
             this.logMessage(`Didn't find an existing thread, making a new thread`);
             await gitApiObject.createThread(
                 {
-                    comments: [newComment],
+                    comments: [newCurrentComment],
                     status: GitInterfaces.CommentThreadStatus.Active,
                 },
                 repoId,
                 prId,
             );
-        } else {
-            this.logMessage(`Already found a thread from us`);
-            await gitApiObject.updateComment(newComment, repoId, prId, existingThread.id, existingComment.id);
+        } else if (existingPreviousComment?.id === undefined) {
+            this.logMessage(`Already found a thread from us, no previous runs`);
+            await gitApiObject.updateComment(newCurrentComment, repoId, prId, existingThread.id, existingCurrentComment.id);
             await gitApiObject.createComment(
                 {
                     parentCommentId: 0,
-                    content: 'Ran again, results comment updated',
+                    content: existingCurrentComment.content?.replace('Results from Current Run', 'Results from Previous Run'),
                     commentType: GitInterfaces.CommentType.Text,
                 },
                 repoId,
                 prId,
                 existingThread.id,
             );
+        } else {
+            this.logMessage(`Already found a thread from us, found previous runs`);
+            const newPreviousComment = {
+                parentCommentId: existingPreviousComment.parentCommentId,
+                content: existingCurrentComment.content?.replace('Results from Current Run', 'Results from Previous Run'),
+                commentType: existingPreviousComment.commentType,
+            };
+
+            await gitApiObject.updateComment(newPreviousComment, repoId, prId, existingThread.id, existingPreviousComment.id);
+            await gitApiObject.updateComment(newCurrentComment, repoId, prId, existingThread.id, existingCurrentComment.id);
         }
     }
 


### PR DESCRIPTION
#### Details

This PR updates how we show the comment in the ADO PR.
The extesnsion will:
- Create a new comment thread if none exists.
- Add a new comment for the latest run and keep the previous run details in a below comment.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
