### PR TITLE
feat(ado-improvement-1): Exclude some strings that shouldn't have debug prefix

### DIFF
--- a/packages/shared/src/output-hooks/stdout-transformer.spec.ts
+++ b/packages/shared/src/output-hooks/stdout-transformer.spec.ts
@@ -28,12 +28,17 @@ describe(stdoutTransformer, () => {
     });
 
     it.each`
-        input                      | expectedOutput
-        ${'##[error] abc'}         | ${'##[error] abc'}
-        ${'##[debug] abc'}         | ${'##[debug] abc'}
-        ${'##vso[task.debug] abc'} | ${'##vso[task.debug] abc'}
-    `(`Debug tag not added - input value '$input' returned as '$expectedOutput'`, ({ input, expectedOutput }) => {
+        input
+        ${'##[error] abc'}
+        ${'##[debug] abc'}
+        ${'##vso[task.debug] abc'}
+        ${'Processing page abc'}
+        ${'Discovered 2 links on page abc'}
+        ${'Discovered 2345 links on page abc'}
+        ${'Found 3 accessibility issues on page abc'}
+        ${'Found 3456 accessibility issues on page abc'}
+    `(`Debug tag not added - input value '$input' returned as '$input'`, ({ input }) => {
         const output = stdoutTransformer(input);
-        expect(output).toBe(expectedOutput);
+        expect(output).toBe(input);
     });
 });

--- a/packages/shared/src/output-hooks/stdout-transformer.ts
+++ b/packages/shared/src/output-hooks/stdout-transformer.ts
@@ -26,6 +26,18 @@ const regexTransformations: RegexTransformation[] = [
         method: useUnmodifiedString,
     },
     {
+        regex: new RegExp('^Processing page .*'),
+        method: useUnmodifiedString,
+    },
+    {
+        regex: new RegExp('^Discovered \\d* links on page '),
+        method: useUnmodifiedString,
+    },
+    {
+        regex: new RegExp('^Found \\d* accessibility issues on page '),
+        method: useUnmodifiedString,
+    },
+    {
         regex: new RegExp('^\\[Trace\\]\\[info\\] === '),
         method: replaceFirstMatchWithDebugPrefix,
     },


### PR DESCRIPTION
#### Details

If #1030, we changed stdout's default behavior to prefix ##[debug] to a string unless a special case existed to override the default. Unfortunately, I overlooked how 3 scanner-generated strings were exempted from the ##[debug] tag in #950's suggested output:

```
Processing page http://localhost:5858/
Discovered 2 links on page http://localhost:5858/
Found 3 accessibility issues on page http://localhost:5858/
```

This also streamlines the unit test that checks for unmodified output, so that the string only needs to be specified once.

##### Motivation

Feature work

##### Comparisons

Before this change:

```
##[debug] Processing page https://markreay.github.io/AU/before.html
##[debug] Discovered 4 links on page https://markreay.github.io/AU/before.html
##[debug] Found 4 accessibility issues on page https://markreay.github.io/AU/before.html
```

After this change:

```
Processing page https://markreay.github.io/AU/before.html
Discovered 4 links on page https://markreay.github.io/AU/before.html
Found 4 accessibility issues on page https://markreay.github.io/AU/before.html
```
##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
#950 identifies other lines that originate within the extension. We'll handle them a bit differently in a later PR

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Part of #950
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
