### PR TITLE
chore: updating default yarn start behavior to scan local website

### DIFF
--- a/packages/ado-extension/scripts/local-overrides.json
+++ b/packages/ado-extension/scripts/local-overrides.json
@@ -1,7 +1,11 @@
 [
     {
-        "name": "url",
-        "value": "https://markreay.github.io/AU/before.html"
+        "name": "siteDir",
+        "value": "../../dev/website-root/"
+    },
+    {
+        "name": "scanUrlRelativePath",
+        "value": "/"
     },
     {
         "name": "failOnAccessibilityError",


### PR DESCRIPTION
#### Details

This updates the default behavior of the `yarn start` command in the ADO extension to scan a website local to the repo rather than making an external request. This will also allow for easier testing of various scenarios, including baselining.

Output from run:
```                       
yarn run v1.22.17
$ node scripts/run-locally.js
run-locally.js is setting up input outputDir to value _accessibility-reports
run-locally.js is setting up input siteDir to value ../../dev/website-root/
run-locally.js is setting up input scanUrlRelativePath to value /
run-locally.js is setting up input maxUrls to value 100
run-locally.js is setting up input scanTimeout to value 90000
run-locally.js is setting up input singleWorker to value true
run-locally.js is setting up input failOnAccessibilityError to value false
beginning task execution below

##[group]Installing runtime dependencies
[1/4] Resolving packages...
warning Lockfile has incorrect entry for "apify-shared@^0.5.0". Ignoring it.
warning Lockfile has incorrect entry for "socket.io@^2.3.0". Ignoring it.
warning Lockfile has incorrect entry for "underscore@1.12.1". Ignoring it.
warning Lockfile has incorrect entry for "axios@^0.21.1". Ignoring it.
warning Lockfile has incorrect entry for "marked@^2.0.0". Ignoring it.
warning Lockfile has incorrect entry for "apify-shared@^0.6.0". Ignoring it.
warning Lockfile has incorrect entry for "apify-shared@^0.1.45". Ignoring it.
warning Lockfile has incorrect entry for "http-signature@~1.2.0". Ignoring it.
warning Lockfile has incorrect entry for "css-what@^5.0.0". Ignoring it.
warning Lockfile has incorrect entry for "css-what@2.1". Ignoring it.
warning Lockfile has incorrect entry for "nth-check@~1.0.1". Ignoring it.
warning accessibility-insights-scan > apify > socket.io > debug@4.1.1: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
warning accessibility-insights-scan > apify > socket.io > socket.io-parser > debug@4.1.1: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
warning accessibility-insights-scan > apify > socket.io > engine.io > debug@4.1.1: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
##[endgroup]
##vso[task.debug]agent.TempDirectory=undefined
##vso[task.debug]agent.workFolder=undefined
##vso[task.debug]loading inputs and endpoints
##vso[task.debug]loading INPUT_OUTPUTDIR
##vso[task.debug]loading INPUT_SITEDIR
##vso[task.debug]loading INPUT_SCANURLRELATIVEPATH
##vso[task.debug]loading INPUT_MAXURLS
##vso[task.debug]loading INPUT_SCANTIMEOUT
##vso[task.debug]loading INPUT_SINGLEWORKER
##vso[task.debug]loading INPUT_FAILONACCESSIBILITYERROR
##vso[task.debug]loaded 7
##vso[task.debug]Agent.ProxyUrl=undefined
##vso[task.debug]Agent.CAInfo=undefined
##vso[task.debug]Agent.ClientCert=undefined
##vso[task.debug]Agent.SkipCertValidation=undefined
##vso[task.debug]scanTimeout=90000
##vso[task.debug]outputDir=_accessibility-reports
##vso[task.debug]url=undefined
##vso[task.debug]localhostPort=undefined
##vso[task.debug]siteDir=../../dev/website-root/
Started local web server. Url: http://localhost:35101 Root directory: ../../dev/website-root/
##vso[task.debug]inputFile=undefined
##vso[task.debug]inputUrls=undefined
##vso[task.debug]discoveryPatterns=undefined
##vso[task.debug]outputDir=_accessibility-reports
##vso[task.debug]maxUrls=100
##vso[task.debug]chromePath=undefined
##vso[task.debug]url=undefined
##vso[task.debug]singleWorker=true
##vso[task.debug]baselineFile=undefined
##vso[task.debug]scanUrlRelativePath=/
##[group]Scanning URL http://localhost:35101/
##[debug]Starting accessibility scanning of URL http://localhost:35101/
##[debug]Chrome app executable: system default
##[debug] PuppeteerCrawler:AutoscaledPool:Snapshotter: Setting max memory of this run to 5994 MB. Use the APIFY_MEMORY_MBYTES environment variable to override it.
##[debug] PuppeteerCrawler:AutoscaledPool: state {"currentConcurrency":0,"desiredConcurrency":1,"systemStatus":{"isSystemIdle":true,"memInfo":{"isOverloaded":false,"limitRatio":0.2,"actualRatio":null},"eventLoopInfo":{"isOverloaded":false,"limitRatio":0.4,"actualRatio":null},"cpuInfo":{"isOverloaded":false,"limitRatio":0.4,"actualRatio":null},"clientInfo":{"isOverloaded":false,"limitRatio":0.3,"actualRatio":null}}}
##[debug] Launching Puppeteer {"args":["--disable-dev-shm-usage","--no-sandbox","--disable-setuid-sandbox","--js-flags=--max-old-space-size=8192","--no-sandbox","--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36"],"defaultViewport":{"width":1920,"height":1080,"deviceScaleFactor":1},"timeout":15000,"headless":true}
Processing page http://localhost:35101/
Discovered 2 links on page http://localhost:35101/
Found 3 accessibility issues on page http://localhost:35101/
Processing page http://localhost:35101/linked1/
Discovered 2 links on page http://localhost:35101/linked1/
Processing page http://localhost:35101/linked2/
Discovered 1 links on page http://localhost:35101/linked2/
Processing page http://localhost:35101/linked1/inner-page.html
Discovered 1 links on page http://localhost:35101/linked1/inner-page.html
Found 2 accessibility issues on page http://localhost:35101/linked1/inner-page.html
##[debug] PuppeteerCrawler: All the requests from request list and/or request queue have been processed, the crawler will shut down.
##[debug] PuppeteerCrawler: Final request statistics: {"requestAvgFailedDurationMillis":null,"requestAvgFinishedDurationMillis":1802,"requestsFinishedPerMinute":33,"requestsFailedPerMinute":0,"requestTotalDurationMillis":7208,"requestsTotal":4,"crawlerRuntimeMillis":7237,"requestsFinished":4,"requestsFailed":0,"retryHistogram":[4]}
##vso[task.debug]outputDir=_accessibility-reports
Scan report saved successfully as /home/brock/projects/ai-action/packages/ado-extension/dist/pkg/_accessibility-reports/index.html
##[endgroup]
##vso[task.debug]baselineFile=undefined
##vso[task.debug]outputDir=_accessibility-reports
##vso[task.uploadsummary]/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/_accessibility-reports/results.md

Accessibility Insights

7 failure instances
* (3) label:  Ensures every form element has a label
* (2) html-has-lang:  Ensures every HTML document has a lang attribute
* (2) image-alt:  Ensures <img> elements have alternate text or a role of none or presentation

Baseline not configured
A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See baselining docs (https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.

See all failures and scan details by downloading the report from run artifacts (undefined)

-------------------
Scan summary
URLs: 2 with failures, 2 passed, 0 not scannable
Rules: 6 with failures, 11 passed, 38 not applicable

-------------------
This scan used axe-core 4.3.2 (https://github.com/dequelabs/axe-core/releases/tag/v4.3.2) with Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36.

##vso[task.debug]failOnAccessibilityError=false
Accessibility scanning of URL http://localhost:35101/ completed
Done in 11.65s.
```



##### Motivation

Improving local dev experience

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
