### PR TITLE
feat(ado-ext-telemetry): Grouping rarely used options under Advanced Options group

### DIFF
--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -13,6 +13,7 @@
         "Patch": 0
     },
     "instanceNameFormat": "Run accessibility testing",
+    "groups": [{ "displayName": "Advanced Options", "isExpanded": false, "name": "advancedOptions" }],
     "inputs": [
         {
             "name": "outputDir",
@@ -20,7 +21,8 @@
             "label": "Output Directory",
             "required": true,
             "defaultValue": "_accessibility-reports",
-            "helpMarkDown": "Folder containing the scan report."
+            "helpMarkDown": "Folder containing the scan report.",
+            "groupName": "advancedOptions"
         },
         {
             "name": "siteDir",
@@ -43,7 +45,8 @@
             "type": "string",
             "label": "Chrome Path",
             "required": false,
-            "helpMarkDown": "Path to Chrome executable."
+            "helpMarkDown": "Path to Chrome executable.",
+            "groupName": "advancedOptions"
         },
         {
             "name": "url",


### PR DESCRIPTION
#### Details

This introduces an advanced options group to the pipeline configuration assistant UI in ADO. It groups the `outputDir` and `chromePath` options under a collapsed by default group called `Advanced Options` that shows up at the bottom of the UI.

Here is what it looks like collapsed:
![image](https://user-images.githubusercontent.com/13286385/159052047-36db02f6-b87b-4c88-8535-7cc1a21c0bec.png)
 
Here it is expanded:
![image](https://user-images.githubusercontent.com/13286385/159052165-1ea5fec1-8598-4f06-80f6-a5ec7667ee80.png)


##### Motivation

Partially addresses #1063

##### Context

We will need to add `artifactName` to the advanced options once #1085 has been merged. I'll add this in a separate commit after merging that PR into main.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Partially addresses #1063
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
