### PR TITLE
feat(pr-baseline-2): add a pipeline for ADO staging validation scenarios

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,7 @@
 **/.DS_Store
 **/.funcignore
 **/.gitignore
+**/*.baseline
 **/*.dat
 **/*.pbix
 **/*.png

--- a/dev/website-baselines/missing-failures-5858.baseline
+++ b/dev/website-baselines/missing-failures-5858.baseline
@@ -1,0 +1,47 @@
+{
+  metadata: {
+    fileFormatVersion: '1',
+  },
+  results: [
+    {
+      cssSelector: 'html',
+      htmlSnippet: '<html>',
+      rule: 'html-has-lang',
+      urls: [
+        'http://localhost:5858/',
+      ],
+    },
+    {
+      cssSelector: '#non-decorative',
+      htmlSnippet: '<img id="non-decorative" src="./img1.png">',
+      rule: 'image-alt',
+      urls: [
+        'http://localhost:5858/',
+      ],
+    },
+    {
+      cssSelector: '#input-radio-1',
+      htmlSnippet: '<input id="input-radio-1" type="radio" name="color" value="red" checked="">',
+      rule: 'label',
+      urls: [
+        'http://localhost:5858/',
+      ],
+    },
+    {
+      cssSelector: 'input[value="blue"]',
+      htmlSnippet: '<input type="radio" name="color" value="blue">',
+      rule: 'label',
+      urls: [
+        'http://localhost:5858/',
+      ],
+    },
+    {
+      cssSelector: 'input[value="green"]',
+      htmlSnippet: '<input type="radio" name="color" value="green">',
+      rule: 'label',
+      urls: [
+        'http://localhost:5858/',
+      ],
+    },
+  ],
+}

--- a/dev/website-baselines/up-to-date-5858.baseline
+++ b/dev/website-baselines/up-to-date-5858.baseline
@@ -1,0 +1,56 @@
+{
+  metadata: {
+    fileFormatVersion: '1',
+  },
+  results: [
+    {
+      cssSelector: 'html',
+      htmlSnippet: '<html>',
+      rule: 'html-has-lang',
+      urls: [
+        'http://localhost:5858/',
+      ],
+    },
+    {
+      cssSelector: 'html',
+      htmlSnippet: '<html><head>\n        <title>Inner page</title>\n    </head>\n    <body>\n        <main>\n            <h1>Inner page with issues</h1>\n            <img id="non-decorative" src="./img1.png">\n            <a href="../">Back to home</a>\n        </main>\n    \n</body></html>',
+      rule: 'html-has-lang',
+      urls: [
+        'http://localhost:5858/linked1/inner-page',
+      ],
+    },
+    {
+      cssSelector: '#non-decorative',
+      htmlSnippet: '<img id="non-decorative" src="./img1.png">',
+      rule: 'image-alt',
+      urls: [
+        'http://localhost:5858/',
+        'http://localhost:5858/linked1/inner-page',
+      ],
+    },
+    {
+      cssSelector: '#input-radio-1',
+      htmlSnippet: '<input id="input-radio-1" type="radio" name="color" value="red" checked="">',
+      rule: 'label',
+      urls: [
+        'http://localhost:5858/',
+      ],
+    },
+    {
+      cssSelector: 'input[value="blue"]',
+      htmlSnippet: '<input type="radio" name="color" value="blue">',
+      rule: 'label',
+      urls: [
+        'http://localhost:5858/',
+      ],
+    },
+    {
+      cssSelector: 'input[value="green"]',
+      htmlSnippet: '<input type="radio" name="color" value="green">',
+      rule: 'label',
+      urls: [
+        'http://localhost:5858/',
+      ],
+    },
+  ],
+}

