### PR TITLE
Chore: Add issue templates to the Action repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,56 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug, needs triage
+assignees: ''
+
+---
+
+## Describe the bug
+
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## CodePen repro example
+
+<!--
+Please provide a reproduction of the bug in a codepen, if possible. Here’s how
+
+* Goto https://codepen.io/ for a starting codepen
+* Create a simple example of the page that you have issues with and Export that codepen or give us a link to that codepen.
+-->
+
+## Expected behavior
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## Context (please complete the following information)
+
+- OS Name & Version: <!--e.g. Windows 10.0.18363 Build 18363 / macOS Catalina 10.15(19A583)-->
+- AI-Action Version & Environment: <!--e.g. 1.140.1 Insider-->
+- Browser Version: <!--e.g. Google Chrome 78.0.3904.108 (Official Build) (64-bit)-->
+- Target Page: <!--e.g. https://www.bing.com-->
+
+## Are you willing to submit a PR?
+
+<!-- If asked, will you be willing to submit a PR to fix this bug? -->
+
+## Did you search for similar existing issues?
+
+<!-- Did you search for similar issues in our github issues or on [stackoverflow](https://stackoverflow.com/questions/tagged/accessibility-insights) -->
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature request
+assignees: ''
+---
+
+## Is your feature request related to a problem? Please describe.
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+## Describe the desired outcome
+<!-- A clear and concise description of what you want to happen. -->
+
+## Describe alternatives you've considered
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+## Additional context
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/general_question.md
+++ b/.github/ISSUE_TEMPLATE/general_question.md
@@ -1,0 +1,15 @@
+---
+name: General Question
+about: This is a template for people to ask questions that don't fit into any other issue categories
+title: ''
+labels: question
+assignees: ''
+---
+
+**We encourage tool related questions to be asked on stackoverflow.com and tagged with `accessibility-insights`.**
+
+## Your question here
+<!--
+Make sure to provide enough context. If you have spoken to a team member please mention them here.
+Add any items (screenshots etc) that will help.
+-->

--- a/license-check-and-add-config.json
+++ b/license-check-and-add-config.json
@@ -1,9 +1,9 @@
 {
     "ignore": [
         ".git",
+        ".github",
         "./.dependabot",
         "**/yarn.lock",
-        "**/.github/pull_request_template.md",
         "**/CODEOWNERS",
         "package.json",
         "cred-scan-suppressions.json",


### PR DESCRIPTION
In particular, dependabot requires these labels and we also use the labels to sort and triage bugs.

#### Details

<!-- Usually a sentence or two describing what the PR changes -->

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
