### PR TITLE
fix: rules with failures count in markdown and console output

### DIFF
--- a/packages/shared/src/console-output/__snapshots__/result-console-log-builder.spec.ts.snap
+++ b/packages/shared/src/console-output/__snapshots__/result-console-log-builder.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`ResultConsoleLogBuilder builds content with failures 1`] = `
 "Accessibility Insights
 * URLs: 5 URL(s) failed, 1 URL(s) passed, and 7 were not scannable
-* Rules: 4 check(s) failed, 1 check(s) passed, and 2 were not applicable
+* Rules: 2 check(s) failed, 1 check(s) passed, and 2 were not applicable
 * Download the Accessibility Insights artifact to view the detailed results of these checks
 Failed instances
 * 3 × rule id:  rule description
@@ -60,7 +60,7 @@ See all failures and scan details by downloading the report from run artifacts (
 -------------------
 Scan summary
 URLs: 5 with failures, 1 passed, 7 not scannable
-Rules: 4 with failures, 1 passed, 2 not applicable
+Rules: 2 with failures, 1 passed, 2 not applicable
 
 -------------------
 This scan used axe-core axeVersion (https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent.
@@ -85,7 +85,7 @@ See all failures and scan details by downloading the report from run artifacts (
 -------------------
 Scan summary
 URLs: 5 with failures, 1 passed, 7 not scannable
-Rules: 4 with failures, 1 passed, 2 not applicable
+Rules: 2 with failures, 1 passed, 2 not applicable
 
 -------------------
 This scan used axe-core axeVersion (https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent.
@@ -109,7 +109,7 @@ See all failures and scan details by downloading the report from run artifacts (
 -------------------
 Scan summary
 URLs: 5 with failures, 1 passed, 7 not scannable
-Rules: 4 with failures, 1 passed, 2 not applicable
+Rules: 2 with failures, 1 passed, 2 not applicable
 
 -------------------
 This scan used axe-core axeVersion (https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent.
@@ -132,7 +132,7 @@ See all failures and scan details by downloading the report from run artifacts (
 -------------------
 Scan summary
 URLs: 5 with failures, 1 passed, 7 not scannable
-Rules: 4 with failures, 1 passed, 2 not applicable
+Rules: 2 with failures, 1 passed, 2 not applicable
 
 -------------------
 This scan used axe-core axeVersion (https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent.
@@ -179,7 +179,7 @@ See all failures and scan details by downloading the report from run artifacts (
 -------------------
 Scan summary
 URLs: 5 with failures, 1 passed, 7 not scannable
-Rules: 4 with failures, 1 passed, 2 not applicable
+Rules: 2 with failures, 1 passed, 2 not applicable
 
 -------------------
 This scan used axe-core axeVersion (https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent.
@@ -202,7 +202,7 @@ See all failures and scan details by downloading the report from run artifacts (
 -------------------
 Scan summary
 URLs: 5 with failures, 1 passed, 7 not scannable
-Rules: 4 with failures, 1 passed, 2 not applicable
+Rules: 2 with failures, 1 passed, 2 not applicable
 
 -------------------
 This scan used axe-core axeVersion (https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent.
@@ -296,7 +296,7 @@ See all failures and scan details by downloading the report from run artifacts (
 -------------------
 Scan summary
 URLs: 5 with failures, 1 passed, 7 not scannable
-Rules: 4 with failures, 1 passed, 2 not applicable
+Rules: 2 with failures, 1 passed, 2 not applicable
 
 -------------------
 This scan used axe-core axeVersion (https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent.

--- a/packages/shared/src/console-output/result-console-log-builder.ts
+++ b/packages/shared/src/console-output/result-console-log-builder.ts
@@ -28,7 +28,7 @@ export class ResultConsoleLogBuilder {
     public buildContent(combinedReportResult: CombinedReportParameters, title?: string, baselineInfo?: BaselineInfo): string {
         const passedChecks = combinedReportResult.results.resultsByRule.passed.length;
         const inapplicableChecks = combinedReportResult.results.resultsByRule.notApplicable.length;
-        const failedChecks = combinedReportResult.results.resultsByRule.failed.reduce((a, b) => a + b.failed.length, 0);
+        const failedChecks = combinedReportResult.results.resultsByRule.failed.length;
 
         let lines = [
             failedChecks === 0 ? this.headingWithMessage('All applicable checks passed') : this.headingWithMessage(),

--- a/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
+++ b/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`ResultMarkdownBuilder builds content with failures 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 * **URLs**: 5 URL(s) failed, 1 URL(s) passed, and 7 were not scannable
-* **Rules**: 4 check(s) failed, 1 check(s) passed, and 2 were not applicable
+* **Rules**: 2 check(s) failed, 1 check(s) passed, and 2 were not applicable
 * Download the **Accessibility Insights artifact** to view the detailed results of these checks
 #### Failed instances
 * **3 × rule id**:  rule description
