### PR TITLE
fix: Add missing PR scenarios

### DIFF
--- a/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
+++ b/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
@@ -42,6 +42,7 @@ You can review the log to troubleshoot the issue. Fix it and re-run the workflow
 
 exports[`ResultMarkdownBuilder with baseline builds content when baseline failures and scanned failures are the same (no new failures) 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
+
 **:white_check_mark: No new failures**
 No failures were detected by automatic scanning except those which exist in the baseline.
 
@@ -66,7 +67,6 @@ exports[`ResultMarkdownBuilder with baseline builds content when some baseline f
 **3 failure instances from baseline no longer exist:**
 * (2) **rule id**
 * (1) **rule id 2**
-
 
 **1 failure instances not in baseline**
 * (1) **rule id**:  rule description
@@ -133,6 +133,7 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 
 exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and no additional failures 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
+
 **:white_check_mark: No new failures**
 No failures were detected by automatic scanning except those which exist in the baseline.
 
@@ -196,6 +197,7 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 
 exports[`ResultMarkdownBuilder with baseline builds content when there are no baseline failures and no new failures 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
+
 **:white_check_mark: No failures detected**
 No failures were detected by automatic scanning.
 
@@ -216,6 +218,7 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 
 exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and baseline failures are undefined 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
+
 **:white_check_mark: No failures detected**
 No failures were detected by automatic scanning.
 
@@ -237,6 +240,7 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 
 exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and no baseline detected 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
+
 **:white_check_mark: No failures detected**
 No failures were detected by automatic scanning.
 

--- a/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
+++ b/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
@@ -61,6 +61,55 @@ See all failures and scan details by downloading the report from [run artifacts]
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
+exports[`ResultMarkdownBuilder with baseline builds content when some baseline failures have been fixed and some new ones have been introduced 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
+**3 failure instances from baseline no longer exist:**
+* (2) **rule id**
+* (1) **rule id 2**
+
+
+**1 failure instances not in baseline**
+* (1) **rule id**:  rule description
+
+**9 failure instances in baseline**
+(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
+
+See all failures and scan details by downloading the report from [run artifacts](artifacts-url)
+
+---
+#### Scan summary
+**URLs**: 5 with failures, 1 passed, 7 not scannable
+**Rules**: 4 with failures, 1 passed, 2 not applicable
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
+exports[`ResultMarkdownBuilder with baseline builds content when some baseline failures have been fixed and some still occur 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
+**3 failure instances from baseline no longer exist:**
+* (2) **rule id**
+* (1) **rule id 2**
+
+**:white_check_mark: No new failures**
+No failures were detected by automatic scanning except those which exist in the baseline.
+
+**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+
+**9 failure instances in baseline**
+(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
+
+See all failures and scan details by downloading the report from [run artifacts](artifacts-url)
+
+---
+#### Scan summary
+**URLs**: 5 with failures, 1 passed, 7 not scannable
+**Rules**: 4 with failures, 1 passed, 2 not applicable
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
 exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and new failures 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
 
@@ -69,7 +118,7 @@ exports[`ResultMarkdownBuilder with baseline builds content when there are basel
 * (1) **rule id 2**:  rule description 2
 
 **2 failure instances in baseline**
-(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to include new failures into the baseline)
+(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
 
 See all failures and scan details by downloading the report from [run artifacts](artifacts-url)
 

--- a/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
+++ b/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
@@ -91,10 +91,7 @@ exports[`ResultMarkdownBuilder with baseline builds content when some baseline f
 * (2) **rule id**
 * (1) **rule id 2**
 
-**:white_check_mark: No new failures**
-No failures were detected by automatic scanning except those which exist in the baseline.
-
-**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+**0 failure instances not in baseline**
 
 **9 failure instances in baseline**
 (not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)

--- a/packages/shared/src/mark-down/result-markdown-builder.spec.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.spec.ts
@@ -93,6 +93,7 @@ describe(ResultMarkdownBuilder, () => {
 
         it('builds content when there are baseline failures and new failures', () => {
             const baselineEvaluation = {
+                suggestedBaselineUpdate: {},
                 totalBaselineViolations: 2,
                 totalNewViolations: 4,
                 newViolationsByRule: { 'rule id': 3, 'rule id 2': 1 } as CountsByRule,
@@ -128,9 +129,11 @@ describe(ResultMarkdownBuilder, () => {
 
         it('builds content when some baseline failures have been fixed and some still occur', () => {
             const baselineEvaluation = {
+                suggestedBaselineUpdate: {},
                 totalBaselineViolations: 9,
                 totalNewViolations: 0,
                 fixedViolationsByRule: { 'rule id': 2, 'rule id 2': 1 } as CountsByRule,
+                totalFixedViolations: 3,
             } as BaselineEvaluation;
             const baselineInfo: BaselineInfo = {
                 baselineFileName,
@@ -146,6 +149,7 @@ describe(ResultMarkdownBuilder, () => {
 
         it('builds content when some baseline failures have been fixed and some new ones have been introduced', () => {
             const baselineEvaluation = {
+                suggestedBaselineUpdate: {},
                 totalBaselineViolations: 9,
                 fixedViolationsByRule: { 'rule id': 2, 'rule id 2': 1 } as CountsByRule,
                 totalNewViolations: 1,

--- a/packages/shared/src/mark-down/result-markdown-builder.spec.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.spec.ts
@@ -126,6 +126,43 @@ describe(ResultMarkdownBuilder, () => {
             verifyAllMocks();
         });
 
+        it('builds content when some baseline failures have been fixed and some still occur', () => {
+            const baselineEvaluation = {
+                totalBaselineViolations: 9,
+                totalNewViolations: 0,
+                fixedViolationsByRule: { 'rule id': 2, 'rule id 2': 1 } as CountsByRule,
+            } as BaselineEvaluation;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithFailures();
+
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
+
+        it('builds content when some baseline failures have been fixed and some new ones have been introduced', () => {
+            const baselineEvaluation = {
+                totalBaselineViolations: 9,
+                fixedViolationsByRule: { 'rule id': 2, 'rule id 2': 1 } as CountsByRule,
+                totalNewViolations: 1,
+                newViolationsByRule: { 'rule id': 1 } as CountsByRule,
+            } as BaselineEvaluation;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithFailures();
+
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
+
         it('builds content when there are baseline failures and no additional failures', () => {
             const baselineEvaluation = {
                 totalBaselineViolations: 1,

--- a/packages/shared/src/mark-down/result-markdown-builder.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.ts
@@ -51,7 +51,6 @@ export class ResultMarkdownBuilder {
             lines = [
                 this.headingWithMessage(),
                 this.fixedFailureDetails(baselineInfo),
-                sectionSeparator(),
                 this.failureDetailsBaseline(combinedReportResult, baselineInfo),
                 sectionSeparator(),
                 this.baselineDetails(baselineInfo),
@@ -183,7 +182,7 @@ export class ResultMarkdownBuilder {
     private fixedFailureDetails = (baselineInfo: BaselineInfo): string => {
         if (!baselineInfo || 
             !this.hasFixedFailureResults(baselineInfo.baselineEvaluation)) {
-            return '';
+            return sectionSeparator();
         }
         
         let totalFixedFailureInstanceCount = 0;
@@ -211,7 +210,7 @@ export class ResultMarkdownBuilder {
             const failureInstancesHeading = this.getFailureInstancesHeading(failureInstances, baselineInfo.baselineEvaluation);
             lines = [sectionSeparator(), bold(failureInstancesHeading), sectionSeparator(), ...failedRulesList];
         } else {
-            lines = this.getNoFailuresText(baselineInfo.baselineEvaluation);
+            lines = [sectionSeparator(), ...this.getNoFailuresText(baselineInfo.baselineEvaluation)];
         }
 
         return lines.join('');

--- a/packages/shared/src/mark-down/result-markdown-builder.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.ts
@@ -107,7 +107,7 @@ export class ResultMarkdownBuilder {
             const baselineFailures = baselineEvaluation.totalBaselineViolations;
             if (baselineFailures === undefined || (baselineFailures === 0 && newFailures > 0)) {
                 lines = [bold('Baseline not detected'), sectionSeparator(), baselineNotDetectedHelpText];
-            } else if (baselineFailures > 0) {
+            } else if (baselineFailures > 0 || this.shouldUpdateBaselineFile(baselineEvaluation)) {
                 const headingWithBaselineFailures = `${baselineFailures} failure instances in baseline`;
                 let baselineFailuresHelpText = `not shown; see ${baseliningDocsLink}`;
                 if (this.shouldUpdateBaselineFile(baselineEvaluation)) {
@@ -121,7 +121,7 @@ export class ResultMarkdownBuilder {
     };
 
     private shouldUpdateBaselineFile(baselineEvaluation: BaselineEvaluation): boolean {
-        return baselineEvaluation.totalNewViolations > 0 || this.hasFixedFailureResults(baselineEvaluation);
+        return (baselineEvaluation && baselineEvaluation.suggestedBaselineUpdate) ? true : false;
     }
 
     private hasFixedFailureResults(baselineEvaluation: BaselineEvaluation): boolean {
@@ -205,7 +205,8 @@ export class ResultMarkdownBuilder {
 
     private failureDetailsBaseline = (combinedReportResult: CombinedReportParameters, baselineInfo: BaselineInfo): string => {
         let lines = [];
-        if (this.hasFailures(combinedReportResult, baselineInfo.baselineEvaluation)) {
+        if (this.hasFailures(combinedReportResult, baselineInfo.baselineEvaluation) ||
+            this.shouldUpdateBaselineFile(baselineInfo.baselineEvaluation)) {
             const failedRulesList = this.getFailedRulesList(combinedReportResult, baselineInfo.baselineEvaluation);
             const failureInstances = this.getFailureInstances(combinedReportResult, baselineInfo.baselineEvaluation);
             const failureInstancesHeading = this.getFailureInstancesHeading(failureInstances, baselineInfo.baselineEvaluation);

--- a/packages/shared/src/mark-down/result-markdown-builder.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.ts
@@ -121,7 +121,7 @@ export class ResultMarkdownBuilder {
     };
 
     private shouldUpdateBaselineFile(baselineEvaluation: BaselineEvaluation): boolean {
-        return (baselineEvaluation && baselineEvaluation.suggestedBaselineUpdate) ? true : false;
+        return baselineEvaluation && baselineEvaluation.suggestedBaselineUpdate ? true : false;
     }
 
     private hasFixedFailureResults(baselineEvaluation: BaselineEvaluation): boolean {
@@ -205,8 +205,10 @@ export class ResultMarkdownBuilder {
 
     private failureDetailsBaseline = (combinedReportResult: CombinedReportParameters, baselineInfo: BaselineInfo): string => {
         let lines = [];
-        if (this.hasFailures(combinedReportResult, baselineInfo.baselineEvaluation) ||
-            this.shouldUpdateBaselineFile(baselineInfo.baselineEvaluation)) {
+        if (
+            this.hasFailures(combinedReportResult, baselineInfo.baselineEvaluation) ||
+            this.shouldUpdateBaselineFile(baselineInfo.baselineEvaluation)
+        ) {
             const failedRulesList = this.getFailedRulesList(combinedReportResult, baselineInfo.baselineEvaluation);
             const failureInstances = this.getFailureInstances(combinedReportResult, baselineInfo.baselineEvaluation);
             const failureInstancesHeading = this.getFailureInstancesHeading(failureInstances, baselineInfo.baselineEvaluation);

--- a/packages/shared/src/mark-down/result-markdown-builder.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.ts
@@ -120,11 +120,11 @@ export class ResultMarkdownBuilder {
         return lines.join('');
     };
 
-    private shouldUpdateBaselineFile(baselineEvaluation: BaselineEvaluation) : boolean {
+    private shouldUpdateBaselineFile(baselineEvaluation: BaselineEvaluation): boolean {
         return baselineEvaluation.totalNewViolations > 0 || this.hasFixedFailureResults(baselineEvaluation);
     }
 
-    private hasFixedFailureResults(baselineEvaluation: BaselineEvaluation) : boolean {
+    private hasFixedFailureResults(baselineEvaluation: BaselineEvaluation): boolean {
         if (baselineEvaluation && baselineEvaluation.fixedViolationsByRule) {
             for (const _ in baselineEvaluation.fixedViolationsByRule) {
                 return true;
@@ -180,17 +180,18 @@ export class ResultMarkdownBuilder {
     };
 
     private fixedFailureDetails = (baselineInfo: BaselineInfo): string => {
-        if (!baselineInfo || 
-            !this.hasFixedFailureResults(baselineInfo.baselineEvaluation)) {
+        if (!baselineInfo || !this.hasFixedFailureResults(baselineInfo.baselineEvaluation)) {
             return sectionSeparator();
         }
-        
+
         let totalFixedFailureInstanceCount = 0;
         const fixedFailureInstanceLines = [];
         for (const ruleId in baselineInfo.baselineEvaluation.fixedViolationsByRule) {
             const fixedFailureInstanceCount = baselineInfo.baselineEvaluation.fixedViolationsByRule[ruleId];
             totalFixedFailureInstanceCount += fixedFailureInstanceCount;
-            fixedFailureInstanceLines.push([this.fixedRuleListItemBaseline(fixedFailureInstanceCount, ruleId), sectionSeparator()].join(''));
+            fixedFailureInstanceLines.push(
+                [this.fixedRuleListItemBaseline(fixedFailureInstanceCount, ruleId), sectionSeparator()].join(''),
+            );
         }
 
         const lines = [


### PR DESCRIPTION
#### Details

As called out in #959, PR comments are wrong in cases where some (but not all) baseline failures are fixed in a PR. This change adds the corrected PR comments. It also includes a minor tweak to use more consistent output of section gaps in the output file. 

The summary of fixed violations only lists the rule and the count, since that's all we get from the diff engine. No rule description is consistently available.

##### Motivation

Address #959 

##### Context

At the moment, it feels like each method that adds text needs to be too aware of its location within a section. I have an idea for how to improve this, but I want to keep this PR relatively small and focused, then the refactoring can be in a separate PR.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Issue #959
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
open .