### PR TITLE
feat(pr-baseline-2): enforce workflow with baseline

### DIFF
--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
@@ -269,7 +269,7 @@ describe(ADOPullRequestCommentCreator, () => {
             gitApiMock.setup((o) => o.createThread(newThread, repoId, prId)).verifiable(Times.once());
             setupIsSupportedReturnsTrue();
             setupFailOnAccessibilityError(false);
-            setupBaselineFileExists();
+            setupBaselineFileParameterExists();
             setupInitializeWithoutServiceConnectionName();
             setupInitializeSetConnection(webApiMock.object);
             prCommentCreator = buildPrCommentCreatorWithMocks();
@@ -339,7 +339,7 @@ describe(ADOPullRequestCommentCreator, () => {
             .verifiable(Times.atLeastOnce());
     };
 
-    const setupBaselineFileExists = () => {
+    const setupBaselineFileParameterExists = () => {
         adoTaskConfigMock
             .setup((o) => o.getBaselineFile())
             .returns(() => It.isAnyString())

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
@@ -362,13 +362,6 @@ describe(ADOPullRequestCommentCreator, () => {
             .verifiable(Times.atLeastOnce());
     };
 
-    const setupBaselineFileDoesNotExist = () => {
-        adoTaskConfigMock
-            .setup((o) => o.getBaselineFile())
-            .returns(() => undefined)
-            .verifiable(Times.atLeastOnce());
-    };
-
     const setupIsSupportedReturnsFalse = () => {
         adoTaskMock
             .setup((o) => o.getVariable('Build.Reason'))

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
@@ -286,13 +286,9 @@ describe(ADOPullRequestCommentCreator, () => {
             setupInitializeSetConnection(webApiMock.object);
             prCommentCreator = buildPrCommentCreatorWithMocks();
 
-            let reason: Error = new Error('Should fail!');
-            try {
-                await prCommentCreator.completeRun(reportStub, baselineEvaluationStub);
-            } catch (error) {
-                reason = error as Error;
-            }
-            expect(reason).toEqual('Failed: New accessibility errors found, not in the baseline. See PR comment for more info.');
+            await expect(prCommentCreator.completeRun(reportStub, baselineEvaluationStub)).rejects.toThrowError(
+                'Failed: The baseline file needs to be updated. See the PR comments for more details.',
+            );
 
             verifyAllMocks();
         });

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
@@ -17,7 +17,7 @@ import { CombinedReportParameters } from 'accessibility-insights-report';
 
 import { Logger, ReportMarkdownConvertor } from '@accessibility-insights-action/shared';
 
-describe(ADOTaskConfig, () => {
+describe(ADOPullRequestCommentCreator, () => {
     let adoTaskMock: IMock<typeof adoTask>;
     let adoTaskConfigMock: IMock<ADOTaskConfig>;
     let gitApiMock: IMock<GitApi.IGitApi>;
@@ -224,7 +224,7 @@ describe(ADOTaskConfig, () => {
             try {
                 await prCommentCreator.completeRun(reportStub);
             } catch (error) {
-                reason = error;
+                reason = error as Error;
             }
             expect(reason).toEqual('Failed Accessibility Error');
 
@@ -257,7 +257,7 @@ describe(ADOTaskConfig, () => {
             try {
                 await prCommentCreator.completeRun(reportStub);
             } catch (error) {
-                reason = error;
+                reason = error as Error;
             }
             expect(reason).toEqual('Failed Accessibility Error');
 

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.spec.ts
@@ -221,13 +221,7 @@ describe(ADOPullRequestCommentCreator, () => {
             setupInitializeSetConnection(webApiMock.object);
             prCommentCreator = buildPrCommentCreatorWithMocks();
 
-            let reason: Error = new Error('Should fail!');
-            try {
-                await prCommentCreator.completeRun(reportStub);
-            } catch (error) {
-                reason = error as Error;
-            }
-            expect(reason).toEqual('Failed Accessibility Error');
+            await expect(prCommentCreator.completeRun(reportStub)).rejects.toThrowError('Failed Accessibility Error');
 
             verifyAllMocks();
         });
@@ -254,13 +248,7 @@ describe(ADOPullRequestCommentCreator, () => {
             setupInitializeSetConnection(webApiMock.object);
             prCommentCreator = buildPrCommentCreatorWithMocks();
 
-            let reason: Error = new Error('Should fail!');
-            try {
-                await prCommentCreator.completeRun(reportStub);
-            } catch (error) {
-                reason = error as Error;
-            }
-            expect(reason).toEqual('Failed Accessibility Error');
+            await expect(prCommentCreator.completeRun(reportStub)).rejects.toThrowError('Failed Accessibility Error');
 
             verifyAllMocks();
         });

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
@@ -177,7 +177,7 @@ export class AdoPullRequestCommentCreator extends ProgressReporter {
 
     private failOnAccessibilityError(combinedReportResult: CombinedReportParameters): void {
         if (this.adoTaskConfig.getFailOnAccessibilityError() && combinedReportResult.results.urlResults.failedUrls > 0) {
-            throw 'Failed Accessibility Error';
+            throw new Error('Failed Accessibility Error');
         }
     }
 

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
@@ -183,7 +183,7 @@ export class AdoPullRequestCommentCreator extends ProgressReporter {
 
     private failOnBaselineNotUpdated(suggestedBaselineUpdate: null | BaselineFileContent): void {
         if (this.adoTaskConfig.getBaselineFile() !== undefined && suggestedBaselineUpdate !== null) {
-            throw 'Failed: New accessibility errors found, not in the baseline. See PR comment for more info.';
+            throw new Error('Failed: The baseline file needs to be updated. See the PR comments for more details.');
         }
     }
 

--- a/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/pull-request/ado-pull-request-comment-creator.ts
@@ -13,6 +13,7 @@ import * as NodeApi from 'azure-devops-node-api';
 import * as GitApi from 'azure-devops-node-api/GitApi';
 import * as GitInterfaces from 'azure-devops-node-api/interfaces/GitInterfaces';
 import * as VsoBaseInterfaces from 'azure-devops-node-api/interfaces/common/VsoBaseInterfaces';
+import { BaselineEvaluation, BaselineFileContent } from '@accessibility-insights-action/shared/src/baseline-types';
 
 @injectable()
 export class AdoPullRequestCommentCreator extends ProgressReporter {
@@ -88,7 +89,7 @@ export class AdoPullRequestCommentCreator extends ProgressReporter {
         // We don't do anything for pull request flow
     }
 
-    public async completeRun(combinedReportResult: CombinedReportParameters): Promise<void> {
+    public async completeRun(combinedReportResult: CombinedReportParameters, baselineEvaluation?: BaselineEvaluation): Promise<void> {
         if (!this.isSupported()) {
             return;
         }
@@ -160,6 +161,9 @@ export class AdoPullRequestCommentCreator extends ProgressReporter {
         }
 
         this.failOnAccessibilityError(combinedReportResult);
+        if (baselineEvaluation) {
+            this.failOnBaselineNotUpdated(baselineEvaluation.suggestedBaselineUpdate);
+        }
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
@@ -174,6 +178,12 @@ export class AdoPullRequestCommentCreator extends ProgressReporter {
     private failOnAccessibilityError(combinedReportResult: CombinedReportParameters): void {
         if (this.adoTaskConfig.getFailOnAccessibilityError() && combinedReportResult.results.urlResults.failedUrls > 0) {
             throw 'Failed Accessibility Error';
+        }
+    }
+
+    private failOnBaselineNotUpdated(suggestedBaselineUpdate: null | BaselineFileContent): void {
+        if (this.adoTaskConfig.getBaselineFile() !== undefined && suggestedBaselineUpdate !== null) {
+            throw 'Failed: New accessibility errors found, not in the baseline. See PR comment for more info.';
         }
     }
 

--- a/packages/shared/src/baseline-types.ts
+++ b/packages/shared/src/baseline-types.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export type UrlNormalizer = (originalUrl: string) => string;
+
+export type BaselineOptions = {
+    baselineContent: BaselineFileContent | null;
+
+    // If specified, this function will be applied to each URL that
+    // would appear in a baseline file before saving a baseline.
+    //
+    // For example, if you are scanning a localhost website on a dynamic
+    // port, you might use this to strip out the port number from URLs.
+    urlNormalizer?: UrlNormalizer;
+};
+
+export type CountsByRule = { [ruleId in string]: number };
+
+export type BaselineEvaluation = {
+    // null implies "no update required"
+    suggestedBaselineUpdate: null | BaselineFileContent;
+
+    newViolationsByRule: CountsByRule;
+    fixedViolationsByRule: CountsByRule;
+    totalNewViolations: number;
+    totalFixedViolations: number;
+};
+
+export type BaselineResult = {
+    rule: string;
+    cssSelector: string;
+    xpathSelector?: string;
+    htmlSnippet: string;
+
+    // Invariant: must be sorted
+    urls: string[];
+};
+
+export type BaselineFileContent = {
+    metadata: { fileFormatVersion: '1' };
+
+    // Invariant: must be sorted by ['rule', 'cssSelector', 'xpathSelector', 'htmlSnippet']
+    results: BaselineResult[];
+};

--- a/packages/shared/src/progress-reporter/all-progress-reporter.spec.ts
+++ b/packages/shared/src/progress-reporter/all-progress-reporter.spec.ts
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { CombinedReportParameters } from 'accessibility-insights-report';
 import 'reflect-metadata';
 
 import { IMock, Mock, Times } from 'typemoq';
+import { BaselineEvaluation } from '../baseline-types';
 import { AllProgressReporter } from './all-progress-reporter';
 import { ProgressReporter } from './progress-reporter';
 
@@ -26,16 +28,31 @@ describe(AllProgressReporter, () => {
         await testSubject.start();
     });
 
-    it('complete should invoke all reporters', async () => {
-        const axeResults = 'axe results' as any;
-        executeOnReporter((reporter) => {
-            reporter
-                .setup((p) => p.completeRun(axeResults))
-                .returns(() => Promise.resolve())
-                .verifiable(Times.once());
+    describe('complete', () => {
+        it('should invoke all reporters', async () => {
+            const axeResults = 'axe results' as unknown as CombinedReportParameters;
+            executeOnReporter((reporter) => {
+                reporter
+                    .setup((p) => p.completeRun(axeResults))
+                    .returns(() => Promise.resolve())
+                    .verifiable(Times.once());
+            });
+
+            await testSubject.completeRun(axeResults);
         });
 
-        await testSubject.completeRun(axeResults);
+        it('should invoke all reporters when baselineEvaluation is available', async () => {
+            const axeResults = 'axe results' as unknown as CombinedReportParameters;
+            const baselineEvalStub = 'baseline evaluation' as unknown as BaselineEvaluation;
+            executeOnReporter((reporter) => {
+                reporter
+                    .setup((p) => p.completeRun(axeResults, baselineEvalStub))
+                    .returns(() => Promise.resolve())
+                    .verifiable(Times.once());
+            });
+
+            await testSubject.completeRun(axeResults, baselineEvalStub);
+        });
     });
 
     it('failRun should invoke all reporters', async () => {

--- a/packages/shared/src/progress-reporter/all-progress-reporter.ts
+++ b/packages/shared/src/progress-reporter/all-progress-reporter.ts
@@ -5,6 +5,7 @@ import { inject, injectable } from 'inversify';
 import { ProgressReporter } from './progress-reporter';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 import { iocTypes } from '../ioc/ioc-types';
+import { BaselineEvaluation } from '../baseline-types';
 
 @injectable()
 export class AllProgressReporter extends ProgressReporter {
@@ -16,8 +17,12 @@ export class AllProgressReporter extends ProgressReporter {
         await this.execute((r) => r.start());
     }
 
-    public async completeRun(combinedReportResult: CombinedReportParameters): Promise<void> {
-        await this.execute((r) => r.completeRun(combinedReportResult));
+    public async completeRun(combinedReportResult: CombinedReportParameters, baselineEvaluation?: BaselineEvaluation): Promise<void> {
+        if (baselineEvaluation) {
+            await this.execute((r) => r.completeRun(combinedReportResult, baselineEvaluation));
+        } else {
+            await this.execute((r) => r.completeRun(combinedReportResult));
+        }
     }
 
     public async failRun(message: string): Promise<void> {

--- a/packages/shared/src/progress-reporter/progress-reporter.ts
+++ b/packages/shared/src/progress-reporter/progress-reporter.ts
@@ -5,6 +5,7 @@ import { injectable } from 'inversify';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 import marked from 'marked';
 import TerminalRenderer from 'marked-terminal';
+import { BaselineEvaluation } from '../baseline-types';
 
 @injectable()
 export abstract class ProgressReporter {
@@ -17,7 +18,7 @@ export abstract class ProgressReporter {
     }
 
     public abstract start(): Promise<void>;
-    public abstract completeRun(combinedReportResult: CombinedReportParameters): Promise<void>;
+    public abstract completeRun(combinedReportResult: CombinedReportParameters, baselineEvaluation?: BaselineEvaluation): Promise<void>;
     public abstract failRun(message: string): Promise<void>;
 
     protected async invoke<T>(fn: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
* Added baseline-types.ts file (same as the one in [scan package PR](https://github.com/microsoft/accessibility-insights-service/pull/1743/files#diff-b8f7a3755b9dca11d1158b4ca3b87c4a6fdb8fcf25753d3da383bba065ef4d0d), will remove after scan package is released)
* Added BaselineEvaluation to progress-reporter to be used by ADOPullRequestCommentCreator
* Throw error if baselineFile was specified and there are suggested changes, implying that there are new failures that aren't currently in the baseline

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Part of feature work

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
This PR doesn't include updating the PR comments to include baseline details; leaving that for a future PR.
<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Partially addresses an existing issue: WI 1882596
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
