### PR TITLE
feat(ado-improvements-1): Add Build summary upload to ADO

### DIFF
--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
@@ -24,10 +24,11 @@ describe(adoStdoutTransformer, () => {
         expect(output).toBe(expectedOutput);
     });
 
+    // Note, a test for ##vso[task.uploadsummary] can't be added because ADO attempts to evaluate it and fails the test suite.
+    // See results here: https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=30878&view=logs&j=81b7b1a0-9e2e-58a5-1601-69aaad9b82d6&t=24cd6560-9d76-5a2b-d63a-565b4fa97a0b&l=448
     it.each`
         input
         ${'##vso[task.debug]abc'}
-        ${'##vso[task.uploadsummary]abc'}
         ${'Processing page abc'}
         ${'Discovered 2 links on page abc'}
         ${'Discovered 2345 links on page abc'}

--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
@@ -24,8 +24,12 @@ describe(adoStdoutTransformer, () => {
         expect(output).toBe(expectedOutput);
     });
 
-    // Note, a test for ##vso[task.uploadsummary] can't be added because ADO attempts to evaluate it and fails the test suite.
-    // See results here: https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=30878&view=logs&j=81b7b1a0-9e2e-58a5-1601-69aaad9b82d6&t=24cd6560-9d76-5a2b-d63a-565b4fa97a0b&l=448
+    // Note: Output results for ##vso[task.uploadsummary] can't be added to the output text of the test because ADO attempts to evaluate it and fails the test suite.
+    test('Upload summary ADO command returns as expected', () => {
+        const output = adoStdoutTransformer('##vso[task.uploadsummary]');
+        expect(output).toBe('##vso[task.uploadsummary]');
+    });
+
     it.each`
         input
         ${'##vso[task.debug]abc'}

