### PR TITLE
feat(pr-baseline-2): Update baseline file after crawling

### DIFF
--- a/packages/shared/src/scanner/scanner.spec.ts
+++ b/packages/shared/src/scanner/scanner.spec.ts
@@ -7,6 +7,7 @@ import {
     AICombinedReportDataConverter,
     AICrawler,
     BaselineEvaluation,
+    BaselineFileUpdater,
     BaselineOptions,
     BaselineOptionsBuilder,
     CombinedScanResult,
@@ -41,6 +42,7 @@ describe(Scanner, () => {
     let taskConfigMock: IMock<TaskConfig>;
     let crawlerParametersBuilder: IMock<CrawlerParametersBuilder>;
     let baselineOptionsBuilderMock: IMock<BaselineOptionsBuilder>;
+    let baselineFileUpdaterMock: IMock<BaselineFileUpdater>;
     let scanner: Scanner;
     let combinedScanResult: CombinedScanResult;
     let scanArguments: ScanArguments;
@@ -64,6 +66,7 @@ describe(Scanner, () => {
         taskConfigMock = Mock.ofType<TaskConfig>();
         crawlerParametersBuilder = Mock.ofType<CrawlerParametersBuilder>();
         baselineOptionsBuilderMock = Mock.ofType<BaselineOptionsBuilder>(null, MockBehavior.Strict);
+        baselineFileUpdaterMock = Mock.ofType<BaselineFileUpdater>();
         scanner = new Scanner(
             aiCrawlerMock.object,
             reportGeneratorMock.object,
@@ -78,6 +81,7 @@ describe(Scanner, () => {
             taskConfigMock.object,
             crawlerParametersBuilder.object,
             baselineOptionsBuilderMock.object,
+            baselineFileUpdaterMock.object,
         );
         combinedScanResult = {
             scanMetadata: {
@@ -191,6 +195,10 @@ describe(Scanner, () => {
                 .setup((m) => m.build(scanArguments))
                 .returns(() => baselineOptions)
                 .verifiable(Times.once());
+            baselineFileUpdaterMock
+                .setup((m) => m.updateBaseline(scanArguments, baselineEvaluation))
+                .returns(() => Promise.resolve())
+                .verifiable(Times.once());
 
             combinedScanResult.baselineEvaluation = baselineEvaluation;
             aiCrawlerMock
@@ -244,5 +252,6 @@ describe(Scanner, () => {
         localFileServerMock.verifyAll();
         promiseUtilsMock.verifyAll();
         baselineOptionsBuilderMock.verifyAll();
+        baselineFileUpdaterMock.verifyAll();
     }
 });

--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -8,6 +8,7 @@ import {
     ScanArguments,
     CrawlerParametersBuilder,
     BaselineOptionsBuilder,
+    BaselineFileUpdater,
 } from 'accessibility-insights-scan';
 import { inject, injectable } from 'inversify';
 import * as util from 'util';
@@ -40,6 +41,7 @@ export class Scanner {
         @inject(iocTypes.TaskConfig) private readonly taskConfig: TaskConfig,
         @inject(CrawlerParametersBuilder) private readonly crawlerParametersBuilder: CrawlerParametersBuilder,
         @inject(BaselineOptionsBuilder) private readonly baselineOptionsBuilder: BaselineOptionsBuilder,
+        @inject(BaselineFileUpdater) private readonly baselineFileUpdater: BaselineFileUpdater,
     ) {}
 
     public async scan(): Promise<void> {
@@ -75,6 +77,7 @@ export class Scanner {
 
             const combinedReportParameters = this.getCombinedReportParameters(combinedScanResult, scanStarted, scanEnded);
             this.reportGenerator.generateReport(combinedReportParameters);
+            await this.baselineFileUpdater.updateBaseline(scanArguments, combinedScanResult.baselineEvaluation);
 
             await this.allProgressReporter.completeRun(combinedReportParameters, combinedScanResult.baselineEvaluation);
         } catch (error) {


### PR DESCRIPTION
#### Details

Add the link to the code that updates the baseline file to disk. This mirrors what happens at https://github.com/microsoft/accessibility-insights-service/blob/main/packages/cli/src/runner/crawler-command-runner.ts#L45, which is why it worked from the CLI of the scanning package but not from the extension

##### Motivation

Part of baselining feature

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
