### PR TITLE
fix(ado-extension): failure counts in PR comment

### DIFF
--- a/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
+++ b/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
@@ -43,8 +43,8 @@ You can review the log to troubleshoot the issue. Fix it and re-run the workflow
 exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and new failures 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
 
-**4 failure instances not in baseline**
-* (3) **rule id**:  rule description
+**3 failure instances not in baseline**
+* (2) **rule id**:  rule description
 * (1) **rule id 2**:  rule description 2
 
 **1 failure instances in baseline**
@@ -175,7 +175,7 @@ No failures were detected by automatic scanning.
 **Baseline not detected**
 To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
 
-See all failures and scan details by downloading the report from [run artifacts](artifacts-url)
+See scan details by downloading the report from [run artifacts](artifacts-url)
 
 ---
 #### Scan summary

--- a/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
+++ b/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
@@ -25,8 +25,8 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 exports[`ResultMarkdownBuilder builds content with title 1`] = `
 "### some title
 ### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action: All applicable checks passed
-* **URLs**: 0 URL(s) passed, and 0 were not scannable
-* **Rules**: 0 check(s) passed, and 0 were not applicable
+* **URLs**: 1 URL(s) passed, and 7 were not scannable
+* **Rules**: 1 check(s) passed, and 2 were not applicable
 * Download the **Accessibility Insights artifact** to view the detailed results of these checks
 ---
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
@@ -38,6 +38,27 @@ You can review the log to troubleshoot the issue. Fix it and re-run the workflow
 
 ---
 "
+`;
+
+exports[`ResultMarkdownBuilder with baseline builds content when baseline failures and scanned failures are the same (no new failures) 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
+**:white_check_mark: No new failures**
+No failures were detected by automatic scanning except those which exist in the baseline.
+
+**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+
+**6 failure instances in baseline**
+(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file))
+
+See all failures and scan details by downloading the report from [run artifacts](artifacts-url)
+
+---
+#### Scan summary
+**URLs**: 5 with failures, 1 passed, 7 not scannable
+**Rules**: 4 with failures, 1 passed, 2 not applicable
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
 exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and new failures 1`] = `
@@ -61,7 +82,7 @@ See all failures and scan details by downloading the report from [run artifacts]
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and no new failures 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and no additional failures 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
 **:white_check_mark: No new failures**
 No failures were detected by automatic scanning except those which exist in the baseline.
@@ -75,8 +96,8 @@ See all failures and scan details by downloading the report from [run artifacts]
 
 ---
 #### Scan summary
-**URLs**: 0 with failures, 0 passed, 0 not scannable
-**Rules**: 0 with failures, 0 passed, 0 not applicable
+**URLs**: 0 with failures, 1 passed, 7 not scannable
+**Rules**: 0 with failures, 1 passed, 2 not applicable
 
 ---
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
@@ -158,8 +179,8 @@ See scan details by downloading the report from [run artifacts](artifacts-url)
 
 ---
 #### Scan summary
-**URLs**: 0 with failures, 0 passed, 0 not scannable
-**Rules**: 0 with failures, 0 passed, 0 not applicable
+**URLs**: 0 with failures, 1 passed, 7 not scannable
+**Rules**: 0 with failures, 1 passed, 2 not applicable
 
 ---
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
@@ -179,8 +200,8 @@ See scan details by downloading the report from [run artifacts](artifacts-url)
 
 ---
 #### Scan summary
-**URLs**: 0 with failures, 0 passed, 0 not scannable
-**Rules**: 0 with failures, 0 passed, 0 not applicable
+**URLs**: 0 with failures, 1 passed, 7 not scannable
+**Rules**: 0 with failures, 1 passed, 2 not applicable
 
 ---
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."

--- a/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
+++ b/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
@@ -85,8 +85,8 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 exports[`ResultMarkdownBuilder with baseline builds content when there are new failures and no baseline detected 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
 
-**4 failure instances**
-* (3) **rule id**:  rule description
+**6 failure instances**
+* (5) **rule id**:  rule description
 * (1) **rule id 2**:  rule description 2
 
 **Baseline not detected**
