### PR TITLE
chore: create self-test workflow to run in main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-name: Build
+name: Continuous Integration
 
 on: 
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-name: Continuous Integration
+name: CI
 
 on: 
   push:

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -14,7 +14,7 @@ jobs:
     name: Self-test GitHub Action
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.os }}
     permissions:
       checks: write

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -1,0 +1,47 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+name: Self-test GitHub Action
+
+on:
+  push:
+    branches:
+      - main
+    # This doesn't run on PRs because of #629
+
+jobs:
+  self-test-dev:
+    name: Self-test GitHub Action
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      checks: write
+      pull-requests: write
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+    - name: Setup node
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node }}
+      
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+    
+    - name: Build
+      run: yarn cbuild
+
+    - name: Scan test site
+      uses: ./packages/gh-action/
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        site-dir: ${{ github.workspace }}/dev/website-root
+
+    - name: Upload report artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: accessibility-reports
+        path: ${{ github.workspace }}/_accessibility-reports


### PR DESCRIPTION
#### Details

We used to run a self-test of the GitHub action in our PR/CI builds, but disabled it due to #629 preventing it from working in PR builds.

However, I think it would still be valuable to run in CI builds against main, even if we can't run it with PRs yet. This restores it in a separate workflow that only triggers on pushes to main (not PRs).

##### Motivation

Maintain ongoing validation that we haven't broken the action.

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
