### PR TITLE
chore: Update files to ignore for license check

### DIFF
--- a/license-check-and-add-config.json
+++ b/license-check-and-add-config.json
@@ -15,7 +15,7 @@
         "**/*.snap",
         "**/*.snap.md",
         "**/*.taskkey",
-        "NOTICES.txt"
+        "**/.DS_Store"
     ],
     "license": "./copyright-header.txt",
     "licenseFormats": {


### PR DESCRIPTION
#### Details

`yarn precheckin` is broken on a mac, since building and testing creates a `.DS_Store` file that then fails the license check with the following error:

```
✗ License not found in .DS_Store
✗ License not found in dev/.DS_Store
✗ License not found in packages/.DS_Store
✗ License not found in dev/website-root/.DS_Store
✗ License not found in packages/ado-extension/.DS_Store
✗ License not found in packages/shared/.DS_Store
```

 While fixing this, I also noticed that we still exclude NOTICES.TXT from license checks. This file was removed a while back, so there's no reason to still have it in the license exclusion list.

##### Motivation

Support `yarn precheckin` from a mac

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