@@ -106,8 +106,8 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 exports[`ResultMarkdownBuilder with baseline builds content when there are new failures and no baseline failures 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
 
-**4 failure instances**
-* (3) **rule id**:  rule description
+**6 failure instances**
+* (5) **rule id**:  rule description
 * (1) **rule id 2**:  rule description 2
 
 **Baseline not detected**
@@ -189,8 +189,8 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 exports[`ResultMarkdownBuilder with baseline builds content when there is no baseline configured 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
 
-**4 failure instances**
-* (3) **rule id**:  rule description
+**6 failure instances**
+* (5) **rule id**:  rule description
 * (1) **rule id 2**:  rule description 2
 
 **Baseline not configured**

--- a/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
+++ b/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
@@ -43,11 +43,11 @@ You can review the log to troubleshoot the issue. Fix it and re-run the workflow
 exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and new failures 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
 
-**3 failure instances not in baseline**
-* (2) **rule id**:  rule description
+**4 failure instances not in baseline**
+* (3) **rule id**:  rule description
 * (1) **rule id 2**:  rule description 2
 
-**1 failure instances in baseline**
+**2 failure instances in baseline**
 (not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to include new failures into the baseline)
 
 See all failures and scan details by downloading the report from [run artifacts](artifacts-url)

--- a/packages/shared/src/mark-down/result-markdown-builder.spec.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.spec.ts
@@ -26,29 +26,7 @@ describe(ResultMarkdownBuilder, () => {
     });
 
     it('builds content with failures', () => {
-        combinedReportResult = {
-            axeVersion: 'axeVersion',
-            userAgent: 'userAgent',
-            results: {
-                resultsByRule: {
-                    failed: [
-                        {
-                            failed: [{ rule: { ruleId: 'rule id', description: 'rule description' } }, {}, {}],
-                        },
-                        {
-                            failed: [{ rule: { ruleId: 'rule id 2', description: 'rule description 2' } }],
-                        },
-                    ],
-                    passed: [{}],
-                    notApplicable: [{}, {}],
-                },
-                urlResults: {
-                    passedUrls: 1,
-                    failedUrls: 5,
-                    unscannableUrls: 7,
-                },
-            },
-        } as CombinedReportParameters;
+        setCombinedReportResultWithFailures();
 
         const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult);
 
@@ -56,22 +34,7 @@ describe(ResultMarkdownBuilder, () => {
     });
 
     it('builds content with no failures', () => {
-        combinedReportResult = {
-            axeVersion: 'axeVersion',
-            userAgent: 'userAgent',
-            results: {
-                resultsByRule: {
-                    failed: [],
-                    passed: [{}],
-                    notApplicable: [{}, {}],
-                },
-                urlResults: {
-                    passedUrls: 1,
-                    failedUrls: 0,
-                    unscannableUrls: 7,
-                },
-            },
-        } as CombinedReportParameters;
+        setCombinedReportResultWithNoFailures();
 
         const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult);
 
@@ -111,22 +74,7 @@ describe(ResultMarkdownBuilder, () => {
 
     it('builds content with title', () => {
         const title = 'some title';
-        combinedReportResult = {
-            axeVersion: 'axeVersion',
-            userAgent: 'userAgent',
-            results: {
-                resultsByRule: {
-                    failed: [],
-                    passed: [],
-                    notApplicable: [],
-                },
-                urlResults: {
-                    passedUrls: 0,
-                    failedUrls: 0,
-                    unscannableUrls: 0,
-                },
-            },
-        } as CombinedReportParameters;
+        setCombinedReportResultWithNoFailures();
 
         const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, title);
 
@@ -161,30 +109,33 @@ describe(ResultMarkdownBuilder, () => {
             verifyAllMocks();
         });
 
-        it('builds content when there are baseline failures and no new failures', () => {
+        it('builds content when baseline failures and scanned failures are the same (no new failures)', () => {
             const baselineEvaluation = {
-                totalBaselineViolations: 1,
+                totalBaselineViolations: 6,
+                totalNewViolations: 0,
             } as BaselineEvaluation;
             const baselineInfo: BaselineInfo = {
                 baselineFileName,
                 baselineEvaluation,
             };
-            combinedReportResult = {
-                axeVersion: 'axeVersion',
-                userAgent: 'userAgent',
-                results: {
-                    resultsByRule: {
-                        failed: [],
-                        passed: [],
-                        notApplicable: [],
-                    },
-                    urlResults: {
-                        passedUrls: 0,
-                        failedUrls: 0,
-                        unscannableUrls: 0,
-                    },
-                },
-            } as CombinedReportParameters;
+            setCombinedReportResultWithFailures();
+
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
+
+        it('builds content when there are baseline failures and no additional failures', () => {
+            const baselineEvaluation = {
+                totalBaselineViolations: 1,
+                totalNewViolations: 0,
+            } as BaselineEvaluation;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithNoFailures();
 
             const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
@@ -200,22 +151,7 @@ describe(ResultMarkdownBuilder, () => {
                 baselineFileName,
                 baselineEvaluation,
             };
-            combinedReportResult = {
-                axeVersion: 'axeVersion',
-                userAgent: 'userAgent',
-                results: {
-                    resultsByRule: {
-                        failed: [],
-                        passed: [{}],
-                        notApplicable: [{}, {}],
-                    },
-                    urlResults: {
-                        passedUrls: 1,
-                        failedUrls: 0,
-                        unscannableUrls: 7,
-                    },
-                },
-            } as CombinedReportParameters;
+            setCombinedReportResultWithNoFailures();
 
             const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
@@ -247,22 +183,7 @@ describe(ResultMarkdownBuilder, () => {
                 baselineFileName,
                 baselineEvaluation,
             };
-            combinedReportResult = {
-                axeVersion: 'axeVersion',
-                userAgent: 'userAgent',
-                results: {
-                    resultsByRule: {
-                        failed: [],
-                        passed: [],
-                        notApplicable: [],
-                    },
-                    urlResults: {
-                        passedUrls: 0,
-                        failedUrls: 0,
-                        unscannableUrls: 0,
-                    },
-                },
-            } as CombinedReportParameters;
+            setCombinedReportResultWithNoFailures();
 
             const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
@@ -307,22 +228,7 @@ describe(ResultMarkdownBuilder, () => {
                 baselineFileName,
                 baselineEvaluation,
             };
-            combinedReportResult = {
-                axeVersion: 'axeVersion',
-                userAgent: 'userAgent',
-                results: {
-                    resultsByRule: {
-                        failed: [],
-                        passed: [],
-                        notApplicable: [],
-                    },
-                    urlResults: {
-                        passedUrls: 0,
-                        failedUrls: 0,
-                        unscannableUrls: 0,
-                    },
-                },
-            } as CombinedReportParameters;
+            setCombinedReportResultWithNoFailures();
 
             const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
@@ -361,6 +267,25 @@ describe(ResultMarkdownBuilder, () => {
             },
         } as CombinedReportParameters;
     };
+
+    const setCombinedReportResultWithNoFailures = (): void => {
+        combinedReportResult = {
+            axeVersion: 'axeVersion',
+            userAgent: 'userAgent',
+            results: {
+                resultsByRule: {
+                    failed: [],
+                    passed: [{}],
+                    notApplicable: [{}, {}],
+                },
+                urlResults: {
+                    passedUrls: 1,
+                    failedUrls: 0,
+                    unscannableUrls: 7,
+                },
+            },
+        } as CombinedReportParameters;
+    }
 
     const verifyAllMocks = (): void => {
         artifactsInfoProviderMock.verifyAll();

--- a/packages/shared/src/mark-down/result-markdown-builder.spec.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.spec.ts
@@ -145,9 +145,9 @@ describe(ResultMarkdownBuilder, () => {
 
         it('builds content when there are baseline failures and new failures', () => {
             const baselineEvaluation = {
-                totalBaselineViolations: 1,
-                totalNewViolations: 3,
-                newViolationsByRule: { 'rule id': 2, 'rule id 2': 1 } as CountsByRule,
+                totalBaselineViolations: 2,
+                totalNewViolations: 4,
+                newViolationsByRule: { 'rule id': 3, 'rule id 2': 1 } as CountsByRule,
             } as BaselineEvaluation;
             const baselineInfo: BaselineInfo = {
                 baselineFileName,

--- a/packages/shared/src/mark-down/result-markdown-builder.spec.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.spec.ts
@@ -285,7 +285,7 @@ describe(ResultMarkdownBuilder, () => {
                 },
             },
         } as CombinedReportParameters;
-    }
+    };
 
     const verifyAllMocks = (): void => {
         artifactsInfoProviderMock.verifyAll();

--- a/packages/shared/src/mark-down/result-markdown-builder.spec.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.spec.ts
@@ -153,29 +153,7 @@ describe(ResultMarkdownBuilder, () => {
                 baselineFileName,
                 baselineEvaluation,
             };
-            combinedReportResult = {
-                axeVersion: 'axeVersion',
-                userAgent: 'userAgent',
-                results: {
-                    resultsByRule: {
-                        failed: [
-                            {
-                                failed: [{ rule: { ruleId: 'rule id', description: 'rule description' } }, {}, {}],
-                            },
-                            {
-                                failed: [{ rule: { ruleId: 'rule id 2', description: 'rule description 2' } }],
-                            },
-                        ],
-                        passed: [{}],
-                        notApplicable: [{}, {}],
-                    },
-                    urlResults: {
-                        passedUrls: 1,
-                        failedUrls: 5,
-                        unscannableUrls: 7,
-                    },
-                },
-            } as CombinedReportParameters;
+            setCombinedReportResultWithFailures();
 
             const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
@@ -248,36 +226,14 @@ describe(ResultMarkdownBuilder, () => {
         it('builds content when there are new failures and no baseline failures', () => {
             const baselineEvaluation = {
                 totalBaselineViolations: 0,
-                totalNewViolations: 4,
-                newViolationsByRule: { 'rule id': 3, 'rule id 2': 1 } as CountsByRule,
+                totalNewViolations: 6,
+                newViolationsByRule: { 'rule id': 5, 'rule id 2': 1 } as CountsByRule,
             } as BaselineEvaluation;
             const baselineInfo: BaselineInfo = {
                 baselineFileName,
                 baselineEvaluation,
             };
-            combinedReportResult = {
-                axeVersion: 'axeVersion',
-                userAgent: 'userAgent',
-                results: {
-                    resultsByRule: {
-                        failed: [
-                            {
-                                failed: [{ rule: { ruleId: 'rule id', description: 'rule description' } }, {}, {}],
-                            },
-                            {
-                                failed: [{ rule: { ruleId: 'rule id 2', description: 'rule description 2' } }],
-                            },
-                        ],
-                        passed: [{}],
-                        notApplicable: [{}, {}],
-                    },
-                    urlResults: {
-                        passedUrls: 1,
-                        failedUrls: 5,
-                        unscannableUrls: 7,
-                    },
-                },
-            } as CombinedReportParameters;
+            setCombinedReportResultWithFailures();
 
             const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
@@ -320,29 +276,7 @@ describe(ResultMarkdownBuilder, () => {
                 baselineFileName,
                 baselineEvaluation,
             };
-            combinedReportResult = {
-                axeVersion: 'axeVersion',
-                userAgent: 'userAgent',
-                results: {
-                    resultsByRule: {
-                        failed: [
-                            {
-                                failed: [{ rule: { ruleId: 'rule id', description: 'rule description' } }, {}, {}],
-                            },
-                            {
-                                failed: [{ rule: { ruleId: 'rule id 2', description: 'rule description 2' } }],
-                            },
-                        ],
-                        passed: [{}],
-                        notApplicable: [{}, {}],
-                    },
-                    urlResults: {
-                        passedUrls: 1,
-                        failedUrls: 5,
-                        unscannableUrls: 7,
-                    },
-                },
-            } as CombinedReportParameters;
+            setCombinedReportResultWithFailures();
 
             const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
@@ -357,29 +291,7 @@ describe(ResultMarkdownBuilder, () => {
                 baselineFileName,
                 baselineEvaluation,
             };
-            combinedReportResult = {
-                axeVersion: 'axeVersion',
-                userAgent: 'userAgent',
-                results: {
-                    resultsByRule: {
-                        failed: [
-                            {
-                                failed: [{ rule: { ruleId: 'rule id', description: 'rule description' } }, {}, {}],
-                            },
-                            {
-                                failed: [{ rule: { ruleId: 'rule id 2', description: 'rule description 2' } }],
-                            },
-                        ],
-                        passed: [{}],
-                        notApplicable: [{}, {}],
-                    },
-                    urlResults: {
-                        passedUrls: 1,
-                        failedUrls: 5,
-                        unscannableUrls: 7,
-                    },
-                },
-            } as CombinedReportParameters;
+            setCombinedReportResultWithFailures();
 
             const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
@@ -418,6 +330,37 @@ describe(ResultMarkdownBuilder, () => {
             verifyAllMocks();
         });
     });
+
+    const setCombinedReportResultWithFailures = (): void => {
+        const ruleInfo1 = { ruleId: 'rule id', description: 'rule description' };
+        combinedReportResult = {
+            axeVersion: 'axeVersion',
+            userAgent: 'userAgent',
+            results: {
+                resultsByRule: {
+                    failed: [
+                        {
+                            failed: [
+                                { rule: ruleInfo1, urls: ['url 1', 'url 2'] },
+                                { rule: ruleInfo1, urls: ['url 1'] },
+                                { rule: ruleInfo1, urls: ['url 3', 'url 4'] },
+                            ],
+                        },
+                        {
+                            failed: [{ rule: { ruleId: 'rule id 2', description: 'rule description 2' }, urls: ['url 5'] }],
+                        },
+                    ],
+                    passed: [{}],
+                    notApplicable: [{}, {}],
+                },
+                urlResults: {
+                    passedUrls: 1,
+                    failedUrls: 5,
+                    unscannableUrls: 7,
+                },
+            },
+        } as CombinedReportParameters;
+    };
 
     const verifyAllMocks = (): void => {
         artifactsInfoProviderMock.verifyAll();

--- a/packages/shared/src/mark-down/result-markdown-builder.spec.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.spec.ts
@@ -6,7 +6,7 @@ import { ResultMarkdownBuilder } from './result-markdown-builder';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 import * as axe from 'axe-core';
 import * as path from 'path';
-import { BaselineEvaluation } from 'accessibility-insights-scan';
+import { BaselineEvaluation, CountsByRule } from 'accessibility-insights-scan';
 import { BaselineInfo } from '../baseline-info';
 import { ArtifactsInfoProvider } from '../artifacts-info-provider';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
@@ -146,6 +146,8 @@ describe(ResultMarkdownBuilder, () => {
         it('builds content when there are baseline failures and new failures', () => {
             const baselineEvaluation = {
                 totalBaselineViolations: 1,
+                totalNewViolations: 3,
+                newViolationsByRule: { 'rule id': 2, 'rule id 2': 1 } as CountsByRule,
             } as BaselineEvaluation;
             const baselineInfo: BaselineInfo = {
                 baselineFileName,
@@ -246,6 +248,8 @@ describe(ResultMarkdownBuilder, () => {
         it('builds content when there are new failures and no baseline failures', () => {
             const baselineEvaluation = {
                 totalBaselineViolations: 0,
+                totalNewViolations: 4,
+                newViolationsByRule: { 'rule id': 3, 'rule id 2': 1 } as CountsByRule,
             } as BaselineEvaluation;
             const baselineInfo: BaselineInfo = {
                 baselineFileName,


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Fixes the failure counts showing in the ADO PR comments. There was some refactoring done as well in result-markdown-builder.ts and its corresponding test file.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Addresses #945 

##### Context
PR comment screenshots:
1. Baseline file configured, no baseline file added to repo
![image](https://user-images.githubusercontent.com/48259897/139960186-be69aa54-8e30-456e-a29f-e05402da75b0.png)
2. Generated baseline file from (1) added to the repo, with previous comment below it as a child comment
![image](https://user-images.githubusercontent.com/48259897/139960616-6044e09d-480c-4cce-a7f4-57a54b27f808.png)
3. Baseline file with fewer failure instances than found in current scan (scenario where errors were introduced)
![image](https://user-images.githubusercontent.com/48259897/139964066-202a9bd2-7f99-44b1-adbb-027140387b18.png)
4. Baseline file with more failure instances than found in current scan (assume errors were fixed)
![image](https://user-images.githubusercontent.com/48259897/139963896-893907f9-1f16-4f22-8570-0ef7ab35fdc8.png)
5. Removed baselineFile input from yml (baseline not configured)
![image](https://user-images.githubusercontent.com/48259897/139962293-6ed703cb-d833-4bbb-9618-6b7014cda805.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes #945
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