--- a/dev/website-baselines/with-resolved-failures-5858.baseline
+++ b/dev/website-baselines/with-resolved-failures-5858.baseline
@@ -1,0 +1,65 @@
+{
+  metadata: {
+    fileFormatVersion: '1',
+  },
+  results: [
+    {
+      cssSelector: 'html',
+      htmlSnippet: '<html>',
+      rule: 'html-has-lang',
+      urls: [
+        'http://localhost:5858/',
+      ],
+    },
+    {
+      cssSelector: 'html',
+      htmlSnippet: '<html><head>\n        <title>Inner page</title>\n    </head>\n    <body>\n        <main>\n            <h1>Inner page with issues</h1>\n            <img id="non-decorative" src="./img1.png">\n            <a href="../">Back to home</a>\n        </main>\n    \n</body></html>',
+      rule: 'html-has-lang',
+      urls: [
+        'http://localhost:5858/linked1/inner-page',
+      ],
+    },
+    {
+      cssSelector: '#non-decorative',
+      htmlSnippet: '<img id="non-decorative" src="./img1.png">',
+      rule: 'image-alt',
+      urls: [
+        'http://localhost:5858/',
+        'http://localhost:5858/linked1/inner-page',
+      ],
+    },
+    {
+      cssSelector: '#input-radio-1',
+      htmlSnippet: '<input id="input-radio-1" type="radio" name="color" value="red" checked="">',
+      rule: 'label',
+      urls: [
+        'http://localhost:5858/',
+        'http://localhost:5858/linked1/inner-page',
+      ],
+    },
+    {
+      cssSelector: 'input[value="blue"]',
+      htmlSnippet: '<input type="radio" name="color" value="blue">',
+      rule: 'label',
+      urls: [
+        'http://localhost:5858/',
+      ],
+    },
+    {
+      cssSelector: 'input[value="purple"]',
+      htmlSnippet: '<input type="radio" name="color" value="purple">',
+      rule: 'label',
+      urls: [
+        'http://localhost:5858/',
+      ],
+    },
+    {
+      cssSelector: 'input[value="green"]',
+      htmlSnippet: '<input type="radio" name="color" value="green">',
+      rule: 'label',
+      urls: [
+        'http://localhost:5858/',
+      ],
+    },
+  ],
+}

--- a/license-check-and-add-config.json
+++ b/license-check-and-add-config.json
@@ -11,6 +11,7 @@
         "**/.gitattributes",
         "**/test-results",
         "**/dist",
+        "**/*.baseline",
         "**/*.snap",
         "**/*.snap.md",
         "**/*.taskkey",

