### PR TITLE
feat(ado-ext-telemetry): Embed upload artifact into task

### DIFF
--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -147,7 +147,7 @@ You can choose to block pull requests if the extension finds accessibility issue
 
 ## Running multiple times in a single pipeline
 
-If you want to run the extension multiple times in a single pipeline, you will need to ensure that a unique `artifactName` input is specified in your YAML file for each task. Artifact names must be unique across all tasks in a pipeline.
+If you want to run the extension multiple times in a single pipeline, you will need to ensure that unique `artifactName` and `outputDir` inputs are specified in your YAML file for each task. Artifact names and the output directory must be unique across all tasks in a pipeline.
 
 ## Troubleshooting
 

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -133,10 +133,15 @@ Here is an example of a YAML file that is configured to take advantage of a base
       baselineFile: '$(Build.SourcesDirectory)/baselines/my-web-site.baseline'
 ```
 
-## Viewing results
+## Report Artifacts
 
--   Summary results along with a link to report artifacts are output in both the task log and in the Extensions tab of the pipeline run. To view the task log, click into the job and then click on the accessibilityinsights task.
--   An HTML report containing detailed results is saved as a pipeline artifact. To view it, navigate to Artifacts from the build. Under `accessibility-reports`, you'll find the downloadable report labeled `index.html`.
+By default, an HTML report containing detailed results is automatically uploaded as a pipeline artifact named `accessibility-reports`. You can opt out of this automatic artifact upload by setting the `uploadResultAsArtifact` parameter to `false`. You can also specify a custom artifact name by setting the `artifactName` parameter in your YAML file. If not opted out, a link to the artifacts will also appear in both the task log and in the Extensions tab of the pipeline run.
+
+To view the report, navigate to Artifacts from the build. Under `accessibility-reports`, or the artifact name manually specified, you'll find the downloadable report labeled `index.html`.
+
+## Summary results
+
+-   Summary results are output in both the task log and in the Extensions tab of the pipeline run. To view the task log, click into the job and then click on the `accessibilityinsights` task.
 
 ## Blocking pull requests
 

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -37,11 +37,6 @@ steps:
           # Provide either siteDir or url
           # siteDir: '$(System.DefaultWorkingDirectory)/path-to-built-website/'
           # url: 'your-website-url'
-
-    - publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports'
-      displayName: Upload report artifact
-      condition: succeededOrFailed()
-      artifact: 'accessibility-reports'
 ```
 
 ### Scan a URL
@@ -136,18 +131,12 @@ Here is an example of a YAML file that is configured to take advantage of a base
   inputs:
       url: 'http://localhost:12345/'
       baselineFile: '$(Build.SourcesDirectory)/baselines/my-web-site.baseline'
