### PR TITLE
chore: add script to help run ADO extension locally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,4 +35,5 @@ module.exports = {
             },
         },
     ],
+    ignorePatterns: ['**/*.js'],
 };

--- a/packages/ado-extension/package.json
+++ b/packages/ado-extension/package.json
@@ -11,7 +11,7 @@
         "lint:check": "eslint -c ../../.eslintrc.js \"src/**/*.{js,ts}\"",
         "lint:fix": "eslint -c ../../.eslintrc.js \"src/**/*.{js,ts}\" --quiet --fix",
         "package": "cd dist && tfx extension create --manifest-globs ado-extension.json",
-        "start": "node dist/pkg/index.js",
+        "start": "node scripts/run-locally.js",
         "test": "jest",
         "watch:test": "jest --watch",
         "test:e2e": "tsc && mocha dist/pkg/*.test.js"

--- a/packages/ado-extension/scripts/local-overrides.json
+++ b/packages/ado-extension/scripts/local-overrides.json
@@ -1,0 +1,6 @@
+[
+    {
+        "name": "url",
+        "value": "https://markreay.github.io/AU/before.html"
+    }
+]

--- a/packages/ado-extension/scripts/run-locally.js
+++ b/packages/ado-extension/scripts/run-locally.js
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/*
+This script runs the ADO extension task locally. It uses the
+default inputs defined in task.json and allows for custom
+overrides. To add or change task inputs, add key-value
+pairs inside local-overrides.json. For instance:
+
+[
+    {
+        name: "url",
+        value: "https://accessibilityinsights.io"
+    }
+]
+
+Valid names include any input name in task.json, e.g.
+outputDir, siteDir, etc.
+*/
+
+const mockRunner = require('azure-pipelines-task-lib/mock-run');
+const path = require('path');
+const { exit } = require('process');
+
+const taskExecutablePath = path.join(__dirname, '..', 'dist', 'pkg', 'index.js');
+const tmr = new mockRunner.TaskMockRunner(taskExecutablePath);
+
+const taskConfigPath = path.join(__dirname, '..', 'dist', 'pkg', 'task.json');
+const taskConfig = require(taskConfigPath);
+
+const inputs = {};
+
+// Apply default input values from task configuration
+for (const inputConfig of taskConfig['inputs']) {
+    if (inputConfig.defaultValue) {
+        inputs[inputConfig.name] = inputConfig.defaultValue;
+    }
+}
+
+// Apply any input overrides
+const localOverrides = require(path.join(__dirname, 'local-overrides.json'));
+for (const override of localOverrides) {
+    const validName = taskConfig['inputs'].some((input) => input.name === override.name);
+    if (!validName) {
+        console.log(`input override ${override.name} is not defined in task.json`);
+        exit(1);
+    }
+
+    inputs[override.name] = override.value;
+}
+
+for (const name of Object.keys(inputs)) {
+    console.log(`run-locally.js is setting up input ${name} to value ${inputs[name]}`);
+    tmr.setInput(name, inputs[name]);
+}
+
+console.log('beginning task execution below');
+console.log();
+
+tmr.run(true);

--- a/packages/ado-extension/scripts/run-locally.js
+++ b/packages/ado-extension/scripts/run-locally.js
@@ -11,11 +11,16 @@ pairs inside local-overrides.json. For instance:
     {
         name: "url",
         value: "https://accessibilityinsights.io"
+    },
+    {
+        name: "singleWorker",
+        value: true
     }
 ]
 
 Valid names include any input name in task.json, e.g.
-outputDir, siteDir, etc.
+outputDir, siteDir, etc. Boolean values can be provided
+without quotes, like singleWorker above.
 */
 
 const mockRunner = require('azure-pipelines-task-lib/mock-run');


### PR DESCRIPTION
#### Details

It can be difficult to debug the ADO extension locally. We can run `dist/pkg/index.js`, but we haven't been mapping input variables into the environment.

This PR adds a script so that we can more easily run the extension locally. It's not a full substitute for running in an agent environment - but it can be helpful in some scenarios.

Running `yarn start` will run the bundled `index.js` script with the following task inputs:
- any default values from [task.json inputs](https://github.com/microsoft/accessibility-insights-action/blob/main/packages/ado-extension/task.json)
- any additional values in `local-overrides.json` (these take precedence)

Here is the output I see when I run `yarn start`:

```
PS C:\Users\karansin\accessibility-insights-action\packages\ado-extension> yarn start
yarn run v1.22.4
$ node scripts/run-locally.js
run-locally.js is setting up input outputDir to value _accessibility-reports
run-locally.js is setting up input siteDir to value .
run-locally.js is setting up input scanUrlRelativePath to value /
run-locally.js is setting up input maxUrls to value 100
run-locally.js is setting up input scanTimeout to value 90000
run-locally.js is setting up input singleWorker to value true
run-locally.js is setting up input url to value https://markreay.github.io/AU/before.html
beginning task execution below

installing runtime dependencies...
[1/4] Resolving packages...
warning Lockfile has incorrect entry for "apify-shared@^0.5.0". Ignoring it.
warning Lockfile has incorrect entry for "socket.io@^2.3.0". Ignoring it.
warning Lockfile has incorrect entry for "underscore@1.12.1". Ignoring it.
warning Lockfile has incorrect entry for "apify-shared@^0.6.0". Ignoring it.
...<further task output>
```

Before this PR, running `yarn start` usually crashes because the `url` parameter is not mapped into the environment. You can get around this by mapping environment variables yourself, e.g. `npx cross-env ACT=true INPUT_URL=https://markreay.github.io/AU/before.html INPUT_SCANTIMEOUT=90000 INPUT_MAXURLS=5 INPUT_OUTPUTDIR=_accessibility-reports yarn start` but this is quite a hassle.

##### Motivation

make it easier to see the impact of small changes locally

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