@@ -56,7 +56,7 @@ See all failures and scan details by downloading the report from [run artifacts]
 ---
 #### Scan summary
 **URLs**: 5 with failures, 1 passed, 7 not scannable
-**Rules**: 4 with failures, 1 passed, 2 not applicable
+**Rules**: 2 with failures, 1 passed, 2 not applicable
 
 ---
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
@@ -79,7 +79,7 @@ See all failures and scan details by downloading the report from [run artifacts]
 ---
 #### Scan summary
 **URLs**: 5 with failures, 1 passed, 7 not scannable
-**Rules**: 4 with failures, 1 passed, 2 not applicable
+**Rules**: 2 with failures, 1 passed, 2 not applicable
 
 ---
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
@@ -101,7 +101,7 @@ See all failures and scan details by downloading the report from [run artifacts]
 ---
 #### Scan summary
 **URLs**: 5 with failures, 1 passed, 7 not scannable
-**Rules**: 4 with failures, 1 passed, 2 not applicable
+**Rules**: 2 with failures, 1 passed, 2 not applicable
 
 ---
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
@@ -122,7 +122,7 @@ See all failures and scan details by downloading the report from [run artifacts]
 ---
 #### Scan summary
 **URLs**: 5 with failures, 1 passed, 7 not scannable
-**Rules**: 4 with failures, 1 passed, 2 not applicable
+**Rules**: 2 with failures, 1 passed, 2 not applicable
 
 ---
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
@@ -165,7 +165,7 @@ See all failures and scan details by downloading the report from [run artifacts]
 ---
 #### Scan summary
 **URLs**: 5 with failures, 1 passed, 7 not scannable
-**Rules**: 4 with failures, 1 passed, 2 not applicable
+**Rules**: 2 with failures, 1 passed, 2 not applicable
 
 ---
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
@@ -186,7 +186,7 @@ See all failures and scan details by downloading the report from [run artifacts]
 ---
 #### Scan summary
 **URLs**: 5 with failures, 1 passed, 7 not scannable
-**Rules**: 4 with failures, 1 passed, 2 not applicable
+**Rules**: 2 with failures, 1 passed, 2 not applicable
 
 ---
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
@@ -272,7 +272,7 @@ See all failures and scan details by downloading the report from [run artifacts]
 ---
 #### Scan summary
 **URLs**: 5 with failures, 1 passed, 7 not scannable
-**Rules**: 4 with failures, 1 passed, 2 not applicable
+**Rules**: 2 with failures, 1 passed, 2 not applicable
 
 ---
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."

--- a/packages/shared/src/mark-down/result-markdown-builder.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.ts
@@ -28,7 +28,7 @@ export class ResultMarkdownBuilder {
     public buildContent(combinedReportResult: CombinedReportParameters, title?: string, baselineInfo?: BaselineInfo): string {
         const passedChecks = combinedReportResult.results.resultsByRule.passed.length;
         const inapplicableChecks = combinedReportResult.results.resultsByRule.notApplicable.length;
-        const failedChecks = combinedReportResult.results.resultsByRule.failed.reduce((a, b) => a + b.failed.length, 0);
+        const failedChecks = combinedReportResult.results.resultsByRule.failed.length;
 
         let lines = [
             failedChecks === 0 ? this.headingWithMessage('All applicable checks passed') : this.headingWithMessage(),


### PR DESCRIPTION
#### Details

This fixes the calculation of the rules with failures in both the markdown and console output.

Previous output below, note that 3 rules failed but the count says 6:
```
Accessibility Insights

7 failure instances
* (3) label:  Ensures every form element has a label
* (2) html-has-lang:  Ensures every HTML document has a lang attribute
* (2) image-alt:  Ensures <img> elements have alternate text or a role of none or presentation

Baseline not configured
A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See baselining docs (https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.

See all failures and scan details by downloading the report from run artifacts (undefined)

-------------------
Scan summary
URLs: 2 with failures, 2 passed, 0 not scannable
Rules: 6 with failures, 11 passed, 38 not applicable

-------------------
This scan used axe-core 4.3.2 (https://github.com/dequelabs/axe-core/releases/tag/v4.3.2) with Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36.
```

New output below with the count fixed:
```
Accessibility Insights

7 failure instances
* (3) label:  Ensures every form element has a label
* (2) html-has-lang:  Ensures every HTML document has a lang attribute
* (2) image-alt:  Ensures <img> elements have alternate text or a role of none or presentation

Baseline not configured
A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See baselining docs (https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.

See all failures and scan details by downloading the report from run artifacts (undefined)

-------------------
Scan summary
URLs: 2 with failures, 2 passed, 0 not scannable
Rules: 3 with failures, 11 passed, 38 not applicable

-------------------
This scan used axe-core 4.3.2 (https://github.com/dequelabs/axe-core/releases/tag/v4.3.2) with Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36.
```

##### Motivation

Fixes known issue

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
