### PR TITLE
feat(mvp-ado-extension-behavior): Fix auth switch by using toLowerCase

### DIFF
--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
@@ -332,7 +332,7 @@ describe(ADOTaskConfig, () => {
             .verifiable(Times.once());
         adoTaskMock
             .setup((o) => o.getEndpointAuthorizationScheme(serviceConnection, true))
-            .returns(() => 'token')
+            .returns(() => 'Token')
             .verifiable(Times.once());
         nodeApiMock
             .setup((o) => o.getPersonalAccessTokenHandler(apitoken))
@@ -342,7 +342,9 @@ describe(ADOTaskConfig, () => {
 
     const setupInitializeWithBasicServiceConnection = () => {
         const serviceConnection = 'service-connection',
+            //[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Fake creds")]
             username = 'user',
+            //[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Fake creds")]
             password = 'secret';
         const endpointAuthorizationStub: adoTask.EndpointAuthorization = {
             parameters: {
@@ -362,7 +364,7 @@ describe(ADOTaskConfig, () => {
             .verifiable(Times.once());
         adoTaskMock
             .setup((o) => o.getEndpointAuthorizationScheme(serviceConnection, true))
-            .returns(() => 'usernamepassword')
+            .returns(() => 'UsernamePassword')
             .verifiable(Times.once());
 
         nodeApiMock
@@ -388,7 +390,7 @@ describe(ADOTaskConfig, () => {
             .verifiable(Times.once());
         adoTaskMock
             .setup((o) => o.getEndpointAuthorizationScheme(serviceConnection, true))
-            .returns(() => 'other')
+            .returns(() => undefined)
             .verifiable(Times.once());
     };
 

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
@@ -53,7 +53,7 @@ export class AdoPullRequestCommentCreator extends ProgressReporter {
         // Will throw if no creds found
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const endpointAuth = this.adoTask.getEndpointAuthorization(serviceConnectionName, false)!;
-        const authScheme = this.adoTask.getEndpointAuthorizationScheme(serviceConnectionName, true);
+        const authScheme = this.adoTask.getEndpointAuthorizationScheme(serviceConnectionName, true)?.toLowerCase();
 
         switch (authScheme) {
             case 'token': {


### PR DESCRIPTION
#### Details
The change in #846 should have called `toLowerCase` on the auth scheme but did not. This PR fixes that. While in the area, it also adds suppression for some CredScan false positives.

##### Motivation
Fixes authentication support

##### Context
- The [service connection handler in the ado pipelines tasks sample repo](https://github.com/microsoft/azure-pipelines-tasks/blob/master/common-npm-packages/artifacts-common/serviceConnectionUtils.ts) this was modelled on calls `toLowerCase`.
- [Test use of extension here](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=26640&view=results)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
