### PR TITLE
(chore): Revert upgrades to V17.X of react types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,11 @@ updates:
   - dependency-name: marked-terminal
     versions:
     - ">= 5"
+    # office-ui-fabric-react is bound to v16 or @types/react
+  - dependency-name: @types/react
+    versions:
+    - ">= 17"
+    # office-ui-fabric-react is bound to v16 or @types/react
+  - dependency-name: @types/react-dom
+    versions:
+    - ">= 17"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,11 +33,11 @@ updates:
   - dependency-name: marked-terminal
     versions:
     - ">= 5"
-    # office-ui-fabric-react is bound to v16 or @types/react
+    # office-ui-fabric-react is bound to v16 of @types/react
   - dependency-name: @types/react
     versions:
     - ">= 17"
-    # office-ui-fabric-react is bound to v16 or @types/react
+    # office-ui-fabric-react is bound to v16 of @types/react
   - dependency-name: @types/react-dom
     versions:
     - ">= 17"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -28,7 +28,7 @@
     "homepage": "https://github.com/microsoft/accessibility-insights-action#readme",
     "devDependencies": {},
     "dependencies": {
-        "@types/react": "^17.0",
+        "@types/react": "^16.8",
         "@types/react-dom": "^16.8",
         "accessibility-insights-report": "4.2.1",
         "accessibility-insights-scan": "0.10.3",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -29,7 +29,7 @@
     "devDependencies": {},
     "dependencies": {
         "@types/react": "^17.0",
-        "@types/react-dom": "^17.0",
+        "@types/react-dom": "^16.8",
         "accessibility-insights-report": "4.2.1",
         "accessibility-insights-scan": "0.10.3",
         "axe-core": "4.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2235,14 +2235,23 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/react-dom@^17.0":
-  version "17.0.11"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
-  integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
+"@types/react-dom@^16.8":
+  version "16.9.14"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.14.tgz#674b8f116645fe5266b40b525777fc6bb8eb3bcd"
+  integrity sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==
   dependencies:
-    "@types/react" "*"
+    "@types/react" "^16"
 
-"@types/react@*", "@types/react@^17.0":
+"@types/react@^16":
+  version "16.14.23"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.23.tgz#37201b9f2324c5ff8fa4600dbf19079dfdffc880"
+  integrity sha512-WngBZLuSkP4IAgPi0HOsGCHo6dn3CcuLQnCfC17VbA7YBgipZiZoTOhObwl/93DsFW0Y2a/ZXeonpW4DxirEJg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17.0":
   version "17.0.39"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
   integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2242,19 +2242,10 @@
   dependencies:
     "@types/react" "^16"
 
-"@types/react@^16":
+"@types/react@^16", "@types/react@^16.8":
   version "16.14.23"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.23.tgz#37201b9f2324c5ff8fa4600dbf19079dfdffc880"
   integrity sha512-WngBZLuSkP4IAgPi0HOsGCHo6dn3CcuLQnCfC17VbA7YBgipZiZoTOhObwl/93DsFW0Y2a/ZXeonpW4DxirEJg==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17.0":
-  version "17.0.39"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
-  integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
#### Details

Revert #1043 and #1044 because the components, which moved @types/react and @types/react-dom from 16.X to 17.X. We have packages that are pinned to 16.X, so this leads to warnings when installing:

```
warning "accessibility-insights-report > office-ui-fabric-react@7.98.1" has incorrect peer dependency "@types/react@>=16.8.0 <17.0.0".
warning "accessibility-insights-report > office-ui-fabric-react@7.98.1" has incorrect peer dependency "@types/react-dom@>=16.8.0 <17.0.0".
warning "accessibility-insights-report > office-ui-fabric-react > @fluentui/react-focus@7.18.1" has incorrect peer dependency "@types/react@>=16.8.0 <17.0.0".
warning "accessibility-insights-report > office-ui-fabric-react > @fluentui/react-focus@7.18.1" has incorrect peer dependency "@types/react-dom@>=16.8.0 <17.0.0".
warning "accessibility-insights-report > office-ui-fabric-react > @uifabric/foundation@7.10.1" has incorrect peer dependency "@types/react@>=16.8.0 <17.0.0".
warning "accessibility-insights-report > office-ui-fabric-react > @uifabric/foundation@7.10.1" has incorrect peer dependency "@types/react-dom@>=16.8.0 
<17.0.0".
warning "accessibility-insights-report > office-ui-fabric-react > @uifabric/react-hooks@7.14.0" has incorrect peer dependency "@types/react@>=16.8.0 <17.0.0".
warning "accessibility-insights-report > office-ui-fabric-react > @uifabric/react-hooks@7.14.0" has incorrect peer dependency "@types/react-dom@>=16.8.0 <17.0.0".
warning "accessibility-insights-report > office-ui-fabric-react > @uifabric/utilities@7.33.5" has incorrect peer dependency "@types/react@>=16.8.0 <17.0.0".
warning "accessibility-insights-report > office-ui-fabric-react > @uifabric/utilities@7.33.5" has incorrect peer dependency "@types/react-dom@>=16.8.0 <17.0.0".
warning "accessibility-insights-report > office-ui-fabric-react > @uifabric/react-hooks > @fluentui/react-window-provider@1.0.2" has incorrect peer dependency "@types/react@>=16.8.0 <17.0.0".
warning "accessibility-insights-report > office-ui-fabric-react > @uifabric/react-hooks > @fluentui/react-window-provider@1.0.2" has incorrect peer dependency "@types/react-dom@>=16.8.0 <17.0.0".
warning "accessibility-insights-report > office-ui-fabric-react > @uifabric/styling > @fluentui/theme@1.7.4" has incorrect peer dependency "@types/react@>=16.8.0 <17.0.0".
warning "accessibility-insights-report > office-ui-fabric-react > @uifabric/styling > @fluentui/theme@1.7.4" has incorrect peer dependency "@types/react-dom@>=16.8.0 <17.0.0".
```

Reverting the update to 17.X prevents the warnings

##### Motivation

Keep the output clean

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
Dependabot will re-suggest these updates, so we'll just need to close it out and remember for the future (at least until the reports package moves to a newer version)

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
