### PR TITLE
docs(ado-extension): add note to have yarn as a prerequisite

### DIFF
--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -5,6 +5,17 @@ Licensed under the MIT License.
 
 # How to use the Azure DevOps extension
 
+## Prerequisites
+
+### Tools
+
+-   [Yarn](https://yarnpkg.com/getting-started/install) >= 1.22.10
+    -   The Accessibility Insights for Azure DevOps extension uses Yarn to install dependencies. If your build agent does not come with Yarn pre-installed, you must add a step to install it yourself.
+    ```yml
+    - script: npm install yarn@1.22.10 -g
+      displayName: install yarn as a global dependency
+    ```
+
 ## Adding the extension
 
 Install [Accessibility Insights for Azure DevOps - Production](https://marketplace.visualstudio.com/items?itemName=accessibility-insights.prod).


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
The ADO extension uses Yarn to install packages before running scans on websites. Some build agents come with Yarn pre-installed, as indicated in [docs for Microsoft-hosted agents](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#software). This adds a note to indicate to users to add a step to install Yarn if it is not already included in their build agent.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
It was previously unclear to users if Yarn was needed for the extension.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
