### PR TITLE
feat(pr-baseline-2): Consume scanner package 0.10.3

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -29,7 +29,7 @@
     "devDependencies": {},
     "dependencies": {
         "accessibility-insights-report": "4.2.0",
-        "accessibility-insights-scan": "0.10.2",
+        "accessibility-insights-scan": "0.10.3",
         "axe-core": "4.3.2",
         "express": "^4.17.1",
         "filenamify-url": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2499,10 +2499,10 @@ accessibility-insights-report@4.2.0:
     react-helmet "^6.1.0"
     uuid "^8.3.2"
 
-accessibility-insights-scan@0.10.2:
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/accessibility-insights-scan/-/accessibility-insights-scan-0.10.2.tgz#7d2c0c8d9558ffc9af84119ef3c1d45ed3af66ac"
-  integrity sha512-XO4SxozCq1YiPP60m61jZglns736KHGINwi7Jc/UAu4dHpWievazSiV4v44L+JqNub2c1d652koHoUSR6m3LUw==
+accessibility-insights-scan@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/accessibility-insights-scan/-/accessibility-insights-scan-0.10.3.tgz#f92191f5938c8033b5668791119ccae588ff86c6"
+  integrity sha512-50azvBFXDgYzyB7rXa4eu/P80vGPgY5CNcjDa4d69gUQ90YLUFRCbaHhKCWFUXiAP22/EvlT4PSuBjEhmDRW4w==
   dependencies:
     "@axe-core/puppeteer" "4.2.2"
     "@medv/finder" "^2.1.0"


### PR DESCRIPTION
#### Details

Update to scanner package 0.10.3. This is identical to 0.10.2, with the exception of publicly documenting the new baseline parameters.

##### Motivation

Part of baselining feature

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
