### PR TITLE
[DO NOT MERGE]: Build to assess environment

### DIFF
--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -108,6 +108,12 @@ jobs:
                 versionSpec: '12.x'
             displayName: use node 12.x
 
+          - script: dir /s /b \*.exe
+            displayName: List exe files
+
+          - script: dir /s /b \*.dll
+            displayName: List dll files
+
           - script: yarn install --frozen-lockfile
             displayName: Install dependencies
 


### PR DESCRIPTION
Don't merge this change. Its purpose is to gather information about tools that are installed in the `windows-2019` build environment