### PR TITLE
feat(pr-baseline-2): Escape artifact url

### DIFF
--- a/packages/ado-extension/src/ado-artifacts-info-provider.spec.ts
+++ b/packages/ado-extension/src/ado-artifacts-info-provider.spec.ts
@@ -24,35 +24,35 @@ describe(ADOArtifactsInfoProvider, () => {
         const expectedEscapedArtifactsUrl = `https://dev.azure.com/myOrganizationName/my%20Proj%C3%A9ct/_build/results?buildId=100&view=artifacts&pathAsName=false&type=publishedArtifacts`;
 
         it.each`
-            collectionUri    | teamProject    | runId        | expectedUrl
-            ${collectionUri} | ${teamProject} | ${100}       | ${expectedArtifactsUrl}
+            collectionUri    | teamProject           | runId        | expectedUrl
+            ${collectionUri} | ${teamProject}        | ${100}       | ${expectedArtifactsUrl}
             ${collectionUri} | ${teamProjectEscaped} | ${100}       | ${expectedEscapedArtifactsUrl}
-            ${collectionUri} | ${teamProject} | ${undefined} | ${undefined}
-            ${collectionUri} | ${teamProject} | ${''}        | ${undefined}
-            ${collectionUri} | ${undefined}   | ${100}       | ${undefined}
-            ${collectionUri} | ${undefined}   | ${undefined} | ${undefined}
-            ${collectionUri} | ${undefined}   | ${''}        | ${undefined}
-            ${collectionUri} | ${''}          | ${100}       | ${undefined}
-            ${collectionUri} | ${''}          | ${undefined} | ${undefined}
-            ${collectionUri} | ${''}          | ${''}        | ${undefined}
-            ${undefined}     | ${teamProject} | ${100}       | ${undefined}
-            ${undefined}     | ${teamProject} | ${undefined} | ${undefined}
-            ${undefined}     | ${teamProject} | ${''}        | ${undefined}
-            ${undefined}     | ${undefined}   | ${100}       | ${undefined}
-            ${undefined}     | ${undefined}   | ${undefined} | ${undefined}
-            ${undefined}     | ${undefined}   | ${''}        | ${undefined}
-            ${undefined}     | ${''}          | ${100}       | ${undefined}
-            ${undefined}     | ${''}          | ${undefined} | ${undefined}
-            ${undefined}     | ${''}          | ${''}        | ${undefined}
-            ${''}            | ${teamProject} | ${100}       | ${undefined}
-            ${''}            | ${teamProject} | ${undefined} | ${undefined}
-            ${''}            | ${teamProject} | ${''}        | ${undefined}
-            ${''}            | ${undefined}   | ${100}       | ${undefined}
-            ${''}            | ${undefined}   | ${undefined} | ${undefined}
-            ${''}            | ${undefined}   | ${''}        | ${undefined}
-            ${''}            | ${''}          | ${100}       | ${undefined}
-            ${''}            | ${''}          | ${undefined} | ${undefined}
-            ${''}            | ${''}          | ${''}        | ${undefined}
+            ${collectionUri} | ${teamProject}        | ${undefined} | ${undefined}
+            ${collectionUri} | ${teamProject}        | ${''}        | ${undefined}
+            ${collectionUri} | ${undefined}          | ${100}       | ${undefined}
+            ${collectionUri} | ${undefined}          | ${undefined} | ${undefined}
+            ${collectionUri} | ${undefined}          | ${''}        | ${undefined}
+            ${collectionUri} | ${''}                 | ${100}       | ${undefined}
+            ${collectionUri} | ${''}                 | ${undefined} | ${undefined}
+            ${collectionUri} | ${''}                 | ${''}        | ${undefined}
+            ${undefined}     | ${teamProject}        | ${100}       | ${undefined}
+            ${undefined}     | ${teamProject}        | ${undefined} | ${undefined}
+            ${undefined}     | ${teamProject}        | ${''}        | ${undefined}
+            ${undefined}     | ${undefined}          | ${100}       | ${undefined}
+            ${undefined}     | ${undefined}          | ${undefined} | ${undefined}
+            ${undefined}     | ${undefined}          | ${''}        | ${undefined}
+            ${undefined}     | ${''}                 | ${100}       | ${undefined}
+            ${undefined}     | ${''}                 | ${undefined} | ${undefined}
+            ${undefined}     | ${''}                 | ${''}        | ${undefined}
+            ${''}            | ${teamProject}        | ${100}       | ${undefined}
+            ${''}            | ${teamProject}        | ${undefined} | ${undefined}
+            ${''}            | ${teamProject}        | ${''}        | ${undefined}
+            ${''}            | ${undefined}          | ${100}       | ${undefined}
+            ${''}            | ${undefined}          | ${undefined} | ${undefined}
+            ${''}            | ${undefined}          | ${''}        | ${undefined}
+            ${''}            | ${''}                 | ${100}       | ${undefined}
+            ${''}            | ${''}                 | ${undefined} | ${undefined}
+            ${''}            | ${''}                 | ${''}        | ${undefined}
         `(
             `returns '$expectedUrl' with collectionUri '$collectionUri', teamProject '$teamProject', runId '$runId'`,
             ({ collectionUri, teamProject, runId, expectedUrl }) => {

--- a/packages/ado-extension/src/ado-artifacts-info-provider.spec.ts
+++ b/packages/ado-extension/src/ado-artifacts-info-provider.spec.ts
@@ -18,12 +18,15 @@ describe(ADOArtifactsInfoProvider, () => {
     describe('getArtifactsUrl', () => {
         const collectionUri = 'https://dev.azure.com/myOrganizationName/';
         const teamProject = 'myProject';
+        const teamProjectEscaped = 'my Projéct';
         const runId = 100;
         const expectedArtifactsUrl = `${collectionUri}${teamProject}/_build/results?buildId=${runId}&view=artifacts&pathAsName=false&type=publishedArtifacts`;
+        const expectedEscapedArtifactsUrl = `https://dev.azure.com/myOrganizationName/my%20Proj%C3%A9ct/_build/results?buildId=100&view=artifacts&pathAsName=false&type=publishedArtifacts`;
 
         it.each`
             collectionUri    | teamProject    | runId        | expectedUrl
             ${collectionUri} | ${teamProject} | ${100}       | ${expectedArtifactsUrl}
+            ${collectionUri} | ${teamProjectEscaped} | ${100}       | ${expectedEscapedArtifactsUrl}
             ${collectionUri} | ${teamProject} | ${undefined} | ${undefined}
             ${collectionUri} | ${teamProject} | ${''}        | ${undefined}
             ${collectionUri} | ${undefined}   | ${100}       | ${undefined}

--- a/packages/ado-extension/src/ado-artifacts-info-provider.ts
+++ b/packages/ado-extension/src/ado-artifacts-info-provider.ts
@@ -18,7 +18,10 @@ export class ADOArtifactsInfoProvider extends ArtifactsInfoProvider {
             return undefined;
         }
 
-        return `${collectionUri}${teamProject}/_build/results?buildId=${runId}&view=artifacts&pathAsName=false&type=publishedArtifacts`;
+        const url = new URL(
+            `${collectionUri}${teamProject}/_build/results?buildId=${runId}&view=artifacts&pathAsName=false&type=publishedArtifacts`,
+        );
+        return url.toString();
     }
 
     public getCommitHash(): string | undefined {


### PR DESCRIPTION
#### Details

All characters in the artifact URLs need to be escaped so that browsers can handle them gracefully. This leverages the [URL class](https://developer.mozilla.org/en-US/docs/Web/API/URL) to generate proper escape sequences. This might be a case where it makes sense to review it by commit. The first commit adds the code, and the second commit is just whitespace changes from running prettier.

##### Motivation

PR baselining feature

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
