### PR TITLE
chore: move the developer docs earlier in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ For more information, see [How to use the GitHub Action](docs/gh-action-usage.md
 
 ## Contributing
 
-To build and test, see [developer docs](./dev/README.md) for more details.
+To build and test, see [developer docs](./dev/README.md).
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for more info about the contributor license agreement.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Automated checks can detect some common accessibility problems such as missing o
 
 For more information, see [How to use the GitHub Action](docs/gh-action-usage.md) and [How to use the Azure DevOps extension](docs/ado-extension-usage.md).
 
+To build and test, see [developer docs](./dev/README.md) for more details.
+
 ## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a
@@ -34,4 +36,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) and [dev docs](./dev/README.md) for more details.
+See [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -20,20 +20,8 @@ Automated checks can detect some common accessibility problems such as missing o
 
 For more information, see [How to use the GitHub Action](docs/gh-action-usage.md) and [How to use the Azure DevOps extension](docs/ado-extension-usage.md).
 
-To build and test, see [developer docs](./dev/README.md) for more details.
-
 ## Contributing
 
-This project welcomes contributions and suggestions. Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+To build and test, see [developer docs](./dev/README.md) for more details.
 
-When you submit a pull request, a CLA bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
-See [CONTRIBUTING.md](./CONTRIBUTING.md).
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for more info about the contributor license agreement.


### PR DESCRIPTION
#### Details

@RobGallo suggested moving the dev docs earlier in the README. The original spot was after the Contributing text, which is highly standardized across repos, so it's easy to assume there's nothing afterwards. I noticed that Contributing.md already contained the relevant license text so I removed the duplicate.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
make it easier to find dev docs

##### Context

n/a
<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
