### PR TITLE
chore(deps): replace verror with pony-cause to preempt future node compat issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
         "@types/normalize-path": "^3.0.0",
         "@types/puppeteer-core": "^5.4.0",
         "@types/serve-static": "^1.13.10",
-        "@types/verror": "^1.10.5",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -41,9 +41,9 @@
         "marked": "^4.0.12",
         "marked-terminal": "^4.2.0",
         "normalize-path": "^3.0.0",
+        "pony-cause": "^1.1.1",
         "reflect-metadata": "^0.1.13",
         "serialize-error": "^8.0.1",
-        "serve-static": "^1.14.2",
-        "verror": "^1.10.1"
+        "serve-static": "^1.14.2"
     }
 }

--- a/packages/shared/src/logger/console-logger-client.ts
+++ b/packages/shared/src/logger/console-logger-client.ts
@@ -3,6 +3,7 @@
 
 import { inject, injectable } from 'inversify';
 import { isEmpty } from 'lodash';
+import { stackWithCauses } from 'pony-cause';
 import * as util from 'util';
 import { iocTypes } from '../ioc/ioc-types';
 import { BaseTelemetryProperties } from './base-telemetry-properties';
@@ -26,7 +27,7 @@ export class ConsoleLoggerClient implements LoggerClient {
     }
 
     public trackException(error: Error): void {
-        this.logInConsole(`[error][Exception]${this.getPrintablePropertiesString()}`, this.getPrintableString(error));
+        this.logInConsole(`[error][Exception]${this.getPrintablePropertiesString()}`, stackWithCauses(error));
     }
 
     public setCustomProperties(properties: LoggerProperties): void {

--- a/packages/shared/src/logger/logger.spec.ts
+++ b/packages/shared/src/logger/logger.spec.ts
@@ -3,7 +3,7 @@
 import 'reflect-metadata';
 
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-import { VError } from 'verror';
+import { ErrorWithCause } from 'pony-cause';
 import { BaseTelemetryProperties } from './base-telemetry-properties';
 import { ConsoleLoggerClient } from './console-logger-client';
 import { Logger } from './logger';
@@ -317,7 +317,7 @@ describe(Logger, () => {
             await testSubject.setup();
 
             invokeAllLoggerClientMocks((m) =>
-                m.setup((c) => c.trackException(new VError(underlyingError, errorMessage))).verifiable(Times.once()),
+                m.setup((c) => c.trackException(new ErrorWithCause(errorMessage, { cause: underlyingError }))).verifiable(Times.once()),
             );
 
             testSubject.trackExceptionAny(underlyingError, errorMessage);
@@ -334,7 +334,11 @@ describe(Logger, () => {
 
             invokeAllLoggerClientMocks((m) =>
                 m
-                    .setup((c) => c.trackException(new VError(new Error(testSubject.serializeError(underlyingError)), errorMessage)))
+                    .setup((c) =>
+                        c.trackException(
+                            new ErrorWithCause(errorMessage, { cause: new Error(testSubject.serializeError(underlyingError)) }),
+                        ),
+                    )
                     .verifiable(Times.once()),
             );
 

--- a/packages/shared/src/logger/logger.ts
+++ b/packages/shared/src/logger/logger.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { VError } from 'verror';
+import { ErrorWithCause } from 'pony-cause';
 import * as utils from 'util';
 import { LoggerClient } from './logger-client';
 import { LogLevel } from './log-level';
@@ -62,9 +62,9 @@ export class Logger {
     }
 
     public trackExceptionAny(underlyingErrorData: any | Error, message: string): void {
-        const parsedErrorObject =
+        const underlyingError =
             underlyingErrorData instanceof Error ? underlyingErrorData : new Error(this.serializeError(underlyingErrorData));
-        this.trackException(new VError(parsedErrorObject, message));
+        this.trackException(new ErrorWithCause(message, { cause: underlyingError }));
     }
 
     public serializeError(error: any): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,9 +2148,9 @@
   integrity sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==
 
 "@types/node@>=10.0.0":
-  version "17.0.21"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
-  integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
+  version "17.0.22"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.22.tgz#38b6c4b9b2f3ed9f2e376cce42a298fb2375251e"
+  integrity sha512-8FwbVoG4fy+ykY86XCAclKZDORttqE5/s7dyWZKLXTdv3vRy5HozBEinG5IqhvPXXzIZEcTVbuHlQEI6iuwcmw==
 
 "@types/node@^10.0.3":
   version "10.17.60"
@@ -2296,11 +2296,6 @@
   integrity sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==
   dependencies:
     "@types/node" "*"
-
-"@types/verror@^1.10.5":
-  version "1.10.5"
-  resolved "https://registry.yarnpkg.com/@types/verror/-/verror-1.10.5.tgz#2a1413aded46e67a1fe2386800e291123ed75eb1"
-  integrity sha512-9UjMCHK5GPgQRoNbqdLIAvAy0EInuiqbW0PBMtVP6B5B2HQJlvoJHM+KodPZMEjOa5VkSc+5LH7xy+cUzQdmHw==
 
 "@types/yargs-parser@*":
   version "20.2.0"
@@ -4247,10 +4242,17 @@ debug@2.6.9, debug@^2.2.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@4.3.3, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@~4.3.1, debug@~4.3.2:
+debug@4, debug@4.3.3, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@~4.3.1:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
+
+debug@~4.3.2:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -5747,11 +5749,11 @@ he@1.2.0:
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hosted-git-info@>=3.0.8, hosted-git-info@^2.1.4, hosted-git-info@^4.0.0, hosted-git-info@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz#827b82867e9ff1c8d0c4d9d53880397d2c86d224"
-  integrity sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-5.0.0.tgz#df7a06678b4ebd722139786303db80fdf302ea56"
+  integrity sha512-rRnjWu0Bxj+nIfUOkz0695C0H6tRrN5iYIzYejb0tDEefe2AekHu/U5Kn9pEie5vsJqpNQU02az7TGSH3qpz4Q==
   dependencies:
-    lru-cache "^6.0.0"
+    lru-cache "^7.5.1"
 
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
@@ -7342,6 +7344,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru-cache@^7.5.1:
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.7.1.tgz#03d2846b1ad2dcc7931a9340b8711d9798fcb0c6"
+  integrity sha512-cRffBiTW8s73eH4aTXqBcTLU0xQnwGV3/imttRHGWCrbergmnK4D6JXQd8qin5z43HnDwRI+o7mVW0LEB+tpAw==
+
 luxon@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.0.2.tgz#11f2cd4a11655fdf92e076b5782d7ede5bcdd133"
@@ -8577,6 +8584,11 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pony-cause@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pony-cause/-/pony-cause-1.1.1.tgz#f795524f83bebbf1878bd3587b45f69143cbf3f9"
+  integrity sha512-PxkIc/2ZpLiEzQXu5YRDOUgBlfGYBY8156HY5ZcRAwwonMk5W/MrJP2LLkG/hF7GEQzaHo2aS7ho6ZLCOvf+6g==
 
 portastic@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### Details

Today, our logger uses `node-verror` to represent an `Error` object that can track an underlying `cause`. It does this by exposing a `cause()` method. However, since verror was written, JavaScript's TC39 group has standardized a `cause` property (not method) on the base `Error` type, which is incompatible (`cause()` vs `cause`).

This doesn't cause any issues for us today, but could in the future if, for example, we ever tracked exceptions through a library (eg, app insights) which tried to read from `cause`. It also causes errors in TypeScript 4.6.2 (see build failures in #1080), which catches the incompatible types.

This PR addresses the issue by swapping out `node-verror` for a similar library called `pony-cause` which implements an `ErrorWithCause` class comparable to `VError` but with the standards-compliant `cause` property. It also provides a `stackWithCauses` helper that I've dropped into our logger which is cross-compatible with both `cause` and `cause()`, which is helpful because several underlying `accessibility-insights-scan` errors still use `VError` for now.

##### Motivation

* Resolves build failure in #1080
* Preempts potential future compat issues when we eventually update node versions

##### Context

We'll want to make a comparable change the service; I've let Maxim know about the service impact offline already

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