-
-- publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports'
-  displayName: Upload report artifacts
-  condition: succeededOrFailed()
-  artifact: 'accessibility-reports'
 ```
 
 ## Viewing results
 
--   An HTML report containing detailed results is saved to disk. To view it, you need to have added the step to upload artifacts to your yml file (see [Basic template](#basic-template)). Navigate to Artifacts from the build. Under `accessibility-reports`, you'll find the downloadable report labeled `index.html`.
-
--   If the workflow was triggered by a pull request, the action should leave a comment on the Azure DevOps pull request with results. The extension does not leave comments on repos in GitHub.
+-   Summary results along with a link to report artifacts are output in both the task log and in the Extensions tab of the pipeline run. To view the task log, click into the job and then click on the accessibilityinsights task.
+-   An HTML report containing detailed results is saved as a pipeline artifact. To view it, navigate to Artifacts from the build. Under `accessibility-reports`, you'll find the downloadable report labeled `index.html`.
 
 ## Blocking pull requests
 
@@ -155,11 +144,9 @@ You can choose to block pull requests if the extension finds accessibility issue
 
 1. Ensure the extension is [triggered on each pull request](https://docs.microsoft.com/en-us/azure/devops/pipelines/customize-pipeline?view=azure-devops#customize-ci-triggers).
 2. Ensure that you have set the `failOnAccessibilityError` input variable to `true`.
-3. Ensure that the `Upload report artifact` step runs even in failure cases using [**succeededOrFailed()**](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml)
 
 ## Troubleshooting
 
 -   If the action didn't trigger as you expected, check the `trigger` or `pr` sections of your yml file. Make sure any listed branch names are correct for your repository.
 -   If the action fails to complete, you can check the build logs for execution errors. Using the template above, these logs will be in the `Scan for accessibility issues` step.
--   If you can't find an artifact, note that your workflow must include a `publish` step to add the report folder to your check results. See the [Basic template](#basic-template) above and [Azure DevOps documentation on publishing artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#publish-artifacts).
 -   If the scan takes longer than 90 seconds, you can override the default timeout by providing a value for `scanTimeout` in milliseconds.

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -145,6 +145,10 @@ You can choose to block pull requests if the extension finds accessibility issue
 1. Ensure the extension is [triggered on each pull request](https://docs.microsoft.com/en-us/azure/devops/pipelines/customize-pipeline?view=azure-devops#customize-ci-triggers).
 2. Ensure that you have set the `failOnAccessibilityError` input variable to `true`.
 
+## Running multiple times in a single pipeline
+
+If you want to run the extension multiple times in a single pipeline, you will need to ensure that a unique `artifactName` input is specified in your YAML file for each task. Artifact names must be unique across all tasks in a pipeline.
+
 ## Troubleshooting
 
 -   If the action didn't trigger as you expected, check the `trigger` or `pr` sections of your yml file. Make sure any listed branch names are correct for your repository.

--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
@@ -24,17 +24,6 @@ describe(adoStdoutTransformer, () => {
         expect(output).toBe(expectedOutput);
     });
 
-    // Note: these are special logging commands in ADO that can't be added to the output text of the test because ADO attempts to evaluate them and fails or throws warnings.
-    it.each`
-        input                          | expectedOutput                 | safeTextIdentifier
-        ${'##vso[task.uploadsummary]'} | ${'##vso[task.uploadsummary]'} | ${'task.uploadsummary'}
-        ${'##vso[task.logissue]abc'}   | ${'##vso[task.logissue]abc'}   | ${'task.logissue'}
-        ${'##vso[artifact.upload]abc'} | ${'##vso[artifact.upload]abc'} | ${'artifact.upload'}
-    `(`ADO Special logging command '$safeTextIdentifier' returns as expected`, ({ input, expectedOutput }) => {
-        const output = adoStdoutTransformer(input);
-        expect(output).toBe(expectedOutput);
-    });
-
     it.each`
         input
         ${'##vso[task.debug]abc'}

