### PR TITLE
chore(deps): update @types/marked and limit marked-terminal updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,8 @@ updates:
   - dependency-name: puppeteer-core
     versions:
     - "> 5.3.1"
+    # marked-terminal v5 depends on chalk v5 which uses the node: protocol;
+    # this protocol is not supported in node 10, the ADO execution environment
+  - dependency-name: marked-terminal
+    versions:
+    - ">= 5"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "@types/express": "^4.17.13",
         "@types/jest": "^27.4.0",
         "@types/lodash": "^4.14.178",
-        "@types/marked": "^3.0.2",
+        "@types/marked": "^4.0.1",
         "@types/marked-terminal": "^3.1.3",
         "@types/normalize-path": "^3.0.0",
         "@types/puppeteer-core": "^5.4.0",

--- a/packages/shared/src/progress-reporter/progress-reporter.ts
+++ b/packages/shared/src/progress-reporter/progress-reporter.ts
@@ -3,7 +3,7 @@
 
 import { injectable } from 'inversify';
 import { CombinedReportParameters } from 'accessibility-insights-report';
-import marked from 'marked';
+import { marked } from 'marked';
 import TerminalRenderer from 'marked-terminal';
 import { BaselineEvaluation } from 'accessibility-insights-scan';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1909,10 +1909,15 @@
     "@types/marked" "^3"
     chalk "^2.4.1"
 
-"@types/marked@^3", "@types/marked@^3.0.2":
+"@types/marked@^3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/marked/-/marked-3.0.3.tgz#37878f405d5f0cff0e6128cea330bd0aa8df8cb3"
   integrity sha512-ZgAr847Wl68W+B0sWH7F4fDPxTzerLnRuUXjUpp1n4NjGSs8hgPAjAp7NQIXblG34MXTrf5wWkAK8PVJ2LIlVg==
+
+"@types/marked@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.0.1.tgz#d588a7bbc4d6551c5e75249bc106ffda96ae33c5"
+  integrity sha512-ZigEmCWdNUU7IjZEuQ/iaimYdDHWHfTe3kg8ORfKjyGYd9RWumPoOJRQXB0bO+XLkNwzCthW3wUIQtANaEZ1ag==
 
 "@types/mime@^1":
   version "1.3.2"


### PR DESCRIPTION
#### Details

This PR replaces https://github.com/microsoft/accessibility-insights-action/pull/969 , which needed a manual change.

I tried to pull in marked-terminal as well, but ran into issues described here: https://github.com/microsoft/accessibility-insights-action/pull/993#issuecomment-1005302270 so I updated our `dependabot.yml`.

##### Motivation

Settle on proper versions for marked*

##### Context

I tested this change by:
- creating a simple `LoggerReporter` that traces the markdown result and adding it to the IOC container
- running `npx cross-env ACT=true INPUT_URL=https://markreay.github.io/AU/before.html INPUT_SCANTIMEOUT=90000 INPUT_maxurls=5 INPUT_outputDir=_accessibility-reports yarn start` in `packages/ado-extension`

I got the following output:
![log output of ai-action](https://user-images.githubusercontent.com/7775527/148443460-3fa6fcad-5e2f-48fb-b526-b69b701c51f7.png)
```
[Trace][info] === Scan report saved successfully as C:/Users/karansin/accessibility-insights-action/packages/ado-extension/dist/pkg/_accessibility-reports/index.html
[ProgressReporter] ===
### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg)
 Accessibility Insights Action

    * URLs: 1 URL(s) failed, 0 URL(s) passed, and 0 were not scannable
    * Rules: 22 check(s) failed, 11 check(s) passed, and 37 were not applicable
    * Download the Accessibility Insights artifact to view the detailed results of these checks#### Failed instances
    * 13 × label:  Ensures every form element has a label
    * 4 × color-contrast:  Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
    * 4 × image-alt:  Ensures <img> elements have alternate text or a role of none or presentation
    * 1 × html-has-lang:  Ensures every HTML document has a lang attribute
```

creating 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