--- a/pipelines/ado-extension-staging-validation.yaml
+++ b/pipelines/ado-extension-staging-validation.yaml
@@ -1,0 +1,126 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# This pipeline covers the staging scenarios for the ADO extension as triggered for
+# a PR/CI build of a GitHub repo. Note that release validation *also* requires covering
+# PR/CI scenarios as triggered from an ADO repo; see the release validation OneNote
+# template for details.
+
+# A CI build will be automatically kicked off when the "publish to staging" stage
+# of prod-release is run. A PR build which triggers this pipeline can be run be
+# creating a PR which touches any file under the "/dev" folder.
+
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - dev
+      - pipelines/ado-extension-staging-validation.yaml
+
+resources:
+  pipelines:
+  - pipeline: prod-release 
+    source: accessibility-insights-ado-extension-release-production 
+    trigger:    
+      stages:
+      - package_publish_staging
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+# reused by all "url" cases
+- script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &
+
+- displayName: '[should succeed] case 1: siteDir, no baseline'
+  task: accessibility-insights.staging.task.accessibility-insights@1
+  inputs:
+    siteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
+    # intentionally omits outputDir; should go to default _accessibility-reports
+  condition: succeededOrFailed()
+
+- displayName: 'case 1: upload report artifact'
+  publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports'  
+  artifact: 'accessibility-reports-case-1'
+  condition: succeededOrFailed()
+
+- displayName: '[should succeed] case 2: url, no baseline'
+  task: accessibility-insights.staging.task.accessibility-insights@1
+  inputs:
+    url: 'http://localhost:5858'
+    outputDir: '_accessibility-reports-case-2'
+  condition: succeededOrFailed()
+
+- displayName: 'case 2: upload report artifact'
+  publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-2'
+  artifact: 'accessibility-reports-case-2'
+  condition: succeededOrFailed()
+
+- displayName: '[should succeed] case 3: up-to-date baseline'
+  task: accessibility-insights.staging.task.accessibility-insights@1
+  inputs:
+    url: 'http://localhost:5858'
+    outputDir: '_accessibility-reports-case-3'
+    baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/up-to-date-5858.baseline'
+  condition: succeededOrFailed()
+
+- displayName: 'case 3: upload report artifact'
+  publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-3'
+  artifact: 'accessibility-reports-case-3'
+  condition: succeededOrFailed()
+
+- displayName: '[should fail] case 4: baseline missing failures'
+  task: accessibility-insights.staging.task.accessibility-insights@1
+  inputs:
+    url: 'http://localhost:5858'
+    outputDir: '_accessibility-reports-case-4'
+    baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/missing-failures-5858.baseline'
+  condition: succeededOrFailed()
+
+- displayName: 'case 4: upload report artifact'
+  publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-4'
+  artifact: 'accessibility-reports-case-4'
+  condition: succeededOrFailed()
+
+- displayName: '[should fail] case 5: baseline with resolved failures'
+  task: accessibility-insights.staging.task.accessibility-insights@1
+  inputs:
+    url: 'http://localhost:5858'
+    outputDir: '_accessibility-reports-case-5'
+    baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/with-resolved-failures-5858.baseline'
+  condition: succeededOrFailed()
+
+- displayName: 'case 5: upload report artifact'
+  publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-5'
+  artifact: 'accessibility-reports-case-5'
+  condition: succeededOrFailed()
+
+- displayName: '[should fail] case 6: new baseline file'
+  task: accessibility-insights.staging.task.accessibility-insights@1
+  inputs:
+    siteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
+    outputDir: '_accessibility-reports-case-6'
+    baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/doesnt-exist.baseline'
+  condition: succeededOrFailed()
+
+- displayName: 'case 6: upload report artifact'
+  publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-6'
+  artifact: 'accessibility-reports-case-6'
+  condition: succeededOrFailed()
+
+- displayName: '[should fail] case 7: failOnAccessibilityError'
+  task: accessibility-insights.staging.task.accessibility-insights@1
+  inputs:
+    url: 'http://localhost:5858'
+    failOnAccessibilityError: true
+    outputDir: '_accessibility-reports-case-7'
+  condition: succeededOrFailed()
+
+- displayName: 'case 7: upload report artifact'
+  publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-7'
+  artifact: 'accessibility-reports-case-7'
+  condition: succeededOrFailed()

--- a/pipelines/ado-extension-staging-validation.yaml
+++ b/pipelines/ado-extension-staging-validation.yaml
@@ -13,114 +13,114 @@
 trigger: none
 
 pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - dev
-      - pipelines/ado-extension-staging-validation.yaml
+    branches:
+        include:
+            - main
+    paths:
+        include:
+            - dev
+            - pipelines/ado-extension-staging-validation.yaml
 
 resources:
-  pipelines:
-  - pipeline: prod-release 
-    source: accessibility-insights-ado-extension-release-production 
-    trigger:    
-      stages:
-      - package_publish_staging
+    pipelines:
+        - pipeline: prod-release
+          source: accessibility-insights-ado-extension-release-production
+          trigger:
+              stages:
+                  - package_publish_staging
 
 pool:
-  vmImage: ubuntu-latest
+    vmImage: ubuntu-latest
 
 steps:
-# reused by all "url" cases
-- script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &
+    # reused by all "url" cases
+    - script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &
 
-- displayName: '[should succeed] case 1: siteDir, no baseline'
-  task: accessibility-insights.staging.task.accessibility-insights@1
-  inputs:
-    siteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
-    # intentionally omits outputDir; should go to default _accessibility-reports
-  condition: succeededOrFailed()
+    - displayName: '[should succeed] case 1: siteDir, no baseline'
+      task: accessibility-insights.staging.task.accessibility-insights@1
+      inputs:
+          siteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
+          # intentionally omits outputDir; should go to default _accessibility-reports
+      condition: succeededOrFailed()
 
