### PR TITLE
feat(ado-improvements-1): Add group around installing dependencies

### DIFF
--- a/packages/ado-extension/src/install-runtime-dependencies.ts
+++ b/packages/ado-extension/src/install-runtime-dependencies.ts
@@ -4,9 +4,10 @@
 import { execSync } from 'child_process';
 
 export function installRuntimeDependencies() {
-    console.log('installing runtime dependencies...');
+    console.log('##[group]Installing runtime dependencies');
     execSync('yarn install --prod --ignore-engines --frozen-lockfile', {
         stdio: 'inherit',
         cwd: __dirname,
     });
+    console.log('##[endgroup]');
 }


### PR DESCRIPTION
#### Details

As requested in #950, this adds a group tag for the ADO extension around the process of installing runtime dependencies. 

Output before this change:

```
installing runtime dependencies...
[1/4] 🔍  Resolving packages...
// Warnings omitted for brevity
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
```

Output after this change:

```
##[group]Installing runtime dependencies
[1/4] 🔍  Resolving packages...
// Warnings omitted for brevity
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
##[endgroup]
```

##### Motivation

Improve logging as requested in #950

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
This changes _only_ the ADO experience. The Action experience already has this broken out as a separate [step](https://github.com/microsoft/accessibility-insights-action/blob/main/packages/gh-action/action.yml#L58), so it's already broken out there. 

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Progress on #950
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
