### PR TITLE
fix: Allow manual test extension pipeline deployments without requiring version number

### DIFF
--- a/pipelines/canary-release.yaml
+++ b/pipelines/canary-release.yaml
@@ -7,12 +7,12 @@ parameters:
       type: string
       default: 'ado-extension-canary'
     - name: versionOverride
-      displayName: Override extension version (if not specified, defaults to upgrading patch version)
+      displayName: Override extension version (for non-patch version upgrades, specify version number)
       type: string
-      default: ''
+      default: 'ignore-for-patch-version-upgrade'
 
 variables:
-    - ${{ if gt(length(parameters.versionOverride), 0) }}:
+    - ${{ if ne(parameters.versionOverride, 'ignore-for-patch-version-upgrade') }}:
           - name: extensionVersionOverride
             value: ${{ parameters.versionOverride }}
 


### PR DESCRIPTION
#### Details

This fixes an issue introduced in #1093. The `versionOverride` parameter would default to an empty string. This worked for automated pipeline runs, but wouldn't allow manual pipeline runs to function without inputting a version number.

The ADO pipelines manual run GUI assumes it's a required field that is empty and must be filled out, even though the default is an empty string.  To address this I've set it to a string `ignore-for-patch-version-upgrade` so that you can manually run the pipeline without specifying the version number.

Here's a screenshot of the behavior, with the required field specified and the run button disabled:
![image](https://user-images.githubusercontent.com/13286385/159974808-aa474cbd-c2cb-4e24-bab5-fdd8a51509fd.png)


##### Motivation

bugfix

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
