### PR TITLE
feat(baseline-implementation): Add Baseline input parameters

### DIFF
--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -51,8 +51,10 @@ describe(ADOTaskConfig, () => {
         ${'localhostPort'}             | ${'8080'}           | ${8080}                                                 | ${() => taskConfig.getLocalhostPort()}
         ${'localhostPort'}             | ${undefined}        | ${undefined}                                            | ${() => taskConfig.getLocalhostPort()}
         ${'repoServiceConnectionName'} | ${'testName'}       | ${'testName'}                                           | ${() => taskConfig.getRepoServiceConnectionName()}
-        ${'baseLine'}                  | ${true}             | ${true}                                                 | ${() => taskConfig.getBaseLine()}
-        ${'baseLineFile'}              | ${'./baseLineFile'} | ${getPlatformAgnosticPath(__dirname + '/baseLineFile')} | ${() => taskConfig.getBaseLineFile()}
+        ${'baseline'}                  | ${true}             | ${true}                                                 | ${() => taskConfig.getBaseline()}
+        ${'baselineFile'}              | ${'./baselineFile'} | ${getPlatformAgnosticPath(__dirname + '/baselineFile')} | ${() => taskConfig.getBaselineFile()}
+        ${'baselineName'}              | ${'baselineName'}   | ${'baselineName'}                                       | ${() => taskConfig.getBaselineName()}
+        ${'baselineName'}              | ${undefined}        | ${'newBaseline'}                                        | ${() => taskConfig.getBaselineName()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {

--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -51,24 +51,15 @@ describe(ADOTaskConfig, () => {
         ${'localhostPort'}             | ${'8080'}           | ${8080}                                                 | ${() => taskConfig.getLocalhostPort()}
         ${'localhostPort'}             | ${undefined}        | ${undefined}                                            | ${() => taskConfig.getLocalhostPort()}
         ${'repoServiceConnectionName'} | ${'testName'}       | ${'testName'}                                           | ${() => taskConfig.getRepoServiceConnectionName()}
-        ${'baseline'}                  | ${true}             | ${true}                                                 | ${() => taskConfig.getBaseline()}
         ${'baselineFile'}              | ${'./baselineFile'} | ${getPlatformAgnosticPath(__dirname + '/baselineFile')} | ${() => taskConfig.getBaselineFile()}
-        ${'baselineName'}              | ${'baselineName'}   | ${'baselineName'}                                       | ${() => taskConfig.getBaselineName()}
-        ${'baselineName'}              | ${undefined}        | ${'newBaseline'}                                        | ${() => taskConfig.getBaselineName()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
-            if (typeof inputValue === 'boolean') {
-                adoTaskMock
-                    .setup((am) => am.getBoolInput(inputOption))
-                    .returns(() => inputValue)
-                    .verifiable(Times.once());
-            } else {
-                adoTaskMock
-                    .setup((am) => am.getInput(inputOption))
-                    .returns(() => inputValue as string)
-                    .verifiable(Times.once());
-            }
+            adoTaskMock
+                .setup((am) => am.getInput(inputOption))
+                .returns(() => inputValue as string)
+                .verifiable(Times.once());
+
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             const retrievedOption: unknown = getInputFunc();
             expect(retrievedOption).toStrictEqual(expectedValue);

--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -30,34 +30,43 @@ describe(ADOTaskConfig, () => {
     }
 
     it.each`
-        inputOption                    | inputValue        | expectedValue                                         | getInputFunc
-        ${'repoToken'}                 | ${'token'}        | ${'token'}                                            | ${() => taskConfig.getToken()}
-        ${'repoToken'}                 | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getToken()}
-        ${'scanUrlRelativePath'}       | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getScanUrlRelativePath()}
-        ${'chromePath'}                | ${'./chromePath'} | ${getPlatformAgnosticPath(__dirname + '/chromePath')} | ${() => taskConfig.getChromePath()}
-        ${'chromePath'}                | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getChromePath()}
-        ${'inputFile'}                 | ${'./inputFile'}  | ${getPlatformAgnosticPath(__dirname + '/inputFile')}  | ${() => taskConfig.getInputFile()}
-        ${'inputFile'}                 | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getInputFile()}
-        ${'outputDir'}                 | ${'./outputDir'}  | ${getPlatformAgnosticPath(__dirname + '/outputDir')}  | ${() => taskConfig.getReportOutDir()}
-        ${'siteDir'}                   | ${'path'}         | ${'path'}                                             | ${() => taskConfig.getSiteDir()}
-        ${'url'}                       | ${'url'}          | ${'url'}                                              | ${() => taskConfig.getUrl()}
-        ${'url'}                       | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getUrl()}
-        ${'discoveryPatterns'}         | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getDiscoveryPatterns()}
-        ${'discoveryPatterns'}         | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getDiscoveryPatterns()}
-        ${'inputUrls'}                 | ${'abc'}          | ${'abc'}                                              | ${() => taskConfig.getInputUrls()}
-        ${'inputUrls'}                 | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getInputUrls()}
-        ${'maxUrls'}                   | ${'20'}           | ${20}                                                 | ${() => taskConfig.getMaxUrls()}
-        ${'scanTimeout'}               | ${'100000'}       | ${100000}                                             | ${() => taskConfig.getScanTimeout()}
-        ${'localhostPort'}             | ${'8080'}         | ${8080}                                               | ${() => taskConfig.getLocalhostPort()}
-        ${'localhostPort'}             | ${undefined}      | ${undefined}                                          | ${() => taskConfig.getLocalhostPort()}
-        ${'repoServiceConnectionName'} | ${'testName'}     | ${'testName'}                                         | ${() => taskConfig.getRepoServiceConnectionName()}
+        inputOption                    | inputValue          | expectedValue                                           | getInputFunc
+        ${'repoToken'}                 | ${'token'}          | ${'token'}                                              | ${() => taskConfig.getToken()}
+        ${'repoToken'}                 | ${undefined}        | ${undefined}                                            | ${() => taskConfig.getToken()}
+        ${'scanUrlRelativePath'}       | ${'path'}           | ${'path'}                                               | ${() => taskConfig.getScanUrlRelativePath()}
+        ${'chromePath'}                | ${'./chromePath'}   | ${getPlatformAgnosticPath(__dirname + '/chromePath')}   | ${() => taskConfig.getChromePath()}
+        ${'chromePath'}                | ${undefined}        | ${undefined}                                            | ${() => taskConfig.getChromePath()}
+        ${'inputFile'}                 | ${'./inputFile'}    | ${getPlatformAgnosticPath(__dirname + '/inputFile')}    | ${() => taskConfig.getInputFile()}
+        ${'inputFile'}                 | ${undefined}        | ${undefined}                                            | ${() => taskConfig.getInputFile()}
+        ${'outputDir'}                 | ${'./outputDir'}    | ${getPlatformAgnosticPath(__dirname + '/outputDir')}    | ${() => taskConfig.getReportOutDir()}
+        ${'siteDir'}                   | ${'path'}           | ${'path'}                                               | ${() => taskConfig.getSiteDir()}
+        ${'url'}                       | ${'url'}            | ${'url'}                                                | ${() => taskConfig.getUrl()}
+        ${'url'}                       | ${undefined}        | ${undefined}                                            | ${() => taskConfig.getUrl()}
+        ${'discoveryPatterns'}         | ${'abc'}            | ${'abc'}                                                | ${() => taskConfig.getDiscoveryPatterns()}
+        ${'discoveryPatterns'}         | ${undefined}        | ${undefined}                                            | ${() => taskConfig.getDiscoveryPatterns()}
+        ${'inputUrls'}                 | ${'abc'}            | ${'abc'}                                                | ${() => taskConfig.getInputUrls()}
+        ${'inputUrls'}                 | ${undefined}        | ${undefined}                                            | ${() => taskConfig.getInputUrls()}
+        ${'maxUrls'}                   | ${'20'}             | ${20}                                                   | ${() => taskConfig.getMaxUrls()}
+        ${'scanTimeout'}               | ${'100000'}         | ${100000}                                               | ${() => taskConfig.getScanTimeout()}
+        ${'localhostPort'}             | ${'8080'}           | ${8080}                                                 | ${() => taskConfig.getLocalhostPort()}
+        ${'localhostPort'}             | ${undefined}        | ${undefined}                                            | ${() => taskConfig.getLocalhostPort()}
+        ${'repoServiceConnectionName'} | ${'testName'}       | ${'testName'}                                           | ${() => taskConfig.getRepoServiceConnectionName()}
+        ${'baseLine'}                  | ${true}             | ${true}                                                 | ${() => taskConfig.getBaseLine()}
+        ${'baseLineFile'}              | ${'./baseLineFile'} | ${getPlatformAgnosticPath(__dirname + '/baseLineFile')} | ${() => taskConfig.getBaseLineFile()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
-            adoTaskMock
-                .setup((am) => am.getInput(inputOption))
-                .returns(() => inputValue as string)
-                .verifiable(Times.once());
+            if (typeof inputValue === 'boolean') {
+                adoTaskMock
+                    .setup((am) => am.getBoolInput(inputOption))
+                    .returns(() => inputValue)
+                    .verifiable(Times.once());
+            } else {
+                adoTaskMock
+                    .setup((am) => am.getInput(inputOption))
+                    .returns(() => inputValue as string)
+                    .verifiable(Times.once());
+            }
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             const retrievedOption: unknown = getInputFunc();
             expect(retrievedOption).toStrictEqual(expectedValue);

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -103,20 +103,10 @@ export class ADOTaskConfig extends TaskConfig {
         return this.adoTaskObj.getBoolInput('failOnAccessibilityError');
     }
 
-    public getBaseline(): boolean {
-        return this.adoTaskObj.getBoolInput('baseline');
-    }
-
     public getBaselineFile(): string | undefined {
         const value = this.getAbsolutePath(this.adoTaskObj.getInput('baselineFile'));
 
         return isEmpty(value) ? undefined : value;
-    }
-
-    public getBaselineName(): string | undefined {
-        const value = this.adoTaskObj.getInput('baselineName');
-
-        return isEmpty(value) ? 'newBaseline' : value;
     }
 
     private getAbsolutePath(path: string | undefined): string | undefined {

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -103,6 +103,16 @@ export class ADOTaskConfig extends TaskConfig {
         return this.adoTaskObj.getBoolInput('failOnAccessibilityError');
     }
 
+    public getBaseLine(): boolean {
+        return this.adoTaskObj.getBoolInput('baseLine');
+    }
+
+    public getBaseLineFile(): string | undefined {
+        const value = this.getAbsolutePath(this.adoTaskObj.getInput('baseLineFile'));
+
+        return isEmpty(value) ? undefined : value;
+    }
+
     private getAbsolutePath(path: string | undefined): string | undefined {
         if (isEmpty(path)) {
             return undefined;

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -103,14 +103,20 @@ export class ADOTaskConfig extends TaskConfig {
         return this.adoTaskObj.getBoolInput('failOnAccessibilityError');
     }
 
-    public getBaseLine(): boolean {
-        return this.adoTaskObj.getBoolInput('baseLine');
+    public getBaseline(): boolean {
+        return this.adoTaskObj.getBoolInput('baseline');
     }
 
-    public getBaseLineFile(): string | undefined {
-        const value = this.getAbsolutePath(this.adoTaskObj.getInput('baseLineFile'));
+    public getBaselineFile(): string | undefined {
+        const value = this.getAbsolutePath(this.adoTaskObj.getInput('baselineFile'));
 
         return isEmpty(value) ? undefined : value;
+    }
+
+    public getBaselineName(): string | undefined {
+        const value = this.adoTaskObj.getInput('baselineName');
+
+        return isEmpty(value) ? 'newBaseline' : value;
     }
 
     private getAbsolutePath(path: string | undefined): string | undefined {

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -112,26 +112,11 @@
             "helpMarkDown": "Fail the task if there are accessibility issues."
         },
         {
-            "name": "baseline",
-            "type": "boolean",
-            "label": "Generate Baseline?",
-            "defaultValue": true,
-            "required": true,
-            "helpMarkDown": "Generate Baseline if true."
-        },
-        {
             "name": "baselineFile",
             "type": "string",
-            "label": "Old Baseline File Path",
+            "label": "Baseline File Path",
             "required": false,
-            "helpMarkDown": "Path to existing baseline file, will generate delta between the generated one and the old one if exists."
-        },
-        {
-            "name": "baselineName",
-            "type": "string",
-            "label": "New Baseline File Name",
-            "required": false,
-            "helpMarkDown": "The file name of the new generated baseline, newBaseline will be used if not provided and baseline is set to true."
+            "helpMarkDown": "The old baseline file path, a new baseline will be generated with the same name, if null baseline option will be disabled."
         }
     ],
     "execution": {

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -110,6 +110,21 @@
             "defaultValue": false,
             "required": false,
             "helpMarkDown": "Fail the task if there are accessibility issues."
+        },
+        {
+            "name": "baseLine",
+            "type": "boolean",
+            "label": "Generate Baseline?",
+            "defaultValue": true,
+            "required": true,
+            "helpMarkDown": "Generate Baseline if true."
+        },
+        {
+            "name": "baseLineFile",
+            "type": "string",
+            "label": "Generate Baseline?",
+            "required": false,
+            "helpMarkDown": "Path to existing baseline file, will generate delta between the generated one and the old one if exists."
         }
     ],
     "execution": {

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -112,7 +112,7 @@
             "helpMarkDown": "Fail the task if there are accessibility issues."
         },
         {
-            "name": "baseLine",
+            "name": "baseline",
             "type": "boolean",
             "label": "Generate Baseline?",
             "defaultValue": true,
@@ -120,11 +120,18 @@
             "helpMarkDown": "Generate Baseline if true."
         },
         {
-            "name": "baseLineFile",
+            "name": "baselineFile",
             "type": "string",
-            "label": "Generate Baseline?",
+            "label": "Old Baseline File Path",
             "required": false,
             "helpMarkDown": "Path to existing baseline file, will generate delta between the generated one and the old one if exists."
+        },
+        {
+            "name": "baselineName",
+            "type": "string",
+            "label": "New Baseline File Name",
+            "required": false,
+            "helpMarkDown": "The file name of the new generated baseline, newBaseline will be used if not provided and baseline is set to true."
         }
     ],
     "execution": {

--- a/packages/gh-action/action.yml
+++ b/packages/gh-action/action.yml
@@ -51,8 +51,7 @@ inputs:
         default: true
     base-line-file:
         description: 'Path to existing baseline file, will generate delta between the generated one and the old one if exists.'
-        required: true
-        default: true
+        required: false
 runs:
     using: 'composite'
     steps:

--- a/packages/gh-action/action.yml
+++ b/packages/gh-action/action.yml
@@ -45,6 +45,14 @@ inputs:
         description: 'The maximum timeout in milliseconds for the scan (excluding dependency setup)'
         required: false
         default: 90000
+    base-line:
+        description: 'Generate Baseline if true.'
+        required: true
+        default: true
+    base-line-file:
+        description: 'Path to existing baseline file, will generate delta between the generated one and the old one if exists.'
+        required: true
+        default: true
 runs:
     using: 'composite'
     steps:

--- a/packages/gh-action/action.yml
+++ b/packages/gh-action/action.yml
@@ -45,15 +45,8 @@ inputs:
         description: 'The maximum timeout in milliseconds for the scan (excluding dependency setup)'
         required: false
         default: 90000
-    baseline:
-        description: 'Generate a baseline if true.'
-        required: true
-        default: true
     baseline-file:
-        description: 'Path to existing baseline file, will generate delta between the generated one and the old one if exists.'
-        required: false
-    baseline-name:
-        description: 'The file name of the new generated baseline, newBaseline will be used if not provided and baseline is set to true.'
+        description: 'The old baseline file path, a new baseline will be generated with the same name, if null baseline option will be disabled.'
         required: false
 runs:
     using: 'composite'

--- a/packages/gh-action/action.yml
+++ b/packages/gh-action/action.yml
@@ -45,12 +45,15 @@ inputs:
         description: 'The maximum timeout in milliseconds for the scan (excluding dependency setup)'
         required: false
         default: 90000
-    base-line:
-        description: 'Generate Baseline if true.'
+    baseline:
+        description: 'Generate a baseline if true.'
         required: true
         default: true
-    base-line-file:
+    baseline-file:
         description: 'Path to existing baseline file, will generate delta between the generated one and the old one if exists.'
+        required: false
+    baseline-name:
+        description: 'The file name of the new generated baseline, newBaseline will be used if not provided and baseline is set to true.'
         required: false
 runs:
     using: 'composite'

--- a/packages/gh-action/src/task-config/gh-task-config.spec.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.spec.ts
@@ -30,26 +30,35 @@ describe(GHTaskConfig, () => {
     }
 
     it.each`
-        inputOption                 | inputValue         | expectedValue                                          | getInputFunc
-        ${'repo-token'}             | ${'token'}         | ${'token'}                                             | ${() => taskConfig.getToken()}
-        ${'scan-url-relative-path'} | ${'path'}          | ${'path'}                                              | ${() => taskConfig.getScanUrlRelativePath()}
-        ${'chrome-path'}            | ${'./chrome-path'} | ${getPlatformAgnosticPath(__dirname + '/chrome-path')} | ${() => taskConfig.getChromePath()}
-        ${'input-file'}             | ${'./input-file'}  | ${getPlatformAgnosticPath(__dirname + '/input-file')}  | ${() => taskConfig.getInputFile()}
-        ${'output-dir'}             | ${'./output-dir'}  | ${getPlatformAgnosticPath(__dirname + '/output-dir')}  | ${() => taskConfig.getReportOutDir()}
-        ${'site-dir'}               | ${'path'}          | ${'path'}                                              | ${() => taskConfig.getSiteDir()}
-        ${'url'}                    | ${'url'}           | ${'url'}                                               | ${() => taskConfig.getUrl()}
-        ${'discovery-patterns'}     | ${'abc'}           | ${'abc'}                                               | ${() => taskConfig.getDiscoveryPatterns()}
-        ${'input-urls'}             | ${'abc'}           | ${'abc'}                                               | ${() => taskConfig.getInputUrls()}
-        ${'max-urls'}               | ${'20'}            | ${20}                                                  | ${() => taskConfig.getMaxUrls()}
-        ${'scan-timeout'}           | ${'100000'}        | ${100000}                                              | ${() => taskConfig.getScanTimeout()}
-        ${'localhost-port'}         | ${'8080'}          | ${8080}                                                | ${() => taskConfig.getLocalhostPort()}
+        inputOption                 | inputValue            | expectedValue                                             | getInputFunc
+        ${'repo-token'}             | ${'token'}            | ${'token'}                                                | ${() => taskConfig.getToken()}
+        ${'scan-url-relative-path'} | ${'path'}             | ${'path'}                                                 | ${() => taskConfig.getScanUrlRelativePath()}
+        ${'chrome-path'}            | ${'./chrome-path'}    | ${getPlatformAgnosticPath(__dirname + '/chrome-path')}    | ${() => taskConfig.getChromePath()}
+        ${'input-file'}             | ${'./input-file'}     | ${getPlatformAgnosticPath(__dirname + '/input-file')}     | ${() => taskConfig.getInputFile()}
+        ${'output-dir'}             | ${'./output-dir'}     | ${getPlatformAgnosticPath(__dirname + '/output-dir')}     | ${() => taskConfig.getReportOutDir()}
+        ${'site-dir'}               | ${'path'}             | ${'path'}                                                 | ${() => taskConfig.getSiteDir()}
+        ${'url'}                    | ${'url'}              | ${'url'}                                                  | ${() => taskConfig.getUrl()}
+        ${'discovery-patterns'}     | ${'abc'}              | ${'abc'}                                                  | ${() => taskConfig.getDiscoveryPatterns()}
+        ${'input-urls'}             | ${'abc'}              | ${'abc'}                                                  | ${() => taskConfig.getInputUrls()}
+        ${'max-urls'}               | ${'20'}               | ${20}                                                     | ${() => taskConfig.getMaxUrls()}
+        ${'scan-timeout'}           | ${'100000'}           | ${100000}                                                 | ${() => taskConfig.getScanTimeout()}
+        ${'localhost-port'}         | ${'8080'}             | ${8080}                                                   | ${() => taskConfig.getLocalhostPort()}
+        ${'base-line'}              | ${true}               | ${true}                                                   | ${() => taskConfig.getBaseLine()}
+        ${'base-line-file'}         | ${'./base-line-file'} | ${getPlatformAgnosticPath(__dirname + '/base-line-file')} | ${() => taskConfig.getBaseLineFile()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
-            actionCoreMock
-                .setup((am) => am.getInput(inputOption))
-                .returns(() => inputValue)
-                .verifiable(Times.once());
+            if (typeof inputValue === 'boolean') {
+                actionCoreMock
+                    .setup((am) => am.getBooleanInput(inputOption))
+                    .returns(() => inputValue)
+                    .verifiable(Times.once());
+            } else {
+                actionCoreMock
+                    .setup((am) => am.getInput(inputOption))
+                    .returns(() => inputValue)
+                    .verifiable(Times.once());
+            }
             const retrievedOption = getInputFunc();
             expect(retrievedOption).toStrictEqual(expectedValue);
         },

--- a/packages/gh-action/src/task-config/gh-task-config.spec.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.spec.ts
@@ -43,24 +43,15 @@ describe(GHTaskConfig, () => {
         ${'max-urls'}               | ${'20'}              | ${20}                                                    | ${() => taskConfig.getMaxUrls()}
         ${'scan-timeout'}           | ${'100000'}          | ${100000}                                                | ${() => taskConfig.getScanTimeout()}
         ${'localhost-port'}         | ${'8080'}            | ${8080}                                                  | ${() => taskConfig.getLocalhostPort()}
-        ${'baseline'}               | ${true}              | ${true}                                                  | ${() => taskConfig.getBaseline()}
         ${'baseline-file'}          | ${'./baseline-file'} | ${getPlatformAgnosticPath(__dirname + '/baseline-file')} | ${() => taskConfig.getBaselineFile()}
-        ${'baseline-name'}          | ${'baseline-name'}   | ${'baseline-name'}                                       | ${() => taskConfig.getBaselineName()}
-        ${'baseline-name'}          | ${undefined}         | ${'newBaseline'}                                         | ${() => taskConfig.getBaselineName()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
-            if (typeof inputValue === 'boolean') {
-                actionCoreMock
-                    .setup((am) => am.getBooleanInput(inputOption))
-                    .returns(() => inputValue)
-                    .verifiable(Times.once());
-            } else {
-                actionCoreMock
-                    .setup((am) => am.getInput(inputOption))
-                    .returns(() => inputValue)
-                    .verifiable(Times.once());
-            }
+            actionCoreMock
+                .setup((am) => am.getInput(inputOption))
+                .returns(() => inputValue)
+                .verifiable(Times.once());
+
             const retrievedOption = getInputFunc();
             expect(retrievedOption).toStrictEqual(expectedValue);
         },

--- a/packages/gh-action/src/task-config/gh-task-config.spec.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.spec.ts
@@ -30,21 +30,23 @@ describe(GHTaskConfig, () => {
     }
 
     it.each`
-        inputOption                 | inputValue            | expectedValue                                             | getInputFunc
-        ${'repo-token'}             | ${'token'}            | ${'token'}                                                | ${() => taskConfig.getToken()}
-        ${'scan-url-relative-path'} | ${'path'}             | ${'path'}                                                 | ${() => taskConfig.getScanUrlRelativePath()}
-        ${'chrome-path'}            | ${'./chrome-path'}    | ${getPlatformAgnosticPath(__dirname + '/chrome-path')}    | ${() => taskConfig.getChromePath()}
-        ${'input-file'}             | ${'./input-file'}     | ${getPlatformAgnosticPath(__dirname + '/input-file')}     | ${() => taskConfig.getInputFile()}
-        ${'output-dir'}             | ${'./output-dir'}     | ${getPlatformAgnosticPath(__dirname + '/output-dir')}     | ${() => taskConfig.getReportOutDir()}
-        ${'site-dir'}               | ${'path'}             | ${'path'}                                                 | ${() => taskConfig.getSiteDir()}
-        ${'url'}                    | ${'url'}              | ${'url'}                                                  | ${() => taskConfig.getUrl()}
-        ${'discovery-patterns'}     | ${'abc'}              | ${'abc'}                                                  | ${() => taskConfig.getDiscoveryPatterns()}
-        ${'input-urls'}             | ${'abc'}              | ${'abc'}                                                  | ${() => taskConfig.getInputUrls()}
-        ${'max-urls'}               | ${'20'}               | ${20}                                                     | ${() => taskConfig.getMaxUrls()}
-        ${'scan-timeout'}           | ${'100000'}           | ${100000}                                                 | ${() => taskConfig.getScanTimeout()}
-        ${'localhost-port'}         | ${'8080'}             | ${8080}                                                   | ${() => taskConfig.getLocalhostPort()}
-        ${'base-line'}              | ${true}               | ${true}                                                   | ${() => taskConfig.getBaseLine()}
-        ${'base-line-file'}         | ${'./base-line-file'} | ${getPlatformAgnosticPath(__dirname + '/base-line-file')} | ${() => taskConfig.getBaseLineFile()}
+        inputOption                 | inputValue           | expectedValue                                            | getInputFunc
+        ${'repo-token'}             | ${'token'}           | ${'token'}                                               | ${() => taskConfig.getToken()}
+        ${'scan-url-relative-path'} | ${'path'}            | ${'path'}                                                | ${() => taskConfig.getScanUrlRelativePath()}
+        ${'chrome-path'}            | ${'./chrome-path'}   | ${getPlatformAgnosticPath(__dirname + '/chrome-path')}   | ${() => taskConfig.getChromePath()}
+        ${'input-file'}             | ${'./input-file'}    | ${getPlatformAgnosticPath(__dirname + '/input-file')}    | ${() => taskConfig.getInputFile()}
+        ${'output-dir'}             | ${'./output-dir'}    | ${getPlatformAgnosticPath(__dirname + '/output-dir')}    | ${() => taskConfig.getReportOutDir()}
+        ${'site-dir'}               | ${'path'}            | ${'path'}                                                | ${() => taskConfig.getSiteDir()}
+        ${'url'}                    | ${'url'}             | ${'url'}                                                 | ${() => taskConfig.getUrl()}
+        ${'discovery-patterns'}     | ${'abc'}             | ${'abc'}                                                 | ${() => taskConfig.getDiscoveryPatterns()}
+        ${'input-urls'}             | ${'abc'}             | ${'abc'}                                                 | ${() => taskConfig.getInputUrls()}
+        ${'max-urls'}               | ${'20'}              | ${20}                                                    | ${() => taskConfig.getMaxUrls()}
+        ${'scan-timeout'}           | ${'100000'}          | ${100000}                                                | ${() => taskConfig.getScanTimeout()}
+        ${'localhost-port'}         | ${'8080'}            | ${8080}                                                  | ${() => taskConfig.getLocalhostPort()}
+        ${'baseline'}               | ${true}              | ${true}                                                  | ${() => taskConfig.getBaseline()}
+        ${'baseline-file'}          | ${'./baseline-file'} | ${getPlatformAgnosticPath(__dirname + '/baseline-file')} | ${() => taskConfig.getBaselineFile()}
+        ${'baseline-name'}          | ${'baseline-name'}   | ${'baseline-name'}                                       | ${() => taskConfig.getBaselineName()}
+        ${'baseline-name'}          | ${undefined}         | ${'newBaseline'}                                         | ${() => taskConfig.getBaselineName()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {

--- a/packages/gh-action/src/task-config/gh-task-config.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.ts
@@ -88,10 +88,6 @@ export class GHTaskConfig extends TaskConfig {
         return this.actionCoreObj.getBooleanInput('base-line');
     }
 
-    public getBaseLine1(): string {
-        return this.actionCoreObj.getInput('base-line');
-    }
-
     public getBaseLineFile(): string | undefined {
         const value = this.getAbsolutePath(this.actionCoreObj.getInput('base-line-file'));
 

--- a/packages/gh-action/src/task-config/gh-task-config.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.ts
@@ -84,20 +84,10 @@ export class GHTaskConfig extends TaskConfig {
         return parseInt(this.processObj.env.GITHUB_RUN_ID, 10);
     }
 
-    public getBaseline(): boolean {
-        return this.actionCoreObj.getBooleanInput('baseline');
-    }
-
     public getBaselineFile(): string | undefined {
         const value = this.getAbsolutePath(this.actionCoreObj.getInput('baseline-file'));
 
         return isEmpty(value) ? undefined : value;
-    }
-
-    public getBaselineName(): string | undefined {
-        const value = this.actionCoreObj.getInput('baseline-name');
-
-        return isEmpty(value) ? 'newBaseline' : value;
     }
 
     private getAbsolutePath(path: string): string {

--- a/packages/gh-action/src/task-config/gh-task-config.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.ts
@@ -84,14 +84,20 @@ export class GHTaskConfig extends TaskConfig {
         return parseInt(this.processObj.env.GITHUB_RUN_ID, 10);
     }
 
-    public getBaseLine(): boolean {
-        return this.actionCoreObj.getBooleanInput('base-line');
+    public getBaseline(): boolean {
+        return this.actionCoreObj.getBooleanInput('baseline');
     }
 
-    public getBaseLineFile(): string | undefined {
-        const value = this.getAbsolutePath(this.actionCoreObj.getInput('base-line-file'));
+    public getBaselineFile(): string | undefined {
+        const value = this.getAbsolutePath(this.actionCoreObj.getInput('baseline-file'));
 
         return isEmpty(value) ? undefined : value;
+    }
+
+    public getBaselineName(): string | undefined {
+        const value = this.actionCoreObj.getInput('baseline-name');
+
+        return isEmpty(value) ? 'newBaseline' : value;
     }
 
     private getAbsolutePath(path: string): string {

--- a/packages/gh-action/src/task-config/gh-task-config.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.ts
@@ -84,6 +84,20 @@ export class GHTaskConfig extends TaskConfig {
         return parseInt(this.processObj.env.GITHUB_RUN_ID, 10);
     }
 
+    public getBaseLine(): boolean {
+        return this.actionCoreObj.getBooleanInput('base-line');
+    }
+
+    public getBaseLine1(): string {
+        return this.actionCoreObj.getInput('base-line');
+    }
+
+    public getBaseLineFile(): string | undefined {
+        const value = this.getAbsolutePath(this.actionCoreObj.getInput('base-line-file'));
+
+        return isEmpty(value) ? undefined : value;
+    }
+
     private getAbsolutePath(path: string): string {
         if (isEmpty(path)) {
             return undefined;

--- a/packages/shared/src/task-config.ts
+++ b/packages/shared/src/task-config.ts
@@ -11,6 +11,7 @@ export abstract class TaskConfig {
     abstract getReportOutDir(): string;
     abstract getSiteDir(): string;
     abstract getScanUrlRelativePath(): string;
+    abstract getBaseLine(): boolean;
     abstract getToken(): string | undefined;
     abstract getChromePath(): string | undefined;
     abstract getUrl(): string | undefined;
@@ -21,4 +22,5 @@ export abstract class TaskConfig {
     abstract getScanTimeout(): number;
     abstract getLocalhostPort(): number | undefined;
     abstract getRunId(): number | undefined;
+    abstract getBaseLineFile(): string | undefined;
 }

--- a/packages/shared/src/task-config.ts
+++ b/packages/shared/src/task-config.ts
@@ -11,8 +11,6 @@ export abstract class TaskConfig {
     abstract getReportOutDir(): string;
     abstract getSiteDir(): string;
     abstract getScanUrlRelativePath(): string;
-    abstract getBaseline(): boolean;
-    abstract getBaselineName(): string | undefined;
     abstract getBaselineFile(): string | undefined;
     abstract getToken(): string | undefined;
     abstract getChromePath(): string | undefined;

--- a/packages/shared/src/task-config.ts
+++ b/packages/shared/src/task-config.ts
@@ -11,7 +11,9 @@ export abstract class TaskConfig {
     abstract getReportOutDir(): string;
     abstract getSiteDir(): string;
     abstract getScanUrlRelativePath(): string;
-    abstract getBaseLine(): boolean;
+    abstract getBaseline(): boolean;
+    abstract getBaselineName(): string | undefined;
+    abstract getBaselineFile(): string | undefined;
     abstract getToken(): string | undefined;
     abstract getChromePath(): string | undefined;
     abstract getUrl(): string | undefined;
@@ -22,5 +24,4 @@ export abstract class TaskConfig {
     abstract getScanTimeout(): number;
     abstract getLocalhostPort(): number | undefined;
     abstract getRunId(): number | undefined;
-    abstract getBaseLineFile(): string | undefined;
 }


### PR DESCRIPTION
#### Details

Add Baseline input parameter for GH action and ADO extension.

##### Motivation

Get the Action repo side ready to consume the scanner package after adding the baseline feature.

##### Context
Adding two new parameter:

1. Baseline:  Generate Baseline if true.
2. Baseline file path: Path to existing baseline file, will generate delta between the generated one and the old one if exists.

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
