### PR TITLE
feat(ado-improvements-1): Add grouping around scanner

### DIFF
--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -66,6 +66,7 @@ export class Scanner {
 
             scanArguments = this.crawlArgumentHandler.processScanArguments(localServerUrl);
 
+            this.logger.logInfo(`##[group]Scanning URL ${scanArguments.url}`);
             this.logger.logVerbose(`Starting accessibility scanning of URL ${scanArguments.url}`);
             this.logger.logVerbose(`Chrome app executable: ${scanArguments.chromePath ?? 'system default'}`);
 
@@ -79,6 +80,7 @@ export class Scanner {
             this.reportGenerator.generateReport(combinedReportParameters);
             await this.baselineFileUpdater.updateBaseline(scanArguments, combinedScanResult.baselineEvaluation);
 
+            this.logger.logInfo('##[endgroup]');
             await this.allProgressReporter.completeRun(combinedReportParameters, combinedScanResult.baselineEvaluation);
         } catch (error) {
             this.logger.trackExceptionAny(error, `An error occurred while scanning website page ${scanArguments?.url}`);


### PR DESCRIPTION
#### Details

Add a `##[group]` and `##[endgroup]` around the main body of the scanner output, so it's easier to focus on the summary that comes after the result. We intentionally close the group before calling `ProgressReporter.completeRun`, since that's the code that produces the output that is interesting to the user.

##### Motivation

Change requested in #950

##### Output samples (redacted)

Output before the change --note the only group is around the runtime dependencies

```
##[group]Installing runtime dependencies
// Lines redacted
##[endgroup]
##vso[task.debug]agent.TempDirectory=undefined
// Lines redacted
##vso[task.debug]baselineFile=undefined
##[debug]Starting accessibility scanning of URL https://markreay.github.io/AU/before.html
##[debug]Chrome app executable: system default
##[debug] PuppeteerCrawler:AutoscaledPool:Snapshotter: Setting max memory of this run to 4096 MB. Use the APIFY_MEMORY_MBYTES environment variable to override it.
##[debug] PuppeteerCrawler:AutoscaledPool: state {"currentConcurrency":0,"desiredConcurrency":1,"systemStatus":{"isSystemIdle":true,"memInfo":{"isOverloaded":false,"limitRatio":0.2,"actualRatio":null},"eventLoopInfo":{"isOverloaded":false,"limitRatio":0.4,"actualRatio":null},"cpuInfo":{"isOverloaded":false,"limitRatio":0.4,"actualRatio":null},"clientInfo":{"isOverloaded":false,"limitRatio":0.3,"actualRatio":null}}}
##[debug] Launching Puppeteer {"args":["--disable-dev-shm-usage","--no-sandbox","--disable-setuid-sandbox","--js-flags=--max-old-space-size=8192","--no-sandbox","--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36"],"defaultViewport":{"width":1920,"height":1080,"deviceScaleFactor":1},"timeout":15000,"headless":true}
Processing page https://markreay.github.io/AU/before.html
Discovered 4 links on page https://markreay.github.io/AU/before.html
Found 4 accessibility issues on page https://markreay.github.io/AU/before.html
##[debug] PuppeteerCrawler: All the requests from request list and/or request queue have been processed, the crawler will shut down.
##[debug] PuppeteerCrawler: Final request statistics: {"requestAvgFailedDurationMillis":null,"requestAvgFinishedDurationMillis":2690,"requestsFinishedPerMinute":21,"requestsFailedPerMinute":0,"requestTotalDurationMillis":2690,"requestsTotal":1,"crawlerRuntimeMillis":2842,"requestsFinished":1,"requestsFailed":0,"retryHistogram":[1]}
##vso[task.debug]outputDir=_accessibility-reports
Scan report saved successfully as /Users/dtryon/repos/ada/action/main/packages/ado-extension/dist/pkg/_accessibility-reports/index.html
##vso[task.debug]baselineFile=undefined
### Results from Current Run
### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
```

Output after the change --note the extra group/endgroup around the scanner detail

```
##[group]Installing runtime dependencies
// Lines redacted
##[endgroup]
##vso[task.debug]agent.TempDirectory=undefined
// Lines redacted
##vso[task.debug]baselineFile=undefined
##[group]Scanning URL https://markreay.github.io/AU/before.html
##[debug]Starting accessibility scanning of URL https://markreay.github.io/AU/before.html
##[debug]Chrome app executable: system default
##[debug] PuppeteerCrawler:AutoscaledPool:Snapshotter: Setting max memory of this run to 4096 MB. Use the APIFY_MEMORY_MBYTES environment variable to override it.
##[debug] PuppeteerCrawler:AutoscaledPool: state {"currentConcurrency":0,"desiredConcurrency":1,"systemStatus":{"isSystemIdle":true,"memInfo":{"isOverloaded":false,"limitRatio":0.2,"actualRatio":null},"eventLoopInfo":{"isOverloaded":false,"limitRatio":0.4,"actualRatio":null},"cpuInfo":{"isOverloaded":false,"limitRatio":0.4,"actualRatio":null},"clientInfo":{"isOverloaded":false,"limitRatio":0.3,"actualRatio":null}}}
##[debug] Launching Puppeteer {"args":["--disable-dev-shm-usage","--no-sandbox","--disable-setuid-sandbox","--js-flags=--max-old-space-size=8192","--no-sandbox","--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36"],"defaultViewport":{"width":1920,"height":1080,"deviceScaleFactor":1},"timeout":15000,"headless":true}
Processing page https://markreay.github.io/AU/before.html
Discovered 4 links on page https://markreay.github.io/AU/before.html
Found 4 accessibility issues on page https://markreay.github.io/AU/before.html
##[debug] PuppeteerCrawler: All the requests from request list and/or request queue have been processed, the crawler will shut down.
##[debug] PuppeteerCrawler: Final request statistics: {"requestAvgFailedDurationMillis":null,"requestAvgFinishedDurationMillis":8957,"requestsFinishedPerMinute":7,"requestsFailedPerMinute":0,"requestTotalDurationMillis":8957,"requestsTotal":1,"crawlerRuntimeMillis":9155,"requestsFinished":1,"requestsFailed":0,"retryHistogram":[1]}
##vso[task.debug]outputDir=_accessibility-reports
Scan report saved successfully as /Users/dtryon/repos/ada/action/MyFork/packages/ado-extension/dist/pkg/_accessibility-reports/index.html
##[endgroup]
##vso[task.debug]baselineFile=undefined
### Results from Current Run
### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights Action
```

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Progress toward #950
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
