### PR TITLE
Update ado-extension-usage documentation

### DIFF
--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -162,4 +162,4 @@ You can choose to block pull requests if the extension finds accessibility issue
 -   If the action didn't trigger as you expected, check the `trigger` or `pr` sections of your yml file. Make sure any listed branch names are correct for your repository.
 -   If the action fails to complete, you can check the build logs for execution errors. Using the template above, these logs will be in the `Scan for accessibility issues` step.
 -   If you can't find an artifact, note that your workflow must include a `publish` step to add the report folder to your check results. See the [Basic template](#basic-template) above and [Azure DevOps documentation on publishing artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#publish-artifacts).
--   If the scan takes longer than 90 seconds, you can override the default timeout by providing a value for `scanTimeout`.
+-   If the scan takes longer than 90 seconds, you can override the default timeout by providing a value for `scanTimeout` in milliseconds.


### PR DESCRIPTION
Add the `scanTimeout` value unit (milliseconds) for clarity. I recently followed these instructions, encountering this issue of unknown units.

#### Details

Updating the ADO extension usage documentation to add 'milliseconds' to the `scanTimeout` optional parameter in the pipeline configuration. 

##### Motivation

I recently followed these instructions to set up AI in our pipelines & encountered the issue of not knowing whether the timeout value was in seconds or milliseconds. After some trial & error I discovered it was the latter. The update is to add my learnings so future readers don't encounter the same issue.


