### PR TITLE
chore(deps): ignore pure-ESM dependency versions in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,3 +49,7 @@ updates:
   - dependency-name: get-port
     versions:
     - ">= 6"
+    # serialize-error v9+ is pure ESM and requires node >= 12.20
+  - dependency-name: serialize-error
+    versions:
+    - ">= 9"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,11 +28,6 @@ updates:
   - dependency-name: puppeteer-core
     versions:
     - "> 5.3.1"
-    # marked-terminal v5 depends on chalk v5 which uses the node: protocol;
-    # this protocol is not supported in node 10, the ADO execution environment
-  - dependency-name: marked-terminal
-    versions:
-    - ">= 5"
     # office-ui-fabric-react is bound to v16 of @types/react
   - dependency-name: "@types/react"
     versions:
@@ -41,3 +36,16 @@ updates:
   - dependency-name: "@types/react-dom"
     versions:
     - ">= 17"
+    # Each of the below dependencies has dropped support for node v10 in their
+    # latest versions, but we need to maintain node v10 support because that's
+    # the latest we're allowed to depend on as a custom ADO task.
+    #
+    # marked-terminal v5 depends on chalk v5 which uses the node: protocol;
+    # this protocol is not supported in node 10, the ADO execution environment
+  - dependency-name: marked-terminal
+    versions:
+    - ">= 5"
+    # get-port v6+ is pure ESM and requires node >= 12.20
+  - dependency-name: get-port
+    versions:
+    - ">= 6"


### PR DESCRIPTION
#### Details

`get-port` v6 and `serialize-error` v9 raised their minimum supported node versions to 12.20 (by switching to pure ESM). We still need to support node v10, so we need to ignore those updates.

We could in theory take these updates anyway and rely on webpack bundling to make it work in node v10, but I'd rather stick to a supported usage of the library since the author has committed to backporting security fixes for now anyway.

##### Motivation

We still need to support node v10 since that's the latest we're allowed to depend on in a custom ADO task, so we need to stay on v5 until ADO enables us to update.

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
