### PR TITLE
chore(deps): fix invalid yaml syntax in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,10 +34,10 @@ updates:
     versions:
     - ">= 5"
     # office-ui-fabric-react is bound to v16 of @types/react
-  - dependency-name: @types/react
+  - dependency-name: "@types/react"
     versions:
     - ">= 17"
     # office-ui-fabric-react is bound to v16 of @types/react
-  - dependency-name: @types/react-dom
+  - dependency-name: "@types/react-dom"
     versions:
     - ">= 17"


### PR DESCRIPTION
#### Details

This PR fixes a bit of invalid YAML syntax introduced into `dependabot.yml` in #1047. This was causing the following error when dependabot tries to parse the config file, leading it to ignore the update and keep using the configuration as of the previous commit. The error message indicating this can be found on this repo's [Insights > Dependency Graph > Dependabot page](https://github.com/microsoft/accessibility-insights-action/network/updates):

> Dependabot couldn't parse the config file at .github/dependabot.yml. The error raised was:
>
> (`<unknown>`): found character that cannot start any token while scanning for the next token at line 37 column 22
Please ensure the config file is a valid YAML file. An online YAML linter is available [here](https://jsonformatter.org/yaml-validator).
>
> [Learn more](https://docs.github.com/github/administering-a-repository/keeping-your-dependencies-updated-automatically)

##### Motivation

Fixing this should prevent Dependabot from raising @types/react and @types/react-dom PRs like #1049 and #1050

##### Context

I spot checked that none of our other repos have a similar misconfiguration using the following ripgrep command from my "repos" folder:

```
rg --iglob '**/.github/dependabot.yml' --hidden 'dependency-name: @'
```

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