--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
@@ -29,6 +29,7 @@ describe(adoStdoutTransformer, () => {
         input                          | expectedOutput                 | safeTextIdentifier
         ${'##vso[task.uploadsummary]'} | ${'##vso[task.uploadsummary]'} | ${'task.uploadsummary'}
         ${'##vso[task.logissue]abc'}   | ${'##vso[task.logissue]abc'}   | ${'task.logissue'}
+        ${'##vso[artifact.upload]abc'} | ${'##vso[artifact.upload]abc'} | ${'artifact.upload'}
     `(`ADO Special logging command '$safeTextIdentifier' returns as expected`, ({ input, expectedOutput }) => {
         const output = adoStdoutTransformer(input);
         expect(output).toBe(expectedOutput);

--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.ts
@@ -22,6 +22,10 @@ const regexTransformations: RegexTransformation[] = [
         method: useUnmodifiedString,
     },
     {
+        regex: new RegExp('^##vso\\[artifact.upload\\]'),
+        method: useUnmodifiedString,
+    },
+    {
         regex: new RegExp('^Processing page .*'),
         method: useUnmodifiedString,
     },

--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.ts
@@ -14,18 +14,6 @@ const regexTransformations: RegexTransformation[] = [
         method: useUnmodifiedString,
     },
     {
-        regex: new RegExp('^##vso\\[task.uploadsummary\\]'),
-        method: useUnmodifiedString,
-    },
-    {
-        regex: new RegExp('^##vso\\[task.logissue\\]'),
-        method: useUnmodifiedString,
-    },
-    {
-        regex: new RegExp('^##vso\\[artifact.upload\\]'),
-        method: useUnmodifiedString,
-    },
-    {
         regex: new RegExp('^Processing page .*'),
         method: useUnmodifiedString,
     },

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -59,7 +59,7 @@ describe(AdoConsoleCommentCreator, () => {
             adoTaskConfigMock
                 .setup((atcm) => atcm.getReportOutDir())
                 .returns(() => reportOutDir)
-                .verifiable(Times.once());
+                .verifiable(Times.exactly(2));
 
             adoTaskConfigMock
                 .setup((atcm) => atcm.getVariable('System.DefaultWorkingDirectory'))
@@ -80,9 +80,7 @@ describe(AdoConsoleCommentCreator, () => {
             loggerMock.setup((lm) => lm.logInfo(`##vso[task.uploadsummary]${fileName}`)).verifiable(Times.once());
             loggerMock
                 .setup((lm) =>
-                    lm.logInfo(
-                        `##vso[artifact.upload artifactname=accessibility-reports]${defaultWorkingDirectory}/_accessibility-reports`,
-                    ),
+                    lm.logInfo(`##vso[artifact.upload artifactname=accessibility-reports]${defaultWorkingDirectory}/${reportOutDir}`),
                 )
                 .verifiable(Times.once());
             fsMock.setup((fsm) => fsm.writeFileSync(fileName, expectedLogOutput)).verifiable();

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -19,6 +19,7 @@ describe(AdoConsoleCommentCreator, () => {
     let fsMock: IMock<typeof fs>;
     const reportOutDir = 'reportOutDir';
     const fileName = `${reportOutDir}/results.md`;
+    const defaultWorkingDirectory = 'working/directory/';
 
     beforeEach(() => {
         adoTaskConfigMock = Mock.ofType<ADOTaskConfig>(undefined, MockBehavior.Strict);
@@ -60,6 +61,11 @@ describe(AdoConsoleCommentCreator, () => {
                 .returns(() => reportOutDir)
                 .verifiable(Times.once());
 
+            adoTaskConfigMock
+                .setup((atcm) => atcm.getVariable('System.DefaultWorkingDirectory'))
+                .returns(() => defaultWorkingDirectory)
+                .verifiable(Times.once());
+
             reportMarkdownConvertorMock
                 .setup((o) => o.convert(reportStub, undefined, baselineInfoStub))
                 .returns(() => expectedLogOutput)
@@ -72,6 +78,13 @@ describe(AdoConsoleCommentCreator, () => {
 
             loggerMock.setup((lm) => lm.logInfo(expectedLogOutput)).verifiable(Times.once());
             loggerMock.setup((lm) => lm.logInfo(`##vso[task.uploadsummary]${fileName}`)).verifiable(Times.once());
+            loggerMock
+                .setup((lm) =>
+                    lm.logInfo(
+                        `##vso[artifact.upload artifactname=accessibility-reports]${defaultWorkingDirectory}/_accessibility-reports`,
+                    ),
+                )
+                .verifiable(Times.once());
             fsMock.setup((fsm) => fsm.writeFileSync(fileName, expectedLogOutput)).verifiable();
 
             adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks();

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -19,7 +19,6 @@ describe(AdoConsoleCommentCreator, () => {
     let fsMock: IMock<typeof fs>;
     const reportOutDir = 'reportOutDir';
     const fileName = `${reportOutDir}/results.md`;
-    const defaultWorkingDirectory = 'working/directory/';
     const artifactName = 'accessibility-reports';
 
     beforeEach(() => {
@@ -63,11 +62,6 @@ describe(AdoConsoleCommentCreator, () => {
                 .verifiable(Times.exactly(2));
 
             adoTaskConfigMock
-                .setup((atcm) => atcm.getVariable('System.DefaultWorkingDirectory'))
-                .returns(() => defaultWorkingDirectory)
-                .verifiable(Times.once());
-
-            adoTaskConfigMock
                 .setup((atcm) => atcm.getVariable('System.JobAttempt'))
                 .returns(() => '1')
                 .verifiable(Times.once());
@@ -90,7 +84,7 @@ describe(AdoConsoleCommentCreator, () => {
             loggerMock.setup((lm) => lm.logInfo(expectedLogOutput)).verifiable(Times.once());
             loggerMock.setup((lm) => lm.logInfo(`##vso[task.uploadsummary]${fileName}`)).verifiable(Times.once());
             loggerMock
-                .setup((lm) => lm.logInfo(`##vso[artifact.upload artifactname=${artifactName}]${defaultWorkingDirectory}/${reportOutDir}`))
+                .setup((lm) => lm.logInfo(`##vso[artifact.upload artifactname=${artifactName}]${reportOutDir}`))
                 .verifiable(Times.once());
             fsMock.setup((fsm) => fsm.writeFileSync(fileName, expectedLogOutput)).verifiable();
 
@@ -124,11 +118,6 @@ describe(AdoConsoleCommentCreator, () => {
                 .verifiable(Times.exactly(2));
 
             adoTaskConfigMock
-                .setup((atcm) => atcm.getVariable('System.DefaultWorkingDirectory'))
-                .returns(() => defaultWorkingDirectory)
-                .verifiable(Times.once());
-
-            adoTaskConfigMock
                 .setup((atcm) => atcm.getVariable('System.JobAttempt'))
                 .returns(() => '2')
                 .verifiable(Times.once());
@@ -151,9 +140,7 @@ describe(AdoConsoleCommentCreator, () => {
             loggerMock.setup((lm) => lm.logInfo(expectedLogOutput)).verifiable(Times.once());
             loggerMock.setup((lm) => lm.logInfo(`##vso[task.uploadsummary]${fileName}`)).verifiable(Times.once());
             loggerMock
-                .setup((lm) =>
-                    lm.logInfo(`##vso[artifact.upload artifactname=${artifactName}-2]${defaultWorkingDirectory}/${reportOutDir}`),
-                )
+                .setup((lm) => lm.logInfo(`##vso[artifact.upload artifactname=${artifactName}-2]${reportOutDir}`))
                 .verifiable(Times.once());
             fsMock.setup((fsm) => fsm.writeFileSync(fileName, expectedLogOutput)).verifiable();
 

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -66,7 +66,20 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
     private uploadReportArtifacts(): void {
         const workingDirectory = this.taskConfig.getVariable('System.DefaultWorkingDirectory') ?? '';
         const outputDirectory = this.taskConfig.getReportOutDir();
-        this.logger.logInfo(`##vso[artifact.upload artifactname=accessibility-reports]${workingDirectory}/${outputDirectory}`);
+        const jobAttemptBuildVariable = this.taskConfig.getVariable('System.JobAttempt');
+        const artifactName = this.taskConfig.getArtifactName();
+
+        let artifactNameSuffix = '';
+        let jobAttemptNumber = 1;
+
+        if (jobAttemptBuildVariable !== undefined) {
+            jobAttemptNumber = parseInt(jobAttemptBuildVariable);
+            artifactNameSuffix = jobAttemptNumber > 1 ? `-${jobAttemptBuildVariable}` : '';
+        }
+
+        this.logger.logInfo(
+            `##vso[artifact.upload artifactname=${artifactName + artifactNameSuffix}]${workingDirectory}/${outputDirectory}`,
+        );
     }
 
     private logResultsToConsole(combinedReportResult: CombinedReportParameters, baselineInfo?: BaselineInfo): void {

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -65,7 +65,8 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
 
     private uploadReportArtifacts(): void {
         const workingDirectory = this.taskConfig.getVariable('System.DefaultWorkingDirectory') ?? '';
-        this.logger.logInfo(`##vso[artifact.upload artifactname=accessibility-reports]${workingDirectory}/_accessibility-reports`);
+        const outputDirectory = this.taskConfig.getReportOutDir();
+        this.logger.logInfo(`##vso[artifact.upload artifactname=accessibility-reports]${workingDirectory}/${outputDirectory}`);
     }
 
     private logResultsToConsole(combinedReportResult: CombinedReportParameters, baselineInfo?: BaselineInfo): void {

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -64,7 +64,6 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
     }
 
     private uploadReportArtifacts(): void {
-        const workingDirectory = this.taskConfig.getVariable('System.DefaultWorkingDirectory') ?? '';
         const outputDirectory = this.taskConfig.getReportOutDir();
         const jobAttemptBuildVariable = this.taskConfig.getVariable('System.JobAttempt');
         const artifactName = this.taskConfig.getArtifactName();
@@ -77,9 +76,7 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
             artifactNameSuffix = jobAttemptNumber > 1 ? `-${jobAttemptBuildVariable}` : '';
         }
 
-        this.logger.logInfo(
-            `##vso[artifact.upload artifactname=${artifactName + artifactNameSuffix}]${workingDirectory}/${outputDirectory}`,
-        );
+        this.logger.logInfo(`##vso[artifact.upload artifactname=${artifactName + artifactNameSuffix}]${outputDirectory}`);
     }
 
     private logResultsToConsole(combinedReportResult: CombinedReportParameters, baselineInfo?: BaselineInfo): void {

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -64,19 +64,22 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
     }
 
     private uploadReportArtifacts(): void {
-        const outputDirectory = this.taskConfig.getReportOutDir();
-        const jobAttemptBuildVariable = this.taskConfig.getVariable('System.JobAttempt');
-        const artifactName = this.taskConfig.getArtifactName();
+        const uploadResultAsArtifactEnabled: boolean = this.taskConfig.getUploadResultAsArtifact();
+        if (uploadResultAsArtifactEnabled) {
+            const outputDirectory = this.taskConfig.getReportOutDir();
+            const jobAttemptBuildVariable = this.taskConfig.getVariable('System.JobAttempt');
+            const artifactName = this.taskConfig.getArtifactName();
 
-        let artifactNameSuffix = '';
-        let jobAttemptNumber = 1;
+            let artifactNameSuffix = '';
+            let jobAttemptNumber = 1;
 
-        if (jobAttemptBuildVariable !== undefined) {
-            jobAttemptNumber = parseInt(jobAttemptBuildVariable);
-            artifactNameSuffix = jobAttemptNumber > 1 ? `-${jobAttemptBuildVariable}` : '';
+            if (jobAttemptBuildVariable !== undefined) {
+                jobAttemptNumber = parseInt(jobAttemptBuildVariable);
+                artifactNameSuffix = jobAttemptNumber > 1 ? `-${jobAttemptBuildVariable}` : '';
+            }
+
+            this.logger.logInfo(`##vso[artifact.upload artifactname=${artifactName + artifactNameSuffix}]${outputDirectory}`);
         }
-
-        this.logger.logInfo(`##vso[artifact.upload artifactname=${artifactName + artifactNameSuffix}]${outputDirectory}`);
     }
 
     private logResultsToConsole(combinedReportResult: CombinedReportParameters, baselineInfo?: BaselineInfo): void {

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -31,6 +31,7 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
     public async completeRun(combinedReportResult: CombinedReportParameters, baselineEvaluation?: BaselineEvaluation): Promise<void> {
         const baselineInfo = this.getBaselineInfo(baselineEvaluation);
         this.outputResultsMarkdownToBuildSummary(combinedReportResult, baselineInfo);
+        this.uploadReportArtifacts();
         this.logResultsToConsole(combinedReportResult, baselineInfo);
 
         return Promise.resolve();
@@ -60,6 +61,11 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
         // eslint-disable-next-line security/detect-non-literal-fs-filename
         this.fileSystemObj.writeFileSync(fileName, reportMarkdown);
         this.logger.logInfo(`##vso[task.uploadsummary]${fileName}`);
+    }
+
+    private uploadReportArtifacts(): void {
+        const workingDirectory = this.taskConfig.getVariable('System.DefaultWorkingDirectory') ?? '';
+        this.logger.logInfo(`##vso[artifact.upload artifactname=accessibility-reports]${workingDirectory}/_accessibility-reports`);
     }
 
     private logResultsToConsole(combinedReportResult: CombinedReportParameters, baselineInfo?: BaselineInfo): void {

--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -53,6 +53,7 @@ describe(ADOTaskConfig, () => {
         ${'baselineFile'}             | ${'./baselineFile'} | ${getPlatformAgnosticPath(__dirname + '/baselineFile')} | ${() => taskConfig.getBaselineFile()}
         ${'failOnAccessibilityError'} | ${true}             | ${true}                                                 | ${() => taskConfig.getFailOnAccessibilityError()}
         ${'singleWorker'}             | ${true}             | ${true}                                                 | ${() => taskConfig.getSingleWorker()}
+        ${'artifactName'}             | ${'artifact-name'}  | ${'artifact-name'}                                      | ${() => taskConfig.getArtifactName()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {

--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -54,6 +54,7 @@ describe(ADOTaskConfig, () => {
         ${'failOnAccessibilityError'} | ${true}             | ${true}                                                 | ${() => taskConfig.getFailOnAccessibilityError()}
         ${'singleWorker'}             | ${true}             | ${true}                                                 | ${() => taskConfig.getSingleWorker()}
         ${'artifactName'}             | ${'artifact-name'}  | ${'artifact-name'}                                      | ${() => taskConfig.getArtifactName()}
+        ${'uploadResultAsArtifact'}   | ${true}             | ${true}                                                 | ${() => taskConfig.getUploadResultAsArtifact()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {

--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -164,4 +164,17 @@ describe(ADOTaskConfig, () => {
 
         expect(actualCommitHash).toEqual(commitHash);
     });
+
+    it('should call get variable from task library', () => {
+        const variableName = 'variableName';
+        const variableValue = 'variableValue';
+        adoTaskMock
+            .setup((o) => o.getVariable(variableName))
+            .returns(() => variableValue)
+            .verifiable(Times.once());
+
+        const actualVariableValue = taskConfig.getVariable(variableName);
+
+        expect(actualVariableValue).toEqual(variableValue);
+    });
 });

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -121,6 +121,11 @@ export class ADOTaskConfig extends TaskConfig {
         return this.processObj.env.SYSTEM_TEAMPROJECT ?? undefined;
     }
 
+    public getArtifactName(): string {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return this.adoTaskObj.getInput('artifactName')!;
+    }
+
     public getVariable(definedVariableName: string): string | undefined {
         return this.adoTaskObj.getVariable(definedVariableName);
     }

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -121,6 +121,10 @@ export class ADOTaskConfig extends TaskConfig {
         return this.processObj.env.SYSTEM_TEAMPROJECT ?? undefined;
     }
 
+    public getVariable(definedVariableName: string): string | undefined {
+        return this.adoTaskObj.getVariable(definedVariableName);
+    }
+
     private getAbsolutePath(path: string | undefined): string | undefined {
         if (isEmpty(path)) {
             return undefined;

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -126,6 +126,10 @@ export class ADOTaskConfig extends TaskConfig {
         return this.adoTaskObj.getInput('artifactName')!;
     }
 
+    public getUploadResultAsArtifact(): boolean {
+        return this.adoTaskObj.getBoolInput('uploadResultAsArtifact');
+    }
+
     public getVariable(definedVariableName: string): string | undefined {
         return this.adoTaskObj.getVariable(definedVariableName);
     }

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -119,6 +119,14 @@
             "defaultValue": true,
             "helpMarkDown": "To get deterministic scanning results, either specify the singleWorker parameter or ensure that the value specified for the maxUrls parameter is larger than the total number of urls in the web site being scanned."
         }
+        {
+            "name": "artifactName",
+            "type": "string",
+            "label": "Artifact Name",
+            "required": false,
+            "defaultValue": "accessibility-reports",
+            "helpMarkDown": "Name of the report artifact to be uploaded to the build."
+        }
     ],
     "execution": {
         "Node10": {

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -118,7 +118,7 @@
             "required": true,
             "defaultValue": true,
             "helpMarkDown": "To get deterministic scanning results, either specify the singleWorker parameter or ensure that the value specified for the maxUrls parameter is larger than the total number of urls in the web site being scanned."
-        }
+        },
         {
             "name": "artifactName",
             "type": "string",

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -133,7 +133,8 @@
             "label": "Artifact Name",
             "required": false,
             "defaultValue": "accessibility-reports",
-            "helpMarkDown": "Name of the report artifact to be uploaded to the build."
+            "helpMarkDown": "Name of the report artifact to be uploaded to the build. Ignored if uploadResultAsArtifact is false.",
+            "visibleRule": "uploadResultAsArtifact = true"
         }
     ],
     "execution": {

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -120,6 +120,14 @@
             "helpMarkDown": "To get deterministic scanning results, either specify the singleWorker parameter or ensure that the value specified for the maxUrls parameter is larger than the total number of urls in the web site being scanned."
         },
         {
+            "name": "uploadResultAsArtifact",
+            "type": "boolean",
+            "label": "Upload result as artifact",
+            "defaultValue": true,
+            "required": true,
+            "helpMarkDown": "Automatically upload the result as an artifact to the build. Set to false if you need to upload the artifact manually in a separate task or publish step."
+        },
+        {
             "name": "artifactName",
             "type": "string",
             "label": "Artifact Name",

--- a/packages/shared/src/console-output/__snapshots__/result-console-log-builder.spec.ts.snap
+++ b/packages/shared/src/console-output/__snapshots__/result-console-log-builder.spec.ts.snap
@@ -43,6 +43,25 @@ You can review the log to troubleshoot the issue. Fix it and re-run the pipeline
 "
 `;
 
+exports[`ResultConsoleLogBuilder uploadResultAsArtifact is false skips artifact link line when artifactsUrl returns undefined 1`] = `
+"
+Accessibility Insights
+
+No failures detected
+No failures were detected by automatic scanning.
+
+Next step: Manually assess keyboard accessibility with Accessibility Insights Tab Stops (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+
+-------------------
+Scan summary
+URLs: 0 with failures, 1 passed, 7 not scannable
+Rules: 0 with failures, 1 passed, 2 not applicable
+
+-------------------
+This scan used axe-core axeVersion (https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent.
+"
+`;
+
 exports[`ResultConsoleLogBuilder with baseline builds content when baseline failures and scanned failures are the same (no new failures) 1`] = `
 "
 Accessibility Insights

--- a/packages/shared/src/console-output/result-console-log-builder.spec.ts
+++ b/packages/shared/src/console-output/result-console-log-builder.spec.ts
@@ -278,6 +278,33 @@ describe(ResultConsoleLogBuilder, () => {
         });
     });
 
+    describe('uploadResultAsArtifact is false', () => {
+        const baselineFileName = 'baseline file';
+
+        beforeEach(() => {
+            artifactsInfoProviderMock
+                .setup((aip) => aip.getArtifactsUrl())
+                .returns(() => undefined)
+                .verifiable(Times.atLeastOnce());
+        });
+
+        it('skips artifact link line when artifactsUrl returns undefined', () => {
+            const baselineEvaluation = {
+                totalBaselineViolations: 0,
+            } as BaselineEvaluation;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithNoFailures();
+
+            const actualContent = resultConsoleLogBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
+    });
+
     const setCombinedReportResultWithFailures = (): void => {
         const ruleInfo1 = { ruleId: 'rule id', description: 'rule description' };
         combinedReportResult = {

--- a/packages/shared/src/console-output/result-console-log-builder.spec.ts
+++ b/packages/shared/src/console-output/result-console-log-builder.spec.ts
@@ -280,15 +280,12 @@ describe(ResultConsoleLogBuilder, () => {
 
     describe('uploadResultAsArtifact is false', () => {
         const baselineFileName = 'baseline file';
-
-        beforeEach(() => {
+        it('skips artifact link line when artifactsUrl returns undefined', () => {
             artifactsInfoProviderMock
                 .setup((aip) => aip.getArtifactsUrl())
                 .returns(() => undefined)
                 .verifiable(Times.atLeastOnce());
-        });
 
-        it('skips artifact link line when artifactsUrl returns undefined', () => {
             const baselineEvaluation = {
                 totalBaselineViolations: 0,
             } as BaselineEvaluation;

--- a/packages/shared/src/console-output/result-console-log-builder.ts
+++ b/packages/shared/src/console-output/result-console-log-builder.ts
@@ -55,11 +55,7 @@ export class ResultConsoleLogBuilder {
                 this.failureDetailsBaseline(combinedReportResult, baselineInfo),
                 sectionSeparator(),
                 this.baselineDetails(baselineInfo),
-                sectionSeparator(),
-                sectionSeparator(),
                 this.downloadArtifactsWithLink(combinedReportResult, baselineInfo.baselineEvaluation),
-                sectionSeparator(),
-                sectionSeparator(),
                 footerSeparator(),
                 sectionSeparator(),
                 'Scan summary',
@@ -334,12 +330,25 @@ export class ResultConsoleLogBuilder {
     }
 
     private downloadArtifactsWithLink(combinedReportResult: CombinedReportParameters, baselineEvaluation?: BaselineEvaluation): string {
-        const artifactsLink = link(this.artifactsInfoProvider.getArtifactsUrl(), 'run artifacts');
+        const artifactsUrl = this.artifactsInfoProvider.getArtifactsUrl();
+        let lines: string[] = [];
+        if (artifactsUrl === undefined) {
+            return lines.join('');
+        }
+
+        const artifactsLink = link(artifactsUrl, 'run artifacts');
         let details = 'all failures and scan details';
         if (!this.baselineHasFailures(baselineEvaluation) && !this.hasFailures(combinedReportResult, baselineEvaluation)) {
             details = 'scan details';
         }
-        return `See ${details} by downloading the report from ${artifactsLink}`;
+        lines = [
+            sectionSeparator(),
+            sectionSeparator(),
+            `See ${details} by downloading the report from ${artifactsLink}`,
+            sectionSeparator(),
+            sectionSeparator(),
+        ];
+        return lines.join('');
     }
 
     private baselineHasFailures = (baselineEvaluation: BaselineEvaluation): boolean => {

--- a/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
+++ b/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
@@ -40,6 +40,23 @@ You can review the log to troubleshoot the issue. Fix it and re-run the workflow
 "
 `;
 
+exports[`ResultMarkdownBuilder uploadResultAsArtifact is false skips artifact link line when artifactsUrl returns undefined 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
+
+**:white_check_mark: No failures detected**
+No failures were detected by automatic scanning.
+
+**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+
+---
+#### Scan summary
+**URLs**: 0 with failures, 1 passed, 7 not scannable
+**Rules**: 0 with failures, 1 passed, 2 not applicable
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
 exports[`ResultMarkdownBuilder with baseline builds content when baseline failures and scanned failures are the same (no new failures) 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 

--- a/packages/shared/src/mark-down/result-markdown-builder.spec.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.spec.ts
@@ -278,6 +278,33 @@ describe(ResultMarkdownBuilder, () => {
         });
     });
 
+    describe('uploadResultAsArtifact is false', () => {
+        const baselineFileName = 'baseline file';
+
+        beforeEach(() => {
+            artifactsInfoProviderMock
+                .setup((aip) => aip.getArtifactsUrl())
+                .returns(() => undefined)
+                .verifiable(Times.atLeastOnce());
+        });
+
+        it('skips artifact link line when artifactsUrl returns undefined', () => {
+            const baselineEvaluation = {
+                totalBaselineViolations: 0,
+            } as BaselineEvaluation;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithNoFailures();
+
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
+    });
+
     const setCombinedReportResultWithFailures = (): void => {
         const ruleInfo1 = { ruleId: 'rule id', description: 'rule description' };
         combinedReportResult = {

--- a/packages/shared/src/mark-down/result-markdown-builder.spec.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.spec.ts
@@ -280,15 +280,12 @@ describe(ResultMarkdownBuilder, () => {
 
     describe('uploadResultAsArtifact is false', () => {
         const baselineFileName = 'baseline file';
-
-        beforeEach(() => {
+        it('skips artifact link line when artifactsUrl returns undefined', () => {
             artifactsInfoProviderMock
                 .setup((aip) => aip.getArtifactsUrl())
                 .returns(() => undefined)
                 .verifiable(Times.atLeastOnce());
-        });
 
-        it('skips artifact link line when artifactsUrl returns undefined', () => {
             const baselineEvaluation = {
                 totalBaselineViolations: 0,
             } as BaselineEvaluation;

--- a/packages/shared/src/mark-down/result-markdown-builder.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.ts
@@ -54,11 +54,7 @@ export class ResultMarkdownBuilder {
                 this.failureDetailsBaseline(combinedReportResult, baselineInfo),
                 sectionSeparator(),
                 this.baselineDetails(baselineInfo),
-                sectionSeparator(),
-                sectionSeparator(),
                 this.downloadArtifactsWithLink(combinedReportResult, baselineInfo.baselineEvaluation),
-                sectionSeparator(),
-                sectionSeparator(),
                 footerSeparator(),
                 sectionSeparator(),
                 heading('Scan summary', 4),
@@ -333,12 +329,25 @@ export class ResultMarkdownBuilder {
     }
 
     private downloadArtifactsWithLink(combinedReportResult: CombinedReportParameters, baselineEvaluation?: BaselineEvaluation): string {
-        const artifactsLink = link(this.artifactsInfoProvider.getArtifactsUrl(), 'run artifacts');
+        const artifactsUrl = this.artifactsInfoProvider.getArtifactsUrl();
+        let lines: string[] = [];
+        if (artifactsUrl === undefined) {
+            return lines.join('');
+        }
+
+        const artifactsLink = link(artifactsUrl, 'run artifacts');
         let details = 'all failures and scan details';
         if (!this.baselineHasFailures(baselineEvaluation) && !this.hasFailures(combinedReportResult, baselineEvaluation)) {
             details = 'scan details';
         }
-        return `See ${details} by downloading the report from ${artifactsLink}`;
+        lines = [
+            sectionSeparator(),
+            sectionSeparator(),
+            `See ${details} by downloading the report from ${artifactsLink}`,
+            sectionSeparator(),
+            sectionSeparator(),
+        ];
+        return lines.join('');
     }
 
     private baselineHasFailures = (baselineEvaluation: BaselineEvaluation): boolean => {


### PR DESCRIPTION
#### Details

This removes the need to have a separate publish task for the report artifacts in the azure-pipelines.yml. It is using the [special logging commands](https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#upload-upload-an-artifact) to upload an artifact in ADO pipelines. It also updates the documentation accordingly.

I ran pipelines for Windows, Ubuntu, and Mac to ensure operability across operating systems.  I also ran a test pipeline that still had the publish step defined in the yaml file. It fails with an error stating that the artifact already exists.

- Embed Upload Pipeline runs
	- Ubuntu Latest: [Pipelines - Run 20220310.2 logs (azure.com)](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=31524&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=7384d774-f7ca-599c-ee57-ab2c05be9247)
	- Windows Latest: [Pipelines - Run 20220310.4 logs (azure.com)](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=31526&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=7384d774-f7ca-599c-ee57-ab2c05be9247)
	- Mac Latest: [Pipelines - Run 20220310.6 logs (azure.com)](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=31528&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=7384d774-f7ca-599c-ee57-ab2c05be9247)
	- What happens if pipeline still has publish step for artifacts (it fails that step): [Pipelines - Run 20220310.8 logs (azure.com)](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=31554&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=a6453dc2-c13f-50dd-7490-386079329673)

##### Motivation

Feature work, partially addressing #1063

##### Context

I initially attempted to use the `uploadArtifact` method defined in the `azure-pipelines-task-lib/task` library only to find out that under the hood it uses the special logging command via a `console.log` call.  We are capturing and modifying the `stdout`, and anything that uses a console.log receives a `##debug` prefix.  Once I realized that the underlying mechanism was to use the logging commands, I switched to using the logging command directly.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
