### PR TITLE
feat(ado-improvements-1): Refactor reporter errors

### DIFF
--- a/packages/ado-extension/src/ado-extension.ts
+++ b/packages/ado-extension/src/ado-extension.ts
@@ -11,7 +11,7 @@ import { hookStdout } from '@accessibility-insights-action/shared';
 import { Scanner } from '@accessibility-insights-action/shared';
 import { setupIocContainer } from './ioc/setup-ioc-container';
 
-export function runScan() {
+export function runScan(): void {
     (async () => {
         hookStderr();
         hookStdout();

--- a/packages/ado-extension/src/ado-extension.ts
+++ b/packages/ado-extension/src/ado-extension.ts
@@ -21,9 +21,7 @@ export function runScan() {
         await logger.setup();
 
         const scanner = container.get(Scanner);
-        if (!(await scanner.scan())) {
-            process.exit(ExitCode.ScanCompletedWithDetectedError);
-        }
+        process.exit((await scanner.scan()) ? ExitCode.ScanCompletedNoUserActionIsNeeded : ExitCode.ScanCompletedUserActionIsNeeded);
     })().catch((error) => {
         console.log('Exception thrown in extension: ', error);
         process.exit(ExitCode.ScanFailedToComplete);

--- a/packages/ado-extension/src/ado-extension.ts
+++ b/packages/ado-extension/src/ado-extension.ts
@@ -21,7 +21,7 @@ export function runScan() {
         await logger.setup();
 
         const scanner = container.get(Scanner);
-        if (!await scanner.scan()) {
+        if (!(await scanner.scan())) {
             process.exit(ExitCode.ScanCompletedWithDetectedError);
         }
     })().catch((error) => {

--- a/packages/ado-extension/src/ado-extension.ts
+++ b/packages/ado-extension/src/ado-extension.ts
@@ -4,6 +4,7 @@
 import 'reflect-metadata';
 import './module-name-mapper';
 
+import { ExitCode } from '@accessibility-insights-action/shared';
 import { Logger } from '@accessibility-insights-action/shared';
 import { hookStderr } from '@accessibility-insights-action/shared';
 import { hookStdout } from '@accessibility-insights-action/shared';
@@ -20,9 +21,11 @@ export function runScan() {
         await logger.setup();
 
         const scanner = container.get(Scanner);
-        await scanner.scan();
+        if (!await scanner.scan()) {
+            process.exit(ExitCode.ScanCompletedWithDetectedError);
+        }
     })().catch((error) => {
         console.log('Exception thrown in extension: ', error);
-        process.exit(1);
+        process.exit(ExitCode.ScanFailedToComplete);
     });
 }

--- a/packages/ado-extension/src/ado-extension.ts
+++ b/packages/ado-extension/src/ado-extension.ts
@@ -23,7 +23,7 @@ export function runScan(): void {
         const scanner = container.get(Scanner);
         process.exit((await scanner.scan()) ? ExitCode.ScanCompletedNoUserActionIsNeeded : ExitCode.ScanCompletedUserActionIsNeeded);
     })().catch((error) => {
-        console.log('Exception thrown in extension: ', error);
+        console.log('##[error][Exception] Exception thrown in extension: ', error);
         process.exit(ExitCode.ScanFailedToComplete);
     });
 }

--- a/packages/ado-extension/src/install-runtime-dependencies.ts
+++ b/packages/ado-extension/src/install-runtime-dependencies.ts
@@ -3,7 +3,7 @@
 
 import { execSync } from 'child_process';
 
-export function installRuntimeDependencies() {
+export function installRuntimeDependencies(): void {
     console.log('##[group]Installing runtime dependencies');
     execSync('yarn install --prod --ignore-engines --frozen-lockfile', {
         stdio: 'inherit',

--- a/packages/ado-extension/src/ioc/setup-ioc-container.ts
+++ b/packages/ado-extension/src/ioc/setup-ioc-container.ts
@@ -21,7 +21,6 @@ export function setupIocContainer(container = new inversify.Container({ autoBind
     container
         .bind(iocTypes.ProgressReporters)
         .toDynamicValue((context) => {
-            // Note: Keep the WorkflowEnforcer creator last in the array!
             return [context.container.get(AdoConsoleCommentCreator), context.container.get(WorkflowEnforcer)];
         })
         .inSingletonScope();

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -23,7 +23,7 @@ describe(AdoConsoleCommentCreator, () => {
 
     describe('constructor', () => {
         it('should initialize', () => {
-            const adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks();
+            buildAdoConsoleCommentCreatorWithMocks();
 
             verifyAllMocks();
         });

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -23,7 +23,7 @@ describe(AdoConsoleCommentCreator, () => {
 
     describe('constructor', () => {
         it('should initialize', () => {
-            adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks();
+            const adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks();
 
             verifyAllMocks();
         });
@@ -64,16 +64,31 @@ describe(AdoConsoleCommentCreator, () => {
 
     describe('failRun', () => {
         it('does nothing interesting', async () => {
-            const message = 'message';
-            adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks();
+            const adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks();
 
-            await adoConsoleCommentCreator.failRun(message);
+            await adoConsoleCommentCreator.failRun();
 
             verifyAllMocks();
         });
     });
 
-    const buildAdoConsoleCommentCreatorWithMocks = () =>
+    describe('didScanSucceed', () => {
+        it('returns true by default', async () => {
+            const adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks();
+
+            await expect(adoConsoleCommentCreator.didScanSucceed()).resolves.toBe(true);
+        });
+
+        it('returns true after failRun() is called', async () => {
+            const adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks();
+
+            await adoConsoleCommentCreator.failRun();
+
+            await expect(adoConsoleCommentCreator.didScanSucceed()).resolves.toBe(true);
+        });
+    });
+
+    const buildAdoConsoleCommentCreatorWithMocks = (): AdoConsoleCommentCreator =>
         new AdoConsoleCommentCreator(adoTaskConfigMock.object, reportMarkdownConvertorMock.object, loggerMock.object);
 
     const verifyAllMocks = () => {

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -39,8 +39,8 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public async failRun(message: string): Promise<void> {
-        // This gets handled in the WorkflowEnforcer
+    public async failRun(): Promise<void> {
+        // We don't do anything for failed runs
     }
 
     private getBaselineInfo(baselineEvaluation?: BaselineEvaluation): BaselineInfo {

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.spec.ts
@@ -12,7 +12,7 @@ import { Logger } from '@accessibility-insights-action/shared';
 
 describe(WorkflowEnforcer, () => {
     let adoTaskConfigMock: IMock<ADOTaskConfig>;
-    let loggerMock: IMock<Logger>
+    let loggerMock: IMock<Logger>;
     let workflowEnforcer: WorkflowEnforcer;
 
     beforeEach(() => {
@@ -127,8 +127,6 @@ describe(WorkflowEnforcer, () => {
     };
 
     const setupLoggerWithErrorMessage = (message: string) => {
-        loggerMock
-            .setup((o) => o.logError(message))
-            .verifiable(Times.once());
-    }
+        loggerMock.setup((o) => o.logError(message)).verifiable(Times.once());
+    };
 });

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.spec.ts
@@ -8,13 +8,16 @@ import { CombinedReportParameters } from 'accessibility-insights-report';
 
 import { BaselineEvaluation, BaselineFileContent } from 'accessibility-insights-scan';
 import { WorkflowEnforcer } from './workflow-enforcer';
+import { Logger } from '@accessibility-insights-action/shared';
 
 describe(WorkflowEnforcer, () => {
     let adoTaskConfigMock: IMock<ADOTaskConfig>;
+    let loggerMock: IMock<Logger>
     let workflowEnforcer: WorkflowEnforcer;
 
     beforeEach(() => {
         adoTaskConfigMock = Mock.ofType<ADOTaskConfig>(undefined, MockBehavior.Strict);
+        loggerMock = Mock.ofType<Logger>(undefined, MockBehavior.Strict);
     });
 
     describe('constructor', () => {
@@ -26,7 +29,7 @@ describe(WorkflowEnforcer, () => {
     });
 
     describe('completeRun', () => {
-        it('throws correct error if accessibility error occurred', async () => {
+        it('logs correct error if accessibility error occurred', async () => {
             const reportStub = {
                 results: {
                     urlResults: {
@@ -37,17 +40,16 @@ describe(WorkflowEnforcer, () => {
             const baselineEvaluationStub = {} as BaselineEvaluation;
 
             setupFailOnAccessibilityError(true);
+            setupLoggerWithErrorMessage('An accessibility error was found and you specified the "failOnAccessibilityError" flag.');
 
-            workflowEnforcer = buildWorkflowEnforcerWithMocks();
+            const workflowEnforcer = buildWorkflowEnforcerWithMocks();
 
-            await expect(workflowEnforcer.completeRun(reportStub, baselineEvaluationStub)).rejects.toThrowError(
-                'Failed Accessibility Error',
-            );
+            await workflowEnforcer.completeRun(reportStub, baselineEvaluationStub);
 
             verifyAllMocks();
         });
 
-        it('throws correct error if baseline needs to be updated', async () => {
+        it('logs correct error if baseline needs to be updated', async () => {
             const reportStub = {} as CombinedReportParameters;
             const baselineEvaluationStub = {
                 suggestedBaselineUpdate: {} as BaselineFileContent,
@@ -55,12 +57,11 @@ describe(WorkflowEnforcer, () => {
 
             setupFailOnAccessibilityError(false);
             setupBaselineFileParameterExists();
+            setupLoggerWithErrorMessage('The baseline file does not match scan results.');
 
-            workflowEnforcer = buildWorkflowEnforcerWithMocks();
+            const workflowEnforcer = buildWorkflowEnforcerWithMocks();
 
-            await expect(workflowEnforcer.completeRun(reportStub, baselineEvaluationStub)).rejects.toThrowError(
-                'Failed: The baseline file does not match scan results. If this is a PR, check the PR comments.',
-            );
+            await workflowEnforcer.completeRun(reportStub, baselineEvaluationStub);
 
             verifyAllMocks();
         });
@@ -72,7 +73,7 @@ describe(WorkflowEnforcer, () => {
             setupFailOnAccessibilityError(false);
             setupBaselineFileParameterExists();
 
-            workflowEnforcer = buildWorkflowEnforcerWithMocks();
+            const workflowEnforcer = buildWorkflowEnforcerWithMocks();
 
             await workflowEnforcer.completeRun(reportStub, baselineEvaluationStub);
 
@@ -92,16 +93,20 @@ describe(WorkflowEnforcer, () => {
         });
     });
 
-    describe('failRun', () => {
-        it('reject promise with matching error', async () => {
-            workflowEnforcer = buildWorkflowEnforcerWithMocks();
+    describe('didScanSucceed', () => {
+        it('returns true by default', async () => {
+            const workflowEnforcer = buildWorkflowEnforcerWithMocks();
+            await expect(workflowEnforcer.didScanSucceed()).resolves.toBe(true);
+        });
 
-            await expect(workflowEnforcer.failRun('message')).rejects.toThrowError('message');
-            verifyAllMocks();
+        it('returns false after failRun() is called', async () => {
+            const workflowEnforcer = buildWorkflowEnforcerWithMocks();
+            await workflowEnforcer.failRun();
+            await expect(workflowEnforcer.didScanSucceed()).resolves.toBe(false);
         });
     });
 
-    const buildWorkflowEnforcerWithMocks = () => new WorkflowEnforcer(adoTaskConfigMock.object);
+    const buildWorkflowEnforcerWithMocks = () => new WorkflowEnforcer(adoTaskConfigMock.object, loggerMock.object);
 
     const verifyAllMocks = () => {
         adoTaskConfigMock.verifyAll();
@@ -120,4 +125,10 @@ describe(WorkflowEnforcer, () => {
             .returns(() => 'baseline-file')
             .verifiable(Times.atLeastOnce());
     };
+
+    const setupLoggerWithErrorMessage = (message: string) => {
+        loggerMock
+            .setup((o) => o.logError(message))
+            .verifiable(Times.once());
+    }
 });

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
@@ -1,16 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AdoIocTypes } from '../../ioc/ado-ioc-types';
 import { ADOTaskConfig } from '../../task-config/ado-task-config';
 import { inject, injectable } from 'inversify';
-import { ProgressReporter } from '@accessibility-insights-action/shared';
+import { Logger, ProgressReporter } from '@accessibility-insights-action/shared';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 import { BaselineEvaluation } from 'accessibility-insights-scan';
 
 @injectable()
 export class WorkflowEnforcer extends ProgressReporter {
-    constructor(@inject(ADOTaskConfig) private readonly adoTaskConfig: ADOTaskConfig) {
+    private scanSucceeded = true;
+
+    constructor(
+        @inject(ADOTaskConfig) private readonly adoTaskConfig: ADOTaskConfig,
+        @inject(Logger) private readonly logger: Logger) {
         super();
     }
 
@@ -20,24 +23,35 @@ export class WorkflowEnforcer extends ProgressReporter {
 
     // eslint-disable-next-line @typescript-eslint/require-await
     public async completeRun(combinedReportResult: CombinedReportParameters, baselineEvaluation?: BaselineEvaluation): Promise<void> {
-        this.failIfAccessibilityErrorExists(combinedReportResult);
-        this.failIfBaselineNeedsUpdating(baselineEvaluation);
+        if (!await this.failIfAccessibilityErrorExists(combinedReportResult)) {
+            await this.failIfBaselineNeedsUpdating(baselineEvaluation);
+        }
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
-    public async failRun(message: string): Promise<void> {
-        throw new Error(message);
+    public async failRun(): Promise<void> {
+        this.scanSucceeded = false;
     }
 
-    private failIfAccessibilityErrorExists(combinedReportResult: CombinedReportParameters): void {
+    public didScanSucceed(): Promise<boolean> {
+        return Promise.resolve(this.scanSucceeded);
+    }
+
+    private async failIfAccessibilityErrorExists(combinedReportResult: CombinedReportParameters): Promise<boolean> {
         if (this.adoTaskConfig.getFailOnAccessibilityError() && combinedReportResult.results.urlResults.failedUrls > 0) {
-            throw new Error('Failed Accessibility Error');
+            this.logger.logError('An accessibility error was found and you specified the "failOnAccessibilityError" flag.');
+            await this.failRun();
+            return true;
         }
+        return false;
     }
 
-    private failIfBaselineNeedsUpdating(baselineEvaluation?: BaselineEvaluation): void {
+    private async failIfBaselineNeedsUpdating(baselineEvaluation?: BaselineEvaluation): Promise<boolean> {
         if (baselineEvaluation && this.adoTaskConfig.getBaselineFile() && baselineEvaluation.suggestedBaselineUpdate) {
-            throw new Error('Failed: The baseline file does not match scan results. If this is a PR, check the PR comments.');
+            this.logger.logError('The baseline file does not match scan results.');
+            await this.failRun();
+            return true;
         }
+        return false;
     }
 }

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
@@ -11,9 +11,7 @@ import { BaselineEvaluation } from 'accessibility-insights-scan';
 export class WorkflowEnforcer extends ProgressReporter {
     private scanSucceeded = true;
 
-    constructor(
-        @inject(ADOTaskConfig) private readonly adoTaskConfig: ADOTaskConfig,
-        @inject(Logger) private readonly logger: Logger) {
+    constructor(@inject(ADOTaskConfig) private readonly adoTaskConfig: ADOTaskConfig, @inject(Logger) private readonly logger: Logger) {
         super();
     }
 
@@ -23,7 +21,7 @@ export class WorkflowEnforcer extends ProgressReporter {
 
     // eslint-disable-next-line @typescript-eslint/require-await
     public async completeRun(combinedReportResult: CombinedReportParameters, baselineEvaluation?: BaselineEvaluation): Promise<void> {
-        if (!await this.failIfAccessibilityErrorExists(combinedReportResult)) {
+        if (!(await this.failIfAccessibilityErrorExists(combinedReportResult))) {
             await this.failIfBaselineNeedsUpdating(baselineEvaluation);
         }
     }

--- a/packages/gh-action/src/console/console-comment-creator.spec.ts
+++ b/packages/gh-action/src/console/console-comment-creator.spec.ts
@@ -32,10 +32,14 @@ describe(ConsoleCommentCreator, () => {
         });
     });
 
-    describe('failRun', () => {
-        it('throws error', async () => {
-            const errorMessage = 'some error message';
-            await expect(testSubject.failRun(errorMessage)).rejects.toBe(errorMessage);
+    describe('didScanSucceed', () => {
+        it('returns true by default', async () => {
+            await expect(testSubject.didScanSucceed()).resolves.toBe(true);
+        });
+
+        it('returns false after failRun() is called', async () => {
+            await testSubject.failRun();
+            await expect(testSubject.didScanSucceed()).resolves.toBe(false);
         });
     });
 

--- a/packages/gh-action/src/console/console-comment-creator.ts
+++ b/packages/gh-action/src/console/console-comment-creator.ts
@@ -7,6 +7,8 @@ import { CombinedReportParameters } from 'accessibility-insights-report';
 
 @injectable()
 export class ConsoleCommentCreator extends ProgressReporter {
+    private scanSucceeded = true;
+
     constructor(
         @inject(ReportMarkdownConvertor) private readonly reportMarkdownConvertor: ReportMarkdownConvertor,
         @inject(Logger) private readonly logger: Logger,
@@ -27,7 +29,11 @@ export class ConsoleCommentCreator extends ProgressReporter {
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
-    public async failRun(message: string): Promise<void> {
-        throw message;
+    public async failRun(): Promise<void> {
+        this.scanSucceeded = false;
+    }
+
+    public didScanSucceed(): Promise<boolean> {
+        return Promise.resolve(this.scanSucceeded);
     }
 }

--- a/packages/gh-action/src/index.ts
+++ b/packages/gh-action/src/index.ts
@@ -21,6 +21,6 @@ import { setupIocContainer } from './ioc/setup-ioc-container';
     const scanner = container.get(Scanner);
     process.exit((await scanner.scan()) ? ExitCode.ScanCompletedNoUserActionIsNeeded : ExitCode.ScanCompletedUserActionIsNeeded);
 })().catch((error) => {
-    console.log('##[error][Exception] Exception thrown in extension: ', error);
+    console.log('::error::[Exception] Exception thrown in extension: ', error);
     process.exit(ExitCode.ScanFailedToComplete);
 });

--- a/packages/gh-action/src/index.ts
+++ b/packages/gh-action/src/index.ts
@@ -19,9 +19,7 @@ import { setupIocContainer } from './ioc/setup-ioc-container';
     await logger.setup();
 
     const scanner = container.get(Scanner);
-    if (!(await scanner.scan())) {
-        process.exit(ExitCode.ScanCompletedWithDetectedError);
-    }
+    process.exit((await scanner.scan()) ? ExitCode.ScanCompletedNoUserActionIsNeeded : ExitCode.ScanCompletedUserActionIsNeeded);
 })().catch((error) => {
     console.log('Exception thrown in action: ', error);
     process.exit(ExitCode.ScanFailedToComplete);

--- a/packages/gh-action/src/index.ts
+++ b/packages/gh-action/src/index.ts
@@ -21,6 +21,6 @@ import { setupIocContainer } from './ioc/setup-ioc-container';
     const scanner = container.get(Scanner);
     process.exit((await scanner.scan()) ? ExitCode.ScanCompletedNoUserActionIsNeeded : ExitCode.ScanCompletedUserActionIsNeeded);
 })().catch((error) => {
-    console.log('Exception thrown in action: ', error);
+    console.log('##[error][Exception] Exception thrown in extension: ', error);
     process.exit(ExitCode.ScanFailedToComplete);
 });

--- a/packages/gh-action/src/index.ts
+++ b/packages/gh-action/src/index.ts
@@ -19,7 +19,7 @@ import { setupIocContainer } from './ioc/setup-ioc-container';
     await logger.setup();
 
     const scanner = container.get(Scanner);
-    if (!await scanner.scan()) {
+    if (!(await scanner.scan())) {
         process.exit(ExitCode.ScanCompletedWithDetectedError);
     }
 })().catch((error) => {

--- a/packages/gh-action/src/index.ts
+++ b/packages/gh-action/src/index.ts
@@ -3,6 +3,7 @@
 import 'reflect-metadata';
 import './module-name-mapper';
 
+import { ExitCode } from '@accessibility-insights-action/shared';
 import { Logger } from '@accessibility-insights-action/shared';
 import { hookStderr } from '@accessibility-insights-action/shared';
 import { hookStdout } from '@accessibility-insights-action/shared';
@@ -18,8 +19,10 @@ import { setupIocContainer } from './ioc/setup-ioc-container';
     await logger.setup();
 
     const scanner = container.get(Scanner);
-    await scanner.scan();
+    if (!await scanner.scan()) {
+        process.exit(ExitCode.ScanCompletedWithDetectedError);
+    }
 })().catch((error) => {
     console.log('Exception thrown in action: ', error);
-    process.exit(1);
+    process.exit(ExitCode.ScanFailedToComplete);
 });

--- a/packages/shared/src/exit-code.ts
+++ b/packages/shared/src/exit-code.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export const ExitCode = {
+    Success: 0,
+    ScanCompletedWithDetectedError: 1,
+    ScanFailedToComplete: 2
+};

--- a/packages/shared/src/exit-code.ts
+++ b/packages/shared/src/exit-code.ts
@@ -4,5 +4,5 @@
 export const ExitCode = {
     Success: 0,
     ScanCompletedWithDetectedError: 1,
-    ScanFailedToComplete: 2
+    ScanFailedToComplete: 2,
 };

--- a/packages/shared/src/exit-code.ts
+++ b/packages/shared/src/exit-code.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 export const ExitCode = {
-    Success: 0,
-    ScanCompletedWithDetectedError: 1,
+    ScanCompletedNoUserActionIsNeeded: 0,
+    ScanCompletedUserActionIsNeeded: 1,
     ScanFailedToComplete: 2,
 };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -15,3 +15,4 @@ export { BaselineInfo } from './baseline-info';
 export { ArtifactsInfoProvider } from './artifacts-info-provider';
 export { hookStdout } from './output-hooks/hook-stdout';
 export { hookStderr } from './output-hooks/hook-stderr';
+export { ExitCode } from './exit-code';

--- a/packages/shared/src/progress-reporter/all-progress-reporter.ts
+++ b/packages/shared/src/progress-reporter/all-progress-reporter.ts
@@ -32,9 +32,9 @@ export class AllProgressReporter extends ProgressReporter {
 
     public async didScanSucceed(): Promise<boolean> {
         let allReportersSucceeded = true;
-        
+
         await this.execute(async (r) => {
-            if (! (await r.didScanSucceed())) {
+            if (!(await r.didScanSucceed())) {
                 allReportersSucceeded = false;
             }
         });

--- a/packages/shared/src/progress-reporter/all-progress-reporter.ts
+++ b/packages/shared/src/progress-reporter/all-progress-reporter.ts
@@ -26,8 +26,20 @@ export class AllProgressReporter extends ProgressReporter {
         }
     }
 
-    public async failRun(message: string): Promise<void> {
-        await this.execute((r) => r.failRun(message));
+    public async failRun(): Promise<void> {
+        await this.execute((r) => r.failRun());
+    }
+
+    public async didScanSucceed(): Promise<boolean> {
+        let allReportersSucceeded = true;
+        
+        await this.execute(async (r) => {
+            if (! (await r.didScanSucceed())) {
+                allReportersSucceeded = false;
+            }
+        });
+
+        return Promise.resolve(allReportersSucceeded);
     }
 
     private async execute(callback: (reporter: ProgressReporter) => Promise<void>): Promise<void> {

--- a/packages/shared/src/progress-reporter/progress-reporter.ts
+++ b/packages/shared/src/progress-reporter/progress-reporter.ts
@@ -19,7 +19,10 @@ export abstract class ProgressReporter {
 
     public abstract start(): Promise<void>;
     public abstract completeRun(combinedReportResult: CombinedReportParameters, baselineEvaluation?: BaselineEvaluation): Promise<void>;
-    public abstract failRun(message: string): Promise<void>;
+    public abstract failRun(): Promise<void>;
+    public didScanSucceed(): Promise<boolean> {
+        return Promise.resolve(true); // Will be overridden in classes that use this
+    }
 
     protected async invoke<T>(fn: () => Promise<T>): Promise<T> {
         return process.env.ACT !== 'true' ? fn() : Promise.resolve(undefined as T);

--- a/packages/shared/src/scanner/scanner.spec.ts
+++ b/packages/shared/src/scanner/scanner.spec.ts
@@ -34,8 +34,6 @@ describe(Scanner, () => {
     let promiseUtilsMock: IMock<PromiseUtils>;
     let axeInfoMock: IMock<AxeInfo>;
     let combinedReportConverterMock: IMock<AICombinedReportDataConverter>;
-    let processStub: typeof process;
-    let exitMock: IMock<(code: number) => void>;
     let loggerMock: IMock<Logger>;
     let crawlArgumentHandlerMock: IMock<CrawlArgumentHandler>;
     let taskConfigMock: IMock<TaskConfig>;
@@ -56,10 +54,6 @@ describe(Scanner, () => {
         promiseUtilsMock = Mock.ofType(PromiseUtils);
         axeInfoMock = Mock.ofType<AxeInfo>();
         combinedReportConverterMock = Mock.ofType<AICombinedReportDataConverter>();
-        exitMock = Mock.ofType<(_: number) => void>();
-        processStub = {
-            exit: exitMock.object,
-        } as typeof process;
         loggerMock = Mock.ofType(Logger);
         crawlArgumentHandlerMock = Mock.ofType<CrawlArgumentHandler>();
         taskConfigMock = Mock.ofType<TaskConfig>();
@@ -74,7 +68,6 @@ describe(Scanner, () => {
             promiseUtilsMock.object,
             axeInfoMock.object,
             combinedReportConverterMock.object,
-            processStub,
             loggerMock.object,
             crawlArgumentHandlerMock.object,
             taskConfigMock.object,
@@ -95,22 +88,23 @@ describe(Scanner, () => {
     });
 
     describe('scan', () => {
-        it('performs expected steps in happy path with remote url', async () => {
+        it('performs expected steps in happy path with remote url and returns true', async () => {
             setupMocksForSuccessfulScan();
             setupWaitForPromiseToReturnOriginalPromise();
 
-            await scanner.scan();
+            const result = await scanner.scan();
+            expect(result).toBe(true);
 
             verifyMocks();
         });
 
-        it('performs expected steps in happy path with local url (starts file server)', async () => {
+        it('performs expected steps in happy path with local url (starts file server) and returns true', async () => {
             scanArguments.url = '';
             localFileServerMock.setup((m) => m.start()).returns((_) => Promise.resolve('localhost'));
             setupMocksForSuccessfulScan();
             setupWaitForPromiseToReturnOriginalPromise();
 
-            await scanner.scan();
+            await expect(scanner.scan()).resolves.toBe(true);
 
             verifyMocks();
             localFileServerMock.verify((m) => m.start(), Times.once());
@@ -120,27 +114,26 @@ describe(Scanner, () => {
             setupMocksForSuccessfulScan({} as BaselineEvaluation);
             setupWaitForPromiseToReturnOriginalPromise();
 
-            await scanner.scan();
+            await expect(scanner.scan()).resolves.toBe(true);
 
             verifyMocks();
         });
 
-        it('reports error when timeout occurs', async () => {
+        it('reports error when timeout occurs and returns false', async () => {
             const errorMessage = `Scan timed out after ${scanTimeoutMsec / 1000} seconds`;
             localFileServerMock.setup((m) => m.stop()).verifiable(Times.once());
             loggerMock.setup((lm) => lm.logError(errorMessage)).verifiable(Times.once());
-            exitMock.setup((em) => em(1)).verifiable(Times.once());
             taskConfigMock
                 .setup((m) => m.getScanTimeout())
                 .returns((_) => scanTimeoutMsec)
                 .verifiable(Times.once());
             setupWaitForPromiseToReturnTimeoutPromise();
-            await scanner.scan();
+            await expect(scanner.scan()).resolves.toBe(false);
 
             verifyMocks();
         });
 
-        it('should trackException and after an Error is thrown', async () => {
+        it('should trackException and return false after an Error is thrown', async () => {
             const errorMessage = 'some err';
             const error = new Error(errorMessage);
 
@@ -156,7 +149,7 @@ describe(Scanner, () => {
 
             setupWaitForPromiseToReturnOriginalPromise();
 
-            await scanner.scan();
+            await expect(scanner.scan()).resolves.toBe(false);
 
             verifyMocks();
         });
@@ -171,6 +164,9 @@ describe(Scanner, () => {
                 .returns((_) => scanArguments.url)
                 .verifiable(Times.once());
             progressReporterMock.setup((p) => p.start()).verifiable(Times.once());
+            progressReporterMock.setup((m) => m.didScanSucceed())
+                .returns(() => Promise.resolve(true))
+                .verifiable(Times.once())
             crawlArgumentHandlerMock
                 .setup((m) => m.processScanArguments(It.isAny()))
                 .returns((_) => scanArguments)

--- a/packages/shared/src/scanner/scanner.spec.ts
+++ b/packages/shared/src/scanner/scanner.spec.ts
@@ -164,9 +164,10 @@ describe(Scanner, () => {
                 .returns((_) => scanArguments.url)
                 .verifiable(Times.once());
             progressReporterMock.setup((p) => p.start()).verifiable(Times.once());
-            progressReporterMock.setup((m) => m.didScanSucceed())
+            progressReporterMock
+                .setup((m) => m.didScanSucceed())
                 .returns(() => Promise.resolve(true))
-                .verifiable(Times.once())
+                .verifiable(Times.once());
             crawlArgumentHandlerMock
                 .setup((m) => m.processScanArguments(It.isAny()))
                 .returns((_) => scanArguments)

--- a/packages/shared/src/scanner/scanner.spec.ts
+++ b/packages/shared/src/scanner/scanner.spec.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import * as util from 'util';
 import {
     AICombinedReportDataConverter,
     AICrawler,
@@ -98,7 +97,7 @@ describe(Scanner, () => {
     describe('scan', () => {
         it('performs expected steps in happy path with remote url', async () => {
             setupMocksForSuccessfulScan();
-            setupWaitForPromisetoReturnOriginalPromise();
+            setupWaitForPromiseToReturnOriginalPromise();
 
             await scanner.scan();
 
@@ -109,7 +108,7 @@ describe(Scanner, () => {
             scanArguments.url = '';
             localFileServerMock.setup((m) => m.start()).returns((_) => Promise.resolve('localhost'));
             setupMocksForSuccessfulScan();
-            setupWaitForPromisetoReturnOriginalPromise();
+            setupWaitForPromiseToReturnOriginalPromise();
 
             await scanner.scan();
 
@@ -119,7 +118,7 @@ describe(Scanner, () => {
 
         it('passes BaselineEvaluation to ProgressReporter', async () => {
             setupMocksForSuccessfulScan({} as BaselineEvaluation);
-            setupWaitForPromisetoReturnOriginalPromise();
+            setupWaitForPromiseToReturnOriginalPromise();
 
             await scanner.scan();
 
@@ -141,7 +140,7 @@ describe(Scanner, () => {
             verifyMocks();
         });
 
-        it('should trackException on error', async () => {
+        it('should trackException and after an Error is thrown', async () => {
             const errorMessage = 'some err';
             const error = new Error(errorMessage);
 
@@ -152,10 +151,10 @@ describe(Scanner, () => {
                 .setup((lm) => lm.trackExceptionAny(error, `An error occurred while scanning website page undefined`))
                 .verifiable(Times.once());
             loggerMock.setup((lm) => lm.logInfo(`Accessibility scanning of URL undefined completed`)).verifiable(Times.once());
-            progressReporterMock.setup((p) => p.failRun(util.inspect(error))).verifiable(Times.once());
+            progressReporterMock.setup((p) => p.failRun()).verifiable(Times.once());
             localFileServerMock.setup((m) => m.stop()).verifiable(Times.once());
 
-            setupWaitForPromisetoReturnOriginalPromise();
+            setupWaitForPromiseToReturnOriginalPromise();
 
             await scanner.scan();
 
@@ -220,7 +219,7 @@ describe(Scanner, () => {
             localFileServerMock.setup((lfs) => lfs.stop()).verifiable();
         }
 
-        function setupWaitForPromisetoReturnOriginalPromise(): void {
+        function setupWaitForPromiseToReturnOriginalPromise(): void {
             promiseUtilsMock
                 .setup((s) => s.waitFor(It.isAny(), scanTimeoutMsec, It.isAny()))
                 // eslint-disable-next-line @typescript-eslint/require-await

--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -34,7 +34,6 @@ export class Scanner {
         @inject(PromiseUtils) private readonly promiseUtils: PromiseUtils,
         @inject(AxeInfo) private readonly axeInfo: AxeInfo,
         @inject(AICombinedReportDataConverter) private readonly combinedReportDataConverter: AICombinedReportDataConverter,
-        @inject(iocTypes.Process) protected readonly currentProcess: typeof process,
         @inject(Logger) private readonly logger: Logger,
         @inject(CrawlArgumentHandler) private readonly crawlArgumentHandler: CrawlArgumentHandler,
         @inject(iocTypes.TaskConfig) private readonly taskConfig: TaskConfig,
@@ -43,12 +42,12 @@ export class Scanner {
         @inject(BaselineFileUpdater) private readonly baselineFileUpdater: BaselineFileUpdater,
     ) {}
 
-    public async scan(): Promise<void> {
+    public async scan(): Promise<boolean> {
         const scanTimeoutMsec = this.taskConfig.getScanTimeout();
         // eslint-disable-next-line @typescript-eslint/require-await
-        await this.promiseUtils.waitFor(this.invokeScan(), scanTimeoutMsec, async () => {
+        return this.promiseUtils.waitFor<boolean, boolean>(this.invokeScan(), scanTimeoutMsec, async (): Promise<boolean> => {
             this.logger.logError(`Scan timed out after ${scanTimeoutMsec / 1000} seconds`);
-            this.currentProcess.exit(1);
+            return Promise.resolve(false);
         });
     }
 

--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -42,6 +42,7 @@ export class Scanner {
         @inject(BaselineFileUpdater) private readonly baselineFileUpdater: BaselineFileUpdater,
     ) {}
 
+    // Return indicates the scan status. It returns true if no corrective user action is needed.
     public async scan(): Promise<boolean> {
         const scanTimeoutMsec = this.taskConfig.getScanTimeout();
         // eslint-disable-next-line @typescript-eslint/require-await

--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -24,6 +24,8 @@ import { CrawlArgumentHandler } from './crawl-argument-handler';
 import { TaskConfig } from '../task-config';
 import { isEmpty } from 'lodash';
 
+export type ScanSucceededWithNoRequiredUserAction = boolean;
+
 @injectable()
 export class Scanner {
     constructor(
@@ -42,17 +44,19 @@ export class Scanner {
         @inject(BaselineFileUpdater) private readonly baselineFileUpdater: BaselineFileUpdater,
     ) {}
 
-    // Return indicates the scan status. It returns true if no corrective user action is needed.
-    public async scan(): Promise<boolean> {
+    public async scan(): Promise<ScanSucceededWithNoRequiredUserAction> {
         const scanTimeoutMsec = this.taskConfig.getScanTimeout();
-        // eslint-disable-next-line @typescript-eslint/require-await
-        return this.promiseUtils.waitFor<boolean, boolean>(this.invokeScan(), scanTimeoutMsec, async (): Promise<boolean> => {
-            this.logger.logError(`Scan timed out after ${scanTimeoutMsec / 1000} seconds`);
-            return Promise.resolve(false);
-        });
+        return this.promiseUtils.waitFor<ScanSucceededWithNoRequiredUserAction, ScanSucceededWithNoRequiredUserAction>(
+            this.invokeScan(),
+            scanTimeoutMsec,
+            async (): Promise<ScanSucceededWithNoRequiredUserAction> => {
+                this.logger.logError(`Scan timed out after ${scanTimeoutMsec / 1000} seconds`);
+                return Promise.resolve(false);
+            },
+        );
     }
 
-    private async invokeScan(): Promise<boolean> {
+    private async invokeScan(): Promise<ScanSucceededWithNoRequiredUserAction> {
         let scanArguments: ScanArguments;
         let localServerUrl: string;
 


### PR DESCRIPTION
#### Details

As called out in #950, we throw an `Error` if a scan fails, then we log the `Error` twice. To a user, it looks like our tool has crashed, when in reality it's an accessibility error that the user should fix. This PR does the following to improve this:

1. Some implementations of `ProgressReporter.failRun` used to throw an Error to force the program to fail. The new code merely sets a flag in `ProgressReporter.failRun`, then a new API, `ProgressReporter.didScanSucceed`, serves as an indicator of whether or not the scan succeeded.
2. Code that called `ProgressReporter.failRun` with a message is now responsible for logging the error message via `Logger.logError` or `Logger.trackException`, depending on the circumstance. With this change order of the `ProgressReporter` objects no longer matters, so I removed the associated comment.
3. `Scanner.scan` now returns a `Promise<boolean>` instead of a `Promise<void>`. The resolved value of the promise indicates user action. A successful value (true) means that no corrective action is needed by the user. A failed value (false) means that the user need to take some corrective action.
4. The application now has 3 supported return codes
  - A value of 0 (`ExitCode.ScanCompletedNoUserActionIsNeeded`) means that the scan completed successfully and no corrective user action is needed.
  - A value of 1 (`ExitCode.ScanCompletedUserActionIsNeeded`) means that the scan completed successfully, but corrective user action is needed.
  - A value of 2 (`ExitCode.ScanFailedToComplete`) means that the scan failed to complete. This will always be accompanied by a log of the Error that led to the failure.

I also wordsmithed a couple of error messages while I was updating the code and associated tests. A couple of linting issues were also flagged, so I tidied them up.

##### Motivation

Make progress toward #950

##### Before and after

<details>
<summary>
Output before this change--baseline file doesn't match the scan results. Notice the duplicated stack dumps and the fact that the error message is lost as the message of the stack dump
</summary>

```
##[group]Installing runtime dependencies
[1/4] 🔍  Resolving packages...
warning Lockfile has incorrect entry for "apify-shared@^0.5.0". Ignoring it.
warning Lockfile has incorrect entry for "socket.io@^2.3.0". Ignoring it.
warning Lockfile has incorrect entry for "underscore@1.12.1". Ignoring it.
warning Lockfile has incorrect entry for "apify-shared@^0.6.0". Ignoring it.
warning Lockfile has incorrect entry for "apify-shared@^0.1.45". Ignoring it.
warning Lockfile has incorrect entry for "css-what@^5.0.0". Ignoring it.
warning Lockfile has incorrect entry for "http-signature@~1.2.0". Ignoring it.
warning Lockfile has incorrect entry for "css-what@2.1". Ignoring it.
warning Lockfile has incorrect entry for "nth-check@~1.0.1". Ignoring it.
warning Lockfile has incorrect entry for "axios@^0.21.1". Ignoring it.
warning Lockfile has incorrect entry for "marked@^2.0.0". Ignoring it.
warning accessibility-insights-scan > apify > socket.io > debug@4.1.1: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
warning accessibility-insights-scan > apify > socket.io > socket.io-parser > debug@4.1.1: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
warning accessibility-insights-scan > apify > socket.io > engine.io > debug@4.1.1: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
##[endgroup]
##vso[task.debug]agent.TempDirectory=undefined
##vso[task.debug]agent.workFolder=undefined
##vso[task.debug]loading inputs and endpoints
##vso[task.debug]loading INPUT_OUTPUTDIR
##vso[task.debug]loading INPUT_SITEDIR
##vso[task.debug]loading INPUT_SCANURLRELATIVEPATH
##vso[task.debug]loading INPUT_MAXURLS
##vso[task.debug]loading INPUT_SCANTIMEOUT
##vso[task.debug]loading INPUT_SINGLEWORKER
##vso[task.debug]loading INPUT_URL
##vso[task.debug]loading INPUT_BASELINEFILE
##vso[task.debug]loaded 8
##vso[task.debug]Agent.ProxyUrl=undefined
##vso[task.debug]Agent.CAInfo=undefined
##vso[task.debug]Agent.ClientCert=undefined
##vso[task.debug]Agent.SkipCertValidation=undefined
##vso[task.debug]scanTimeout=90000
##vso[task.debug]url=https://markreay.github.io/AU/before.html
##vso[task.debug]inputFile=undefined
##vso[task.debug]inputUrls=undefined
##vso[task.debug]discoveryPatterns=undefined
##vso[task.debug]outputDir=_accessibility-reports
##vso[task.debug]maxUrls=100
##vso[task.debug]chromePath=undefined
##vso[task.debug]url=https://markreay.github.io/AU/before.html
##vso[task.debug]singleWorker=true
##vso[task.debug]baselineFile=./test.baseline
##[debug]Starting accessibility scanning of URL https://markreay.github.io/AU/before.html
##[debug]Chrome app executable: system default
##[debug] PuppeteerCrawler:AutoscaledPool:Snapshotter: Setting max memory of this run to 4096 MB. Use the APIFY_MEMORY_MBYTES environment variable to override it.
##[debug] PuppeteerCrawler:AutoscaledPool: state {"currentConcurrency":0,"desiredConcurrency":1,"systemStatus":{"isSystemIdle":true,"memInfo":{"isOverloaded":false,"limitRatio":0.2,"actualRatio":null},"eventLoopInfo":{"isOverloaded":false,"limitRatio":0.4,"actualRatio":null},"cpuInfo":{"isOverloaded":false,"limitRatio":0.4,"actualRatio":null},"clientInfo":{"isOverloaded":false,"limitRatio":0.3,"actualRatio":null}}}
##[debug] Launching Puppeteer {"args":["--disable-dev-shm-usage","--no-sandbox","--disable-setuid-sandbox","--js-flags=--max-old-space-size=8192","--no-sandbox","--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36"],"defaultViewport":{"width":1920,"height":1080,"deviceScaleFactor":1},"timeout":15000,"headless":true}
Processing page https://markreay.github.io/AU/before.html
Discovered 4 links on page https://markreay.github.io/AU/before.html
Found 4 accessibility issues on page https://markreay.github.io/AU/before.html
##[debug] PuppeteerCrawler: All the requests from request list and/or request queue have been processed, the crawler will shut down.
##[debug] PuppeteerCrawler: Final request statistics: {"requestAvgFailedDurationMillis":null,"requestAvgFinishedDurationMillis":2914,"requestsFinishedPerMinute":20,"requestsFailedPerMinute":0,"requestTotalDurationMillis":2914,"requestsTotal":1,"crawlerRuntimeMillis":3033,"requestsFinished":1,"requestsFailed":0,"retryHistogram":[1]}
##vso[task.debug]outputDir=_accessibility-reports
Scan report saved successfully as /Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/_accessibility-reports/index.html
##[debug]Found 22 new violations compared to the baseline.
##[debug]Found 0 cases where a previously baselined violation was fixed.
##[debug]Saved new baseline file at /Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/_accessibility-reports/test.baseline
##[debug]To update the baseline with these changes, either rerun with --updateBaseline or copy the updated baseline file to /Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/test.baseline
##vso[task.debug]baselineFile=./test.baseline
### Results from Current Run
### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action

**22 failure instances**
* (4) **color-contrast**:  Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
* (1) **html-has-lang**:  Ensures every HTML document has a lang attribute
* (4) **image-alt**:  Ensures \<img> elements have alternate text or a role of none or presentation
* (13) **label**:  Ensures every form element has a label

**Baseline not detected**
To update the baseline with these changes, copy the updated baseline file to [scan arguments](undefined). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.

See all failures and scan details by downloading the report from [run artifacts](undefined)

---
#### Scan summary
**URLs**: 1 with failures, 0 passed, 0 not scannable
**Rules**: 22 with failures, 11 passed, 37 not applicable

---
This scan used [axe-core 4.3.2](https://github.com/dequelabs/axe-core/releases/tag/v4.3.2) with Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36.
##vso[task.debug]failOnAccessibilityError=undefined
##vso[task.debug]baselineFile=./test.baseline
##[error][Exception]VError: An error occurred while scanning website page https://markreay.github.io/AU/before.html: Failed: The baseline file does not match scan results. If this is a PR, check the PR comments.
    at Logger.trackExceptionAny (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:134706:29)
    at Scanner.<anonymous> (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:135826:29)
    at Generator.throw (<anonymous>)
    at rejected (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:135755:65) {
  jse_shortmsg: 'An error occurred while scanning website page https://markreay.github.io/AU/before.html',
  jse_cause: Error: Failed: The baseline file does not match scan results. If this is a PR, check the PR comments.
      at WorkflowEnforcer.failIfBaselineNeedsUpdating (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:130124:19)
      at WorkflowEnforcer.<anonymous> (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:130108:18)
      at Generator.next (<anonymous>)
      at /Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:130085:71
      at new Promise (<anonymous>)
      at __webpack_modules__../src/progress-reporter/enforcement/workflow-enforcer.ts.__awaiter (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:130081:12)
      at WorkflowEnforcer.completeRun (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:130106:16)
      at /Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:135391:45
      at AllProgressReporter.<anonymous> (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:135409:27)
      at Generator.next (<anonymous>)
      at fulfilled (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:135366:58),
  jse_info: {}
}
Accessibility scanning of URL https://markreay.github.io/AU/before.html completed
##[debug]Exception thrown in extension:  Error: Error: Failed: The baseline file does not match scan results. If this is a PR, check the PR comments.
    at WorkflowEnforcer.failIfBaselineNeedsUpdating (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:130124:19)
    at WorkflowEnforcer.<anonymous> (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:130108:18)
    at Generator.next (<anonymous>)
    at /Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:130085:71
    at new Promise (<anonymous>)
    at __webpack_modules__../src/progress-reporter/enforcement/workflow-enforcer.ts.__awaiter (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:130081:12)
    at WorkflowEnforcer.completeRun (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:130106:16)
    at /Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:135391:45
    at AllProgressReporter.<anonymous> (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:135409:27)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:135366:58)
    at WorkflowEnforcer.<anonymous> (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:130114:19)
    at Generator.next (<anonymous>)
    at /Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:130085:71
    at new Promise (<anonymous>)
    at __webpack_modules__../src/progress-reporter/enforcement/workflow-enforcer.ts.__awaiter (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:130081:12)
    at WorkflowEnforcer.failRun (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:130113:16)
    at /Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:135400:41
    at AllProgressReporter.<anonymous> (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:135409:27)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/index.js:135366:58)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

</details>

<details>
<summary>
Output after this change--baseline file doesn't match the scan results. Notice that the stack dumps are removed and that the message is called out with an `##[error]` tag near the end of the output
</summary>

```
##[group]Installing runtime dependencies
[1/4] 🔍  Resolving packages...
warning Lockfile has incorrect entry for "apify-shared@^0.5.0". Ignoring it.
warning Lockfile has incorrect entry for "socket.io@^2.3.0". Ignoring it.
warning Lockfile has incorrect entry for "underscore@1.12.1". Ignoring it.
warning Lockfile has incorrect entry for "apify-shared@^0.6.0". Ignoring it.
warning Lockfile has incorrect entry for "apify-shared@^0.1.45". Ignoring it.
warning Lockfile has incorrect entry for "css-what@^5.0.0". Ignoring it.
warning Lockfile has incorrect entry for "http-signature@~1.2.0". Ignoring it.
warning Lockfile has incorrect entry for "css-what@2.1". Ignoring it.
warning Lockfile has incorrect entry for "nth-check@~1.0.1". Ignoring it.
warning accessibility-insights-scan > apify > socket.io > debug@4.1.1: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
warning accessibility-insights-scan > apify > socket.io > socket.io-parser > debug@4.1.1: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
warning accessibility-insights-scan > apify > socket.io > engine.io > debug@4.1.1: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
warning Lockfile has incorrect entry for "axios@^0.21.1". Ignoring it.
warning Lockfile has incorrect entry for "marked@^2.0.0". Ignoring it.
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
##[endgroup]
##vso[task.debug]agent.TempDirectory=undefined
##vso[task.debug]agent.workFolder=undefined
##vso[task.debug]loading inputs and endpoints
##vso[task.debug]loading INPUT_OUTPUTDIR
##vso[task.debug]loading INPUT_SITEDIR
##vso[task.debug]loading INPUT_SCANURLRELATIVEPATH
##vso[task.debug]loading INPUT_MAXURLS
##vso[task.debug]loading INPUT_SCANTIMEOUT
##vso[task.debug]loading INPUT_SINGLEWORKER
##vso[task.debug]loading INPUT_URL
##vso[task.debug]loading INPUT_BASELINEFILE
##vso[task.debug]loaded 8
##vso[task.debug]Agent.ProxyUrl=undefined
##vso[task.debug]Agent.CAInfo=undefined
##vso[task.debug]Agent.ClientCert=undefined
##vso[task.debug]Agent.SkipCertValidation=undefined
##vso[task.debug]scanTimeout=90000
##vso[task.debug]url=https://markreay.github.io/AU/before.html
##vso[task.debug]inputFile=undefined
##vso[task.debug]inputUrls=undefined
##vso[task.debug]discoveryPatterns=undefined
##vso[task.debug]outputDir=_accessibility-reports
##vso[task.debug]maxUrls=100
##vso[task.debug]chromePath=undefined
##vso[task.debug]url=https://markreay.github.io/AU/before.html
##vso[task.debug]singleWorker=true
##vso[task.debug]baselineFile=./test.baseline
##[debug]Starting accessibility scanning of URL https://markreay.github.io/AU/before.html
##[debug]Chrome app executable: system default
##[debug] PuppeteerCrawler:AutoscaledPool:Snapshotter: Setting max memory of this run to 4096 MB. Use the APIFY_MEMORY_MBYTES environment variable to override it.
##[debug] PuppeteerCrawler:AutoscaledPool: state {"currentConcurrency":0,"desiredConcurrency":1,"systemStatus":{"isSystemIdle":true,"memInfo":{"isOverloaded":false,"limitRatio":0.2,"actualRatio":null},"eventLoopInfo":{"isOverloaded":false,"limitRatio":0.4,"actualRatio":null},"cpuInfo":{"isOverloaded":false,"limitRatio":0.4,"actualRatio":null},"clientInfo":{"isOverloaded":false,"limitRatio":0.3,"actualRatio":null}}}
##[debug] Launching Puppeteer {"args":["--disable-dev-shm-usage","--no-sandbox","--disable-setuid-sandbox","--js-flags=--max-old-space-size=8192","--no-sandbox","--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36"],"defaultViewport":{"width":1920,"height":1080,"deviceScaleFactor":1},"timeout":15000,"headless":true}
Processing page https://markreay.github.io/AU/before.html
Discovered 4 links on page https://markreay.github.io/AU/before.html
Found 4 accessibility issues on page https://markreay.github.io/AU/before.html
##[debug] PuppeteerCrawler: All the requests from request list and/or request queue have been processed, the crawler will shut down.
##[debug] PuppeteerCrawler: Final request statistics: {"requestAvgFailedDurationMillis":null,"requestAvgFinishedDurationMillis":2824,"requestsFinishedPerMinute":20,"requestsFailedPerMinute":0,"requestTotalDurationMillis":2824,"requestsTotal":1,"crawlerRuntimeMillis":2972,"requestsFinished":1,"requestsFailed":0,"retryHistogram":[1]}
##vso[task.debug]outputDir=_accessibility-reports
Scan report saved successfully as /Users/dtryon/repos/ada/action/MyFork/packages/ado-extension/dist/pkg/_accessibility-reports/index.html
##[debug]Found 22 new violations compared to the baseline.
##[debug]Found 0 cases where a previously baselined violation was fixed.
##[debug]Saved new baseline file at /Users/dtryon/repos/ada/action/MyFork/packages/ado-extension/dist/pkg/_accessibility-reports/test.baseline
##[debug]To update the baseline with these changes, either rerun with --updateBaseline or copy the updated baseline file to /Users/dtryon/repos/ada/action/MyFork/packages/ado-extension/dist/pkg/test.baseline
##vso[task.debug]baselineFile=./test.baseline
### Results from Current Run
### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action

**22 failure instances**
* (4) **color-contrast**:  Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
* (1) **html-has-lang**:  Ensures every HTML document has a lang attribute
* (4) **image-alt**:  Ensures \<img> elements have alternate text or a role of none or presentation
* (13) **label**:  Ensures every form element has a label

**Baseline not detected**
To update the baseline with these changes, copy the updated baseline file to [scan arguments](undefined). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.

See all failures and scan details by downloading the report from [run artifacts](undefined)

---
#### Scan summary
**URLs**: 1 with failures, 0 passed, 0 not scannable
**Rules**: 22 with failures, 11 passed, 37 not applicable

---
This scan used [axe-core 4.3.2](https://github.com/dequelabs/axe-core/releases/tag/v4.3.2) with Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36.
##vso[task.debug]failOnAccessibilityError=undefined
##vso[task.debug]baselineFile=./test.baseline
##[error]The baseline file does not match scan results.
Accessibility scanning of URL https://markreay.github.io/AU/before.html completed
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

</details>


##### Context

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Progress against #950
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
