### PR TITLE
chore: remove the os matrix from the self-test workflow

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
-      pull-requests: write
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -12,10 +12,7 @@ on:
 jobs:
   self-test-dev:
     name: Self-test GitHub Action
-    strategy:
-      matrix:
-        os: ["ubuntu-latest", "windows-latest"]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     permissions:
       checks: write
       pull-requests: write


### PR DESCRIPTION
#### Details

The self test workflow added today in #1110 and #1111 uncovered issue #1112 when I tried to use a matrix strategy to test it across both ubuntu and windows agents. This PR disables the matrix strategy as a workaround until we fix #1112.

##### Motivation

Unblock self-test workflow

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
