### PR TITLE
feat(baseline-implementation): Add singleWorker Option

### DIFF
--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -52,6 +52,7 @@ describe(ADOTaskConfig, () => {
         ${'localhostPort'}             | ${undefined}        | ${undefined}                                            | ${() => taskConfig.getLocalhostPort()}
         ${'repoServiceConnectionName'} | ${'testName'}       | ${'testName'}                                           | ${() => taskConfig.getRepoServiceConnectionName()}
         ${'baselineFile'}              | ${'./baselineFile'} | ${getPlatformAgnosticPath(__dirname + '/baselineFile')} | ${() => taskConfig.getBaselineFile()}
+        ${'failOnAccessibilityError'}  | ${true}             | ${true}                                                 | ${() => taskConfig.getFailOnAccessibilityError()}
         ${'singleWorker'}              | ${true}             | ${true}                                                 | ${() => taskConfig.getSingleWorker()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
@@ -67,22 +68,6 @@ describe(ADOTaskConfig, () => {
                     .returns(() => inputValue as string)
                     .verifiable(Times.once());
             }
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-            const retrievedOption: unknown = getInputFunc();
-            expect(retrievedOption).toStrictEqual(expectedValue);
-        },
-    );
-
-    it.each`
-        inputOption                   | inputValue | expectedValue | getInputFunc
-        ${'failOnAccessibilityError'} | ${true}    | ${true}       | ${() => taskConfig.getFailOnAccessibilityError()}
-    `(
-        `bool input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
-        ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
-            adoTaskMock
-                .setup((am) => am.getBoolInput(inputOption))
-                .returns(() => inputValue as boolean)
-                .verifiable(Times.once());
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             const retrievedOption: unknown = getInputFunc();
             expect(retrievedOption).toStrictEqual(expectedValue);

--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -52,14 +52,21 @@ describe(ADOTaskConfig, () => {
         ${'localhostPort'}             | ${undefined}        | ${undefined}                                            | ${() => taskConfig.getLocalhostPort()}
         ${'repoServiceConnectionName'} | ${'testName'}       | ${'testName'}                                           | ${() => taskConfig.getRepoServiceConnectionName()}
         ${'baselineFile'}              | ${'./baselineFile'} | ${getPlatformAgnosticPath(__dirname + '/baselineFile')} | ${() => taskConfig.getBaselineFile()}
+        ${'singleWorker'}              | ${true}             | ${true}                                                 | ${() => taskConfig.getSingleWorker()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
-            adoTaskMock
-                .setup((am) => am.getInput(inputOption))
-                .returns(() => inputValue as string)
-                .verifiable(Times.once());
-
+            if (typeof inputValue == 'boolean') {
+                adoTaskMock
+                    .setup((am) => am.getBoolInput(inputOption))
+                    .returns(() => inputValue)
+                    .verifiable(Times.once());
+            } else {
+                adoTaskMock
+                    .setup((am) => am.getInput(inputOption))
+                    .returns(() => inputValue as string)
+                    .verifiable(Times.once());
+            }
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             const retrievedOption: unknown = getInputFunc();
             expect(retrievedOption).toStrictEqual(expectedValue);

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -103,6 +103,10 @@ export class ADOTaskConfig extends TaskConfig {
         return this.adoTaskObj.getBoolInput('failOnAccessibilityError');
     }
 
+    public getSingleWorker(): boolean {
+        return this.adoTaskObj.getBoolInput('singleWorker');
+    }
+
     public getBaselineFile(): string | undefined {
         const value = this.getAbsolutePath(this.adoTaskObj.getInput('baselineFile'));
 

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -117,6 +117,14 @@
             "label": "Baseline File Path",
             "required": false,
             "helpMarkDown": "The old baseline file path, a new baseline will be generated with the same name, if null baseline option will be disabled."
+        },
+        {
+            "name": "singleWorker",
+            "type": "boolean",
+            "label": "Uses a single crawler worker.",
+            "required": true,
+            "defaultValue": true,
+            "helpMarkDown": "To help getting a deterministic result, either use a single worker or make sure that maxUrls is greater than total number of urls in the website."
         }
     ],
     "execution": {

--- a/packages/gh-action/action.yml
+++ b/packages/gh-action/action.yml
@@ -48,6 +48,10 @@ inputs:
     baseline-file:
         description: 'The old baseline file path, a new baseline will be generated with the same name, if null baseline option will be disabled.'
         required: false
+    single-worker:
+        description: 'To help getting a deterministic result, either use a single worker or make sure that maxUrls is greater than total number of urls in the website.'
+        required: true
+        default: true
 runs:
     using: 'composite'
     steps:

--- a/packages/gh-action/src/task-config/gh-task-config.spec.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.spec.ts
@@ -44,14 +44,21 @@ describe(GHTaskConfig, () => {
         ${'scan-timeout'}           | ${'100000'}          | ${100000}                                                | ${() => taskConfig.getScanTimeout()}
         ${'localhost-port'}         | ${'8080'}            | ${8080}                                                  | ${() => taskConfig.getLocalhostPort()}
         ${'baseline-file'}          | ${'./baseline-file'} | ${getPlatformAgnosticPath(__dirname + '/baseline-file')} | ${() => taskConfig.getBaselineFile()}
+        ${'single-worker'}          | ${true}              | ${true}                                                  | ${() => taskConfig.getSingleWorker()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {
-            actionCoreMock
-                .setup((am) => am.getInput(inputOption))
-                .returns(() => inputValue)
-                .verifiable(Times.once());
-
+            if (typeof inputValue == 'boolean') {
+                actionCoreMock
+                    .setup((am) => am.getBooleanInput(inputOption))
+                    .returns(() => inputValue)
+                    .verifiable(Times.once());
+            } else {
+                actionCoreMock
+                    .setup((am) => am.getInput(inputOption))
+                    .returns(() => inputValue)
+                    .verifiable(Times.once());
+            }
             const retrievedOption = getInputFunc();
             expect(retrievedOption).toStrictEqual(expectedValue);
         },

--- a/packages/gh-action/src/task-config/gh-task-config.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.ts
@@ -84,6 +84,10 @@ export class GHTaskConfig extends TaskConfig {
         return parseInt(this.processObj.env.GITHUB_RUN_ID, 10);
     }
 
+    public getSingleWorker(): boolean {
+        return this.actionCoreObj.getBooleanInput('single-worker');
+    }
+
     public getBaselineFile(): string | undefined {
         const value = this.getAbsolutePath(this.actionCoreObj.getInput('baseline-file'));
 

--- a/packages/shared/src/scanner/crawl-argument-handler.ts
+++ b/packages/shared/src/scanner/crawl-argument-handler.ts
@@ -50,6 +50,7 @@ export class CrawlArgumentHandler {
             discoveryPatterns: discoveryPatternsArg?.split(/\s+/),
             inputUrls: inputUrlsArg?.split(/\s+/),
             url: this.taskConfig.getUrl(),
+            //to-do singleWorker: this.taskConfig.getSingleWorker()
         };
 
         return args;

--- a/packages/shared/src/task-config.ts
+++ b/packages/shared/src/task-config.ts
@@ -11,6 +11,7 @@ export abstract class TaskConfig {
     abstract getReportOutDir(): string;
     abstract getSiteDir(): string;
     abstract getScanUrlRelativePath(): string;
+    abstract getSingleWorker(): boolean;
     abstract getBaselineFile(): string | undefined;
     abstract getToken(): string | undefined;
     abstract getChromePath(): string | undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2646,7 +2646,7 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@5.0.1, ansi-regex@^2.0.0, ansi-regex@^3.0.0, ansi-regex@^4.0.0, ansi-regex@^4.1.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+ansi-regex@^2.0.0, ansi-regex@^3.0.0, ansi-regex@^4.0.0, ansi-regex@^4.1.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==


### PR DESCRIPTION
#### Details
Add singleWorker option in the GH Action/ ADO extension side.
<!-- Usually a sentence or two describing what the PR changes -->

##### Motivation
Getting deterministic result for the baselining.
<!-- This can be as simple as "addresses issue #123" -->

##### Context
singleWorker and maxUrls will be used to check if the result is deterministic or not.

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
