### PR TITLE
chore: fix self-test workflow node version

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node }}
+        node-version: 12.x
       
     - name: Install dependencies
       run: yarn install --frozen-lockfile


### PR DESCRIPTION
#### Details

This is a followup to #1110 which fixes a half-reverted change I'd been trying out to use a matrix of node versions to test with

##### Motivation

Fixes https://github.com/microsoft/accessibility-insights-action/runs/5726695339?check_suite_focus=true

##### Context

see #1110

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