-- displayName: 'case 1: upload report artifact'
-  publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports'  
-  artifact: 'accessibility-reports-case-1'
-  condition: succeededOrFailed()
+    - displayName: 'case 1: upload report artifact'
+      publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports'
+      artifact: 'accessibility-reports-case-1'
+      condition: succeededOrFailed()
 
-- displayName: '[should succeed] case 2: url, no baseline'
-  task: accessibility-insights.staging.task.accessibility-insights@1
-  inputs:
-    url: 'http://localhost:5858'
-    outputDir: '_accessibility-reports-case-2'
-  condition: succeededOrFailed()
+    - displayName: '[should succeed] case 2: url, no baseline'
+      task: accessibility-insights.staging.task.accessibility-insights@1
+      inputs:
+          url: 'http://localhost:5858'
+          outputDir: '_accessibility-reports-case-2'
+      condition: succeededOrFailed()
 
-- displayName: 'case 2: upload report artifact'
-  publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-2'
-  artifact: 'accessibility-reports-case-2'
-  condition: succeededOrFailed()
+    - displayName: 'case 2: upload report artifact'
+      publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-2'
+      artifact: 'accessibility-reports-case-2'
+      condition: succeededOrFailed()
 
-- displayName: '[should succeed] case 3: up-to-date baseline'
-  task: accessibility-insights.staging.task.accessibility-insights@1
-  inputs:
-    url: 'http://localhost:5858'
-    outputDir: '_accessibility-reports-case-3'
-    baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/up-to-date-5858.baseline'
-  condition: succeededOrFailed()
+    - displayName: '[should succeed] case 3: up-to-date baseline'
+      task: accessibility-insights.staging.task.accessibility-insights@1
+      inputs:
+          url: 'http://localhost:5858'
+          outputDir: '_accessibility-reports-case-3'
+          baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/up-to-date-5858.baseline'
+      condition: succeededOrFailed()
 
-- displayName: 'case 3: upload report artifact'
-  publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-3'
-  artifact: 'accessibility-reports-case-3'
-  condition: succeededOrFailed()
+    - displayName: 'case 3: upload report artifact'
+      publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-3'
+      artifact: 'accessibility-reports-case-3'
+      condition: succeededOrFailed()
 
-- displayName: '[should fail] case 4: baseline missing failures'
-  task: accessibility-insights.staging.task.accessibility-insights@1
-  inputs:
-    url: 'http://localhost:5858'
-    outputDir: '_accessibility-reports-case-4'
-    baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/missing-failures-5858.baseline'
-  condition: succeededOrFailed()
+    - displayName: '[should fail] case 4: baseline missing failures'
+      task: accessibility-insights.staging.task.accessibility-insights@1
+      inputs:
+          url: 'http://localhost:5858'
+          outputDir: '_accessibility-reports-case-4'
+          baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/missing-failures-5858.baseline'
+      condition: succeededOrFailed()
 
-- displayName: 'case 4: upload report artifact'
-  publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-4'
-  artifact: 'accessibility-reports-case-4'
-  condition: succeededOrFailed()
+    - displayName: 'case 4: upload report artifact'
+      publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-4'
+      artifact: 'accessibility-reports-case-4'
+      condition: succeededOrFailed()
 
-- displayName: '[should fail] case 5: baseline with resolved failures'
-  task: accessibility-insights.staging.task.accessibility-insights@1
-  inputs:
-    url: 'http://localhost:5858'
-    outputDir: '_accessibility-reports-case-5'
-    baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/with-resolved-failures-5858.baseline'
-  condition: succeededOrFailed()
+    - displayName: '[should fail] case 5: baseline with resolved failures'
+      task: accessibility-insights.staging.task.accessibility-insights@1
+      inputs:
+          url: 'http://localhost:5858'
+          outputDir: '_accessibility-reports-case-5'
+          baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/with-resolved-failures-5858.baseline'
+      condition: succeededOrFailed()
 
-- displayName: 'case 5: upload report artifact'
-  publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-5'
-  artifact: 'accessibility-reports-case-5'
-  condition: succeededOrFailed()
+    - displayName: 'case 5: upload report artifact'
+      publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-5'
+      artifact: 'accessibility-reports-case-5'
+      condition: succeededOrFailed()
 
