### PR TITLE
feat(ado-improvements-1): Update baseline output on error

### DIFF
--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
@@ -37,7 +37,6 @@ describe(adoStdoutTransformer, () => {
     it.each`
         input
         ${'##vso[task.debug]abc'}
-        ${'##vso[task.logissue]abc'}
         ${'Processing page abc'}
         ${'Discovered 2 links on page abc'}
         ${'Discovered 2345 links on page abc'}

--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
@@ -33,6 +33,7 @@ describe(adoStdoutTransformer, () => {
     it.each`
         input
         ${'##vso[task.debug]abc'}
+        ${'##vso[task.logissue]abc'}
         ${'Processing page abc'}
         ${'Discovered 2 links on page abc'}
         ${'Discovered 2345 links on page abc'}

--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
@@ -24,10 +24,14 @@ describe(adoStdoutTransformer, () => {
         expect(output).toBe(expectedOutput);
     });
 
-    // Note: Output results for ##vso[task.uploadsummary] can't be added to the output text of the test because ADO attempts to evaluate it and fails the test suite.
-    test('Upload summary ADO command returns as expected', () => {
-        const output = adoStdoutTransformer('##vso[task.uploadsummary]');
-        expect(output).toBe('##vso[task.uploadsummary]');
+    // Note: these are special logging commands in ADO that can't be added to the output text of the test because ADO attempts to evaluate them and fails or throws warnings.
+    it.each`
+        input                          | expectedOutput
+        ${'##vso[task.uploadsummary]'} | ${'##vso[task.uploadsummary]'}
+        ${'##vso[task.logissue]abc'}   | ${'##vso[task.logissue]abc'}
+    `(`ADO Special logging command: '$input' returned as '$expectedOutput'`, ({ input, expectedOutput }) => {
+        const output = adoStdoutTransformer(input);
+        expect(output).toBe(expectedOutput);
     });
 
     it.each`

--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.ts
@@ -18,6 +18,10 @@ const regexTransformations: RegexTransformation[] = [
         method: useUnmodifiedString,
     },
     {
+        regex: new RegExp('^##vso\\[task.logissue\\]'),
+        method: useUnmodifiedString,
+    },
+    {
         regex: new RegExp('^Processing page .*'),
         method: useUnmodifiedString,
     },

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.spec.ts
@@ -59,7 +59,7 @@ describe(WorkflowEnforcer, () => {
             setupBaselineFileParameterExists();
             loggerMock
                 .setup((o) =>
-                    o.logInfo(`##vso[task.logissue type=error] The baseline file found at baseline-file does not match scan results.`),
+                    o.logInfo(`##vso[task.logissue type=error;sourcepath=baseline-file] The baseline file does not match scan results.`),
                 )
                 .verifiable(Times.once());
 

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.spec.ts
@@ -57,9 +57,11 @@ describe(WorkflowEnforcer, () => {
 
             setupFailOnAccessibilityError(false);
             setupBaselineFileParameterExists();
-            setupLoggerWithErrorMessage(
-                `##vso[task.logissue type=error;sourcepath=baseline-file] The baseline file does not match scan results.`,
-            );
+            loggerMock
+                .setup((o) =>
+                    o.logInfo(`##vso[task.logissue type=error;sourcepath=baseline-file] The baseline file does not match scan results.`),
+                )
+                .verifiable(Times.once());
 
             const workflowEnforcer = buildWorkflowEnforcerWithMocks();
 

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.spec.ts
@@ -57,7 +57,9 @@ describe(WorkflowEnforcer, () => {
 
             setupFailOnAccessibilityError(false);
             setupBaselineFileParameterExists();
-            setupLoggerWithErrorMessage('The baseline file does not match scan results.');
+            setupLoggerWithErrorMessage(
+                `##vso[task.logissue type=error;sourcepath=baseline-file] The baseline file does not match scan results.`,
+            );
 
             const workflowEnforcer = buildWorkflowEnforcerWithMocks();
 

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.spec.ts
@@ -59,7 +59,7 @@ describe(WorkflowEnforcer, () => {
             setupBaselineFileParameterExists();
             loggerMock
                 .setup((o) =>
-                    o.logInfo(`##vso[task.logissue type=error;sourcepath=baseline-file] The baseline file does not match scan results.`),
+                    o.logInfo(`##vso[task.logissue type=error] The baseline file found at baseline-file does not match scan results.`),
                 )
                 .verifiable(Times.once());
 

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
@@ -48,7 +48,7 @@ export class WorkflowEnforcer extends ProgressReporter {
         if (baselineEvaluation && this.adoTaskConfig.getBaselineFile() && baselineEvaluation.suggestedBaselineUpdate) {
             this.logger.logInfo(
                 // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-                `##vso[task.logissue type=error] The baseline file found at ${this.adoTaskConfig.getBaselineFile()} does not match scan results.`,
+                `##vso[task.logissue type=error;sourcepath=${this.adoTaskConfig.getBaselineFile()}] The baseline file does not match scan results.`,
             );
             await this.failRun();
             return true;

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
@@ -48,7 +48,7 @@ export class WorkflowEnforcer extends ProgressReporter {
         if (baselineEvaluation && this.adoTaskConfig.getBaselineFile() && baselineEvaluation.suggestedBaselineUpdate) {
             this.logger.logInfo(
                 // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-                `##vso[task.logissue type=error;sourcepath=${this.adoTaskConfig.getBaselineFile()}] The baseline file does not match scan results.`,
+                `##vso[task.logissue type=error] The baseline file found at ${this.adoTaskConfig.getBaselineFile()} does not match scan results.`,
             );
             await this.failRun();
             return true;

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
@@ -46,7 +46,10 @@ export class WorkflowEnforcer extends ProgressReporter {
 
     private async failIfBaselineNeedsUpdating(baselineEvaluation?: BaselineEvaluation): Promise<boolean> {
         if (baselineEvaluation && this.adoTaskConfig.getBaselineFile() && baselineEvaluation.suggestedBaselineUpdate) {
-            this.logger.logError('The baseline file does not match scan results.');
+            this.logger.logInfo(
+                // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+                `##vso[task.logissue type=error;sourcepath=${this.adoTaskConfig.getBaselineFile()}] The baseline file does not match scan results.`,
+            );
             await this.failRun();
             return true;
         }


### PR DESCRIPTION
#### Details

This is the final change required in #950, it adds error output for when the baseline file does not match the scan results.

It now adds an error message and also throws an exception, which will help guide users to update their baseline file when needed.

```
##[error]baselines/my-web-site.baseline(,): error :  The baseline file does not match scan results.
```

##### Motivation

addresses #950 

##### Context

Unfortunately the `task.logissue` logging command in ADO gives an extra trailing `(,)` on the error message.  This is still a big improvement over the previous error message that we had that is not actionable.  The `(,)` is supposed to be for line number/column number of the error, but that's not applicable in our case.

Also it says error twice, I looked into whether we can remove the second instance of the word Error.  These are automatically generated by ADO, we don't have control over this.

See an example pipeline output here: [Pipelines - Run 20220224.20 logs (azure.com)](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=31132&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=7384d774-f7ca-599c-ee57-ab2c05be9247)

I also tried pulling the full path into the error message but it pulls in the ADO artifact path, which is not relevant and would be confusing to the user.  You can see the output of that here: [Pipelines - Run 20220224.22 logs (azure.com)](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=31141&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=7384d774-f7ca-599c-ee57-ab2c05be9247)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes #950
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
