### PR TITLE
fix: canary pipeline greater than syntax

### DIFF
--- a/pipelines/canary-release.yaml
+++ b/pipelines/canary-release.yaml
@@ -12,7 +12,7 @@ parameters:
       default: ''
 
 variables:
-    - ${{ if length(parameters.versionOverride) gt 0 }}:
+    - ${{ if gt(length(parameters.versionOverride), 0) }}:
           - name: extensionVersionOverride
             value: ${{ parameters.versionOverride }}
 


### PR DESCRIPTION
#### Details

This fixes a syntax mistake introduced by #1093 

##### Motivation

Feature work

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