-- displayName: '[should fail] case 6: new baseline file'
-  task: accessibility-insights.staging.task.accessibility-insights@1
-  inputs:
-    siteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
-    outputDir: '_accessibility-reports-case-6'
-    baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/doesnt-exist.baseline'
-  condition: succeededOrFailed()
+    - displayName: '[should fail] case 6: new baseline file'
+      task: accessibility-insights.staging.task.accessibility-insights@1
+      inputs:
+          siteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
+          outputDir: '_accessibility-reports-case-6'
+          baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/doesnt-exist.baseline'
+      condition: succeededOrFailed()
 
-- displayName: 'case 6: upload report artifact'
-  publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-6'
-  artifact: 'accessibility-reports-case-6'
-  condition: succeededOrFailed()
+    - displayName: 'case 6: upload report artifact'
+      publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-6'
+      artifact: 'accessibility-reports-case-6'
+      condition: succeededOrFailed()
 
-- displayName: '[should fail] case 7: failOnAccessibilityError'
-  task: accessibility-insights.staging.task.accessibility-insights@1
-  inputs:
-    url: 'http://localhost:5858'
-    failOnAccessibilityError: true
-    outputDir: '_accessibility-reports-case-7'
-  condition: succeededOrFailed()
+    - displayName: '[should fail] case 7: failOnAccessibilityError'
+      task: accessibility-insights.staging.task.accessibility-insights@1
+      inputs:
+          url: 'http://localhost:5858'
+          failOnAccessibilityError: true
+          outputDir: '_accessibility-reports-case-7'
+      condition: succeededOrFailed()
 
-- displayName: 'case 7: upload report artifact'
-  publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-7'
-  artifact: 'accessibility-reports-case-7'
-  condition: succeededOrFailed()
+    - displayName: 'case 7: upload report artifact'
+      publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-7'
+      artifact: 'accessibility-reports-case-7'
+      condition: succeededOrFailed()


### PR DESCRIPTION
#### Details

This PR adds partial automation for the e2e release validation scenarios for the ADO extension. Once this is merged, the intention is to update the `Verify ADO extension works when codebase is in GitHub` release validation scenario to read something like this:

```
## ADO extension CI scenarios with GitHub repo

- [ ] Find the `ado-extension-github-repo-staging-validation` CI build corresponding to this staging release from [the list of builds](https://example.com/link/to/definition). Paste a link to it here: <INSERT LINK>
- For each of the test cases run by the build, verify that it succeeds or fails appropriately, that it produces a reasonable-looking report in its corresponding build artifact, that task log output looks reasonable, and that it produces the expected updated baseline file (if applicable).
  - [ ] [should succeed] case 1: siteDir, no baseline
  - [ ] [should succeed] case 2: url, no baseline
  - [ ] [should succeed] case 3: up-to-date baseline
  - [ ] [should fail] case 4: baseline missing failures
  - [ ] [should fail] case 5: baseline with resolved failures
  - [ ] [should fail] case 6: new baseline file
  - [ ] [should fail] case 7: failOnAccessibilityError

## ADO extension PR scenarios with GitHub repo

- [ ] Create a new draft PR in the `microsoft/accessibility-insights-action` repo which makes a no-op change to `/dev/README.md`
- [ ] This should trigger an `ado-extension-github-repo-staging-validation` PR build. Paste a link to the PR build here: <INSERT LINK>
- For each of the test cases run by the build, verify that it succeeds or fails appropriately, that it produces a reasonable-looking report in its corresponding build artifact, that task log output looks reasonable, and that it produces the expected updated baseline file (if applicable).
  - [ ] [should succeed] case 1: siteDir, no baseline
  - [ ] [should succeed] case 2: url, no baseline
  - [ ] [should succeed] case 3: up-to-date baseline
  - [ ] [should fail] case 4: baseline missing failures
  - [ ] [should fail] case 5: baseline with resolved failures
  - [ ] [should fail] case 6: new baseline file
  - [ ] [should fail] case 7: failOnAccessibilityError
```

##### Motivation

Make ADO release process more automated

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
