### PR TITLE
feat(ado-ext-telemetry): update canary release pipeline to allow an extension version override

### DIFF
--- a/pipelines/canary-release.yaml
+++ b/pipelines/canary-release.yaml
@@ -12,7 +12,7 @@ parameters:
       default: 'ignore-if-canary'
 
 variables:
-    - ${{ if ne(parameters.variableGroupName, 'ado-extension-canary') }}:
+    - ${{ if and(ne(parameters.variableGroupName, 'ado-extension-canary'), ne(parameters.versionOverride, 'ignore-if-canary')) }}:
           - name: extensionVersionOverride
             value: ${{ parameters.versionOverride }}
 


### PR DESCRIPTION
#### Details

This allows for the canary release pipeline version to be overridden.  Before this, even if the `versionOverride` parameter was set, it would look at the `ado-extension-canary` variable group and throw it out.  This allows us to upgrade the canary version by overriding the default 'ignore-if-canary' parameter in the build.

We need this to be able to upgrade the major version of Canary as we prepare to merge in breaking changes.

##### Motivation

Feature work

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
