### PR TITLE
fix: ADO special logging commands test

### DIFF
--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
@@ -26,10 +26,10 @@ describe(adoStdoutTransformer, () => {
 
     // Note: these are special logging commands in ADO that can't be added to the output text of the test because ADO attempts to evaluate them and fails or throws warnings.
     it.each`
-        input                          | expectedOutput
-        ${'##vso[task.uploadsummary]'} | ${'##vso[task.uploadsummary]'}
-        ${'##vso[task.logissue]abc'}   | ${'##vso[task.logissue]abc'}
-    `(`ADO Special logging command: '$input' returned as '$expectedOutput'`, ({ input, expectedOutput }) => {
+        input                          | expectedOutput                 | safeTextIdentifier
+        ${'##vso[task.uploadsummary]'} | ${'##vso[task.uploadsummary]'} | ${'task.uploadsummary'}
+        ${'##vso[task.logissue]abc'}   | ${'##vso[task.logissue]abc'}   | ${'task.logissue'}
+    `(`ADO Special logging command '$safeTextIdentifier' returns as expected`, ({ input, expectedOutput }) => {
         const output = adoStdoutTransformer(input);
         expect(output).toBe(expectedOutput);
     });


### PR DESCRIPTION
#### Details

This fixes a bug introduced in a recent PR that is causing the ADO tests to fail. See Example here: [Failed pipeline run](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=31183&view=logs&j=81b7b1a0-9e2e-58a5-1601-69aaad9b82d6&t=24cd6560-9d76-5a2b-d63a-565b4fa97a0b&l=491)

##### Motivation

Fixes known issue

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