--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
@@ -27,6 +27,7 @@ describe(adoStdoutTransformer, () => {
     it.each`
         input
         ${'##vso[task.debug]abc'}
+        ${'##vso[task.uploadsummary]abc'}
         ${'Processing page abc'}
         ${'Discovered 2 links on page abc'}
         ${'Discovered 2345 links on page abc'}

--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.ts
@@ -14,6 +14,10 @@ const regexTransformations: RegexTransformation[] = [
         method: useUnmodifiedString,
     },
     {
+        regex: new RegExp('^##vso\\[task.uploadsummary\\]'),
+        method: useUnmodifiedString,
+    },
+    {
         regex: new RegExp('^Processing page .*'),
         method: useUnmodifiedString,
     },

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -46,7 +46,7 @@ describe(AdoConsoleCommentCreator, () => {
             const baselineInfoStub = {};
             const reportMarkdownStub = '#ReportMarkdownStub';
 
-            const expectedLogOutput = AdoConsoleCommentCreator.CURRENT_COMMENT_TITLE + reportMarkdownStub;
+            const expectedLogOutput = reportMarkdownStub;
 
             adoTaskConfigMock
                 .setup((atcm) => atcm.getBaselineFile())
@@ -59,14 +59,14 @@ describe(AdoConsoleCommentCreator, () => {
                 .verifiable(Times.once());
 
             reportMarkdownConvertorMock
-                .setup((o) => o.convert(reportStub, AdoConsoleCommentCreator.CURRENT_COMMENT_TITLE, baselineInfoStub))
+                .setup((o) => o.convert(reportStub, undefined, baselineInfoStub))
                 .returns(() => expectedLogOutput)
-                .verifiable(Times.once());
+                .verifiable(Times.exactly(2));
 
             loggerMock.setup((lm) => lm.logInfo(expectedLogOutput)).verifiable(Times.once());
             loggerMock.setup((lm) => lm.logInfo(`##vso[task.uploadsummary]${fileName}`)).verifiable(Times.once());
             loggerMock
-                .setup((lm) => lm.logInfo('Report output directory does not exists. Creating directory reportOutDir'))
+                .setup((lm) => lm.logInfo('Report output directory does not exist. Creating directory reportOutDir'))
                 .verifiable(Times.once());
 
             fsMock

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -89,7 +89,13 @@ describe(AdoConsoleCommentCreator, () => {
     });
 
     const buildAdoConsoleCommentCreatorWithMocks = (): AdoConsoleCommentCreator =>
-        new AdoConsoleCommentCreator(adoTaskConfigMock.object, reportMarkdownConvertorMock.object, loggerMock.object);
+        new AdoConsoleCommentCreator(
+            adoTaskConfigMock.object,
+            reportMarkdownConvertorMock.object,
+            loggerMock.object,
+            adoTaskConfigMock.object,
+            {} as typeof import('fs'),
+        );
 
     const verifyAllMocks = () => {
         adoTaskConfigMock.verifyAll();

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -65,15 +65,6 @@ describe(AdoConsoleCommentCreator, () => {
 
             loggerMock.setup((lm) => lm.logInfo(expectedLogOutput)).verifiable(Times.once());
             loggerMock.setup((lm) => lm.logInfo(`##vso[task.uploadsummary]${fileName}`)).verifiable(Times.once());
-            loggerMock
-                .setup((lm) => lm.logInfo('Report output directory does not exist. Creating directory reportOutDir'))
-                .verifiable(Times.once());
-
-            fsMock
-                .setup((fsm) => fsm.existsSync(reportOutDir))
-                .returns(() => false)
-                .verifiable();
-            fsMock.setup((fsm) => fsm.mkdirSync(reportOutDir)).verifiable();
             fsMock.setup((fsm) => fsm.writeFileSync(fileName, expectedLogOutput)).verifiable();
 
             adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks();

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -57,13 +57,6 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
         const fileName = `${outDirectory}/results.md`;
 
         // eslint-disable-next-line security/detect-non-literal-fs-filename
-        if (!this.fileSystemObj.existsSync(outDirectory)) {
-            this.logger.logInfo(`Report output directory does not exist. Creating directory ${outDirectory}`);
-            // eslint-disable-next-line security/detect-non-literal-fs-filename
-            this.fileSystemObj.mkdirSync(outDirectory);
-        }
-
-        // eslint-disable-next-line security/detect-non-literal-fs-filename
         this.fileSystemObj.writeFileSync(fileName, reportMarkdown);
         this.logger.logInfo(`##vso[task.uploadsummary]${fileName}`);
     }

--- a/packages/shared/src/report/consolidated-report-generator.spec.ts
+++ b/packages/shared/src/report/consolidated-report-generator.spec.ts
@@ -42,11 +42,6 @@ describe(ConsolidatedReportGenerator, () => {
             .setup((o) => o.getReportOutDir())
             .returns(() => reportOutDir)
             .verifiable();
-        fsMock
-            .setup((o) => o.existsSync(reportOutDir))
-            .returns(() => false)
-            .verifiable();
-        fsMock.setup((o) => o.mkdirSync(reportOutDir)).verifiable();
         fsMock.setup((o) => o.writeFileSync(reportFileName, htmlReportString)).verifiable();
 
         consolidatedReportGenerator = new ConsolidatedReportGenerator(

--- a/packages/shared/src/report/consolidated-report-generator.ts
+++ b/packages/shared/src/report/consolidated-report-generator.ts
@@ -24,13 +24,6 @@ export class ConsolidatedReportGenerator {
         const outDirectory = this.taskConfig.getReportOutDir();
         const reportFileName = `${outDirectory}/index.html`;
 
-        // eslint-disable-next-line security/detect-non-literal-fs-filename
-        if (!this.fileSystemObj.existsSync(outDirectory)) {
-            this.logger.logInfo(`Report output directory does not exists. Creating directory ${outDirectory}`);
-            // eslint-disable-next-line security/detect-non-literal-fs-filename
-            this.fileSystemObj.mkdirSync(outDirectory);
-        }
-
         this.saveHtmlReport(reportFileName, htmlReportContent);
 
         return reportFileName;


### PR DESCRIPTION
#### Details

This adds logic to upload a build summary to the ADO extension that displays in the Extension tab. You can view a sample output here: [ADO Extension run Extension Tab output](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=30880&view=ms.vss-build-web.run-extensions-tab)

This also removes the PR Comment titles that were left over from when we switched things over to console.


##### Motivation

Feature work

##### Context

Currently the reportMarkdownConverter.convert() method is called in two separate places with the same parameters in the AdoConsoleCommentCreator. The LogResultsToConsole instance will change in a future PR, which is why I've left them separate instead of refactoring to only have it convert to markdown once.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
