### PR TITLE
chore: remove obsolete checklist item from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,4 +18,3 @@
 - [ ] Added relevant unit test for your changes. (`yarn test`)
 - [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
 - [ ] Ran precheckin (`yarn precheckin`)
-- [ ] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.


### PR DESCRIPTION
#### Details

A previous feature removed the intentionally-failing "Accessibility Checks (pull_request)" check; this updates our PR template accordingly.

##### Motivation

Makes PR template less misleading

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [nope!] (after PR created) The `Accessibility Checks (pull_request)` check should fail. All other checks should pass.
