### PR TITLE
feat(ado-ext-telemetry-1893588): implement App Insights telemetry entry point

### DIFF
--- a/packages/ado-extension/package.json
+++ b/packages/ado-extension/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@accessibility-insights-action/shared": "^1.0.0",
-        "@microsoft/applicationinsights-web-basic": "^2.7.4",
+        "applicationinsights": "^2.2.2",
         "azure-pipelines-task-lib": "^3.2.0",
         "reflect-metadata": "^0.1.13"
     }

--- a/packages/ado-extension/package.json
+++ b/packages/ado-extension/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@accessibility-insights-action/shared": "^1.0.0",
-        "@microsoft/applicationinsights-web": "^2.7.4",
+        "@microsoft/applicationinsights-web-basic": "^2.7.4",
         "azure-pipelines-task-lib": "^3.2.0",
         "reflect-metadata": "^0.1.13"
     }

--- a/packages/ado-extension/package.json
+++ b/packages/ado-extension/package.json
@@ -32,8 +32,9 @@
         "tfx-cli": "^0.11.0"
     },
     "dependencies": {
-        "reflect-metadata": "^0.1.13",
+        "@accessibility-insights-action/shared": "^1.0.0",
+        "@microsoft/applicationinsights-web": "^2.7.4",
         "azure-pipelines-task-lib": "^3.2.0",
-        "@accessibility-insights-action/shared": "^1.0.0"
+        "reflect-metadata": "^0.1.13"
     }
 }

--- a/packages/ado-extension/scripts/local-ado-extension-metadata.json
+++ b/packages/ado-extension/scripts/local-ado-extension-metadata.json
@@ -1,0 +1,8 @@
+{
+    "publisherId": "unpublished",
+    "extensionId": "local-dev",
+    "extensionName": "Local dev build (run-locally.js)",
+    "extensionVersion": "0.0.0",
+    "environment": "dev",
+    "appInsightsConnectionString": ""
+}

--- a/packages/ado-extension/scripts/run-locally.js
+++ b/packages/ado-extension/scripts/run-locally.js
@@ -24,6 +24,7 @@ without quotes, like singleWorker above.
 */
 
 const mockRunner = require('azure-pipelines-task-lib/mock-run');
+const fs = require('fs');
 const path = require('path');
 const { exit } = require('process');
 
@@ -58,6 +59,11 @@ for (const name of Object.keys(inputs)) {
     console.log(`run-locally.js is setting up input ${name} to value ${inputs[name]}`);
     tmr.setInput(name, inputs[name]);
 }
+
+const srcAdoExtensionMetadata = path.join(__dirname, 'local-ado-extension-metadata.json');
+const destAdoExtensionMetadata = path.join(__dirname, '..', 'dist', 'pkg', 'ado-extension-metadata.json');
+console.log(`run-locally.js is copying ${srcAdoExtensionMetadata} to ${destAdoExtensionMetadata}`);
+fs.copyFileSync(srcAdoExtensionMetadata, destAdoExtensionMetadata);
 
 console.log('beginning task execution below');
 console.log();

--- a/packages/ado-extension/src/ado-extension.ts
+++ b/packages/ado-extension/src/ado-extension.ts
@@ -18,11 +18,7 @@ export function runScan(): void {
         await logger.setup();
 
         const scanner = container.get(Scanner);
-        const completedWithNoUserActionNeeded = await scanner.scan();
-
-        process.exit(
-            completedWithNoUserActionNeeded ? ExitCode.ScanCompletedNoUserActionIsNeeded : ExitCode.ScanCompletedUserActionIsNeeded,
-        );
+        process.exit((await scanner.scan()) ? ExitCode.ScanCompletedNoUserActionIsNeeded : ExitCode.ScanCompletedUserActionIsNeeded);
     })().catch((error) => {
         console.log('##[error][Exception] Exception thrown in extension: ', error);
         process.exit(ExitCode.ScanFailedToComplete);

--- a/packages/ado-extension/src/ado-extension.ts
+++ b/packages/ado-extension/src/ado-extension.ts
@@ -20,10 +20,6 @@ export function runScan(): void {
         const scanner = container.get(Scanner);
         const completedWithNoUserActionNeeded = await scanner.scan();
 
-        logger.logDebug(`Waiting 5s for telemetry to flush...`);
-        const delay = (delayMs: number) => new Promise((resolve) => setTimeout(resolve, delayMs));
-        await delay(5000); // for telemetry flush
-
         process.exit(
             completedWithNoUserActionNeeded ? ExitCode.ScanCompletedNoUserActionIsNeeded : ExitCode.ScanCompletedUserActionIsNeeded,
         );

--- a/packages/ado-extension/src/ado-extension.ts
+++ b/packages/ado-extension/src/ado-extension.ts
@@ -18,7 +18,15 @@ export function runScan(): void {
         await logger.setup();
 
         const scanner = container.get(Scanner);
-        process.exit((await scanner.scan()) ? ExitCode.ScanCompletedNoUserActionIsNeeded : ExitCode.ScanCompletedUserActionIsNeeded);
+        const completedWithNoUserActionNeeded = await scanner.scan();
+
+        logger.logDebug(`Waiting 5s for telemetry to flush...`);
+        const delay = (delayMs: number) => new Promise((resolve) => setTimeout(resolve, delayMs));
+        await delay(5000); // for telemetry flush
+
+        process.exit(
+            completedWithNoUserActionNeeded ? ExitCode.ScanCompletedNoUserActionIsNeeded : ExitCode.ScanCompletedUserActionIsNeeded,
+        );
     })().catch((error) => {
         console.log('##[error][Exception] Exception thrown in extension: ', error);
         process.exit(ExitCode.ScanFailedToComplete);

--- a/packages/ado-extension/src/ioc/ado-ioc-types.ts
+++ b/packages/ado-extension/src/ioc/ado-ioc-types.ts
@@ -4,4 +4,5 @@
 export const AdoIocTypes = {
     AdoTask: 'AdoTask',
     NodeApi: 'NodeApi',
+    AppInsights: 'AppInsights',
 };

--- a/packages/ado-extension/src/ioc/setup-ioc-container.spec.ts
+++ b/packages/ado-extension/src/ioc/setup-ioc-container.spec.ts
@@ -4,7 +4,7 @@ import 'reflect-metadata';
 
 import * as AdoTask from 'azure-pipelines-task-lib/task';
 import * as NodeApi from 'azure-devops-node-api';
-import * as AppInsights from '@microsoft/applicationinsights-web-basic';
+import * as AppInsights from 'applicationinsights';
 import { Container } from 'inversify';
 import { setupIocContainer } from './setup-ioc-container';
 import { iocTypes, NullTelemetryClient, TelemetryClient } from '@accessibility-insights-action/shared';

--- a/packages/ado-extension/src/ioc/setup-ioc-container.spec.ts
+++ b/packages/ado-extension/src/ioc/setup-ioc-container.spec.ts
@@ -4,11 +4,13 @@ import 'reflect-metadata';
 
 import * as AdoTask from 'azure-pipelines-task-lib/task';
 import * as NodeApi from 'azure-devops-node-api';
+import * as AppInsights from '@microsoft/applicationinsights-web';
 import { Container } from 'inversify';
 import { setupIocContainer } from './setup-ioc-container';
-import { iocTypes } from '@accessibility-insights-action/shared';
+import { iocTypes, NullTelemetryClient, TelemetryClient } from '@accessibility-insights-action/shared';
 import { AdoIocTypes } from './ado-ioc-types';
 import { AdoConsoleCommentCreator } from '../progress-reporter/console/ado-console-comment-creator';
+import { TelemetryClientFactory } from '../telemetry/telemetry-client-factory';
 
 describe(setupIocContainer, () => {
     let testSubject: Container;
@@ -27,10 +29,19 @@ describe(setupIocContainer, () => {
     test('verify progress reporter resolution', () => {
         verifySingletonDependencyResolution(testSubject, iocTypes.ProgressReporters);
     });
+    
+    test('verify singleton TelemetryClient resolution using TelemetryClientFactory', () => {
+        testSubject.bind(TelemetryClientFactory).to(StubTelemetryClientFactory);
+
+        expect(testSubject.get(iocTypes.TelemetryClient)).toBeInstanceOf(StubTelemetryClient);
+
+        verifySingletonDependencyResolution(testSubject, iocTypes.TelemetryClient);
+    })
 
     test.each([
         { key: AdoIocTypes.AdoTask, value: AdoTask },
         { key: AdoIocTypes.NodeApi, value: NodeApi },
+        { key: AdoIocTypes.AppInsights, value: AppInsights },
     ])('verify constant value resolution %s', (pair: { key: string; value: any }) => {
         expect(testSubject.get(pair.key)).toEqual(pair.value);
     });
@@ -40,3 +51,8 @@ describe(setupIocContainer, () => {
         expect(container.get(key)).toBe(container.get(key));
     }
 });
+
+class StubTelemetryClient extends NullTelemetryClient {}
+class StubTelemetryClientFactory extends TelemetryClientFactory {
+    public createTelemetryClient(): TelemetryClient { return new StubTelemetryClient(); }
+}

--- a/packages/ado-extension/src/ioc/setup-ioc-container.spec.ts
+++ b/packages/ado-extension/src/ioc/setup-ioc-container.spec.ts
@@ -4,7 +4,7 @@ import 'reflect-metadata';
 
 import * as AdoTask from 'azure-pipelines-task-lib/task';
 import * as NodeApi from 'azure-devops-node-api';
-import * as AppInsights from '@microsoft/applicationinsights-web';
+import * as AppInsights from '@microsoft/applicationinsights-web-basic';
 import { Container } from 'inversify';
 import { setupIocContainer } from './setup-ioc-container';
 import { iocTypes, NullTelemetryClient, TelemetryClient } from '@accessibility-insights-action/shared';

--- a/packages/ado-extension/src/ioc/setup-ioc-container.spec.ts
+++ b/packages/ado-extension/src/ioc/setup-ioc-container.spec.ts
@@ -29,14 +29,14 @@ describe(setupIocContainer, () => {
     test('verify progress reporter resolution', () => {
         verifySingletonDependencyResolution(testSubject, iocTypes.ProgressReporters);
     });
-    
+
     test('verify singleton TelemetryClient resolution using TelemetryClientFactory', () => {
         testSubject.bind(TelemetryClientFactory).to(StubTelemetryClientFactory);
 
         expect(testSubject.get(iocTypes.TelemetryClient)).toBeInstanceOf(StubTelemetryClient);
 
         verifySingletonDependencyResolution(testSubject, iocTypes.TelemetryClient);
-    })
+    });
 
     test.each([
         { key: AdoIocTypes.AdoTask, value: AdoTask },
@@ -54,5 +54,7 @@ describe(setupIocContainer, () => {
 
 class StubTelemetryClient extends NullTelemetryClient {}
 class StubTelemetryClientFactory extends TelemetryClientFactory {
-    public createTelemetryClient(): TelemetryClient { return new StubTelemetryClient(); }
+    public createTelemetryClient(): TelemetryClient {
+        return new StubTelemetryClient();
+    }
 }

--- a/packages/ado-extension/src/ioc/setup-ioc-container.ts
+++ b/packages/ado-extension/src/ioc/setup-ioc-container.ts
@@ -4,7 +4,7 @@
 import * as AdoTask from 'azure-pipelines-task-lib/task';
 import * as inversify from 'inversify';
 import * as NodeApi from 'azure-devops-node-api';
-import * as AppInsights from '@microsoft/applicationinsights-web-basic';
+import * as AppInsights from 'applicationinsights';
 import { iocTypes, setupSharedIocContainer } from '@accessibility-insights-action/shared';
 import { ADOTaskConfig } from '../task-config/ado-task-config';
 import { AdoIocTypes } from './ado-ioc-types';

--- a/packages/ado-extension/src/ioc/setup-ioc-container.ts
+++ b/packages/ado-extension/src/ioc/setup-ioc-container.ts
@@ -4,17 +4,20 @@
 import * as AdoTask from 'azure-pipelines-task-lib/task';
 import * as inversify from 'inversify';
 import * as NodeApi from 'azure-devops-node-api';
+import * as AppInsights from '@microsoft/applicationinsights-web';
 import { iocTypes, setupSharedIocContainer } from '@accessibility-insights-action/shared';
 import { ADOTaskConfig } from '../task-config/ado-task-config';
 import { AdoIocTypes } from './ado-ioc-types';
 import { ADOArtifactsInfoProvider } from '../ado-artifacts-info-provider';
 import { WorkflowEnforcer } from '../progress-reporter/enforcement/workflow-enforcer';
 import { AdoConsoleCommentCreator } from '../progress-reporter/console/ado-console-comment-creator';
+import { TelemetryClientFactory } from '../telemetry/telemetry-client-factory';
 
 export function setupIocContainer(container = new inversify.Container({ autoBindInjectable: true })): inversify.Container {
     container = setupSharedIocContainer(container);
     container.bind(AdoIocTypes.AdoTask).toConstantValue(AdoTask);
     container.bind(AdoIocTypes.NodeApi).toConstantValue(NodeApi);
+    container.bind(AdoIocTypes.AppInsights).toConstantValue(AppInsights);
     container.bind(iocTypes.TaskConfig).to(ADOTaskConfig).inSingletonScope();
     container.bind(AdoConsoleCommentCreator).toSelf().inSingletonScope();
     container.bind(WorkflowEnforcer).toSelf().inSingletonScope();
@@ -25,6 +28,13 @@ export function setupIocContainer(container = new inversify.Container({ autoBind
         })
         .inSingletonScope();
     container.bind(iocTypes.ArtifactsInfoProvider).to(ADOArtifactsInfoProvider).inSingletonScope();
+
+    container
+        .rebind(iocTypes.TelemetryClient)
+        .toDynamicValue((context) => {
+            return context.container.get(TelemetryClientFactory).createTelemetryClient();
+        })
+        .inSingletonScope();
 
     return container;
 }

--- a/packages/ado-extension/src/ioc/setup-ioc-container.ts
+++ b/packages/ado-extension/src/ioc/setup-ioc-container.ts
@@ -4,7 +4,7 @@
 import * as AdoTask from 'azure-pipelines-task-lib/task';
 import * as inversify from 'inversify';
 import * as NodeApi from 'azure-devops-node-api';
-import * as AppInsights from '@microsoft/applicationinsights-web';
+import * as AppInsights from '@microsoft/applicationinsights-web-basic';
 import { iocTypes, setupSharedIocContainer } from '@accessibility-insights-action/shared';
 import { ADOTaskConfig } from '../task-config/ado-task-config';
 import { AdoIocTypes } from './ado-ioc-types';

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -161,6 +161,8 @@ describe(AdoConsoleCommentCreator, () => {
 
             loggerMock.setup((lm) => lm.logInfo(expectedLogOutput)).verifiable(Times.once());
             loggerMock.setup((lm) => lm.logInfo(`##vso[task.uploadsummary]${fileName}`)).verifiable(Times.once());
+
+            // eslint-disable-next-line security/detect-non-literal-fs-filename
             fsMock.setup((fsm) => fsm.writeFileSync(fileName, expectedLogOutput)).verifiable();
         }
 

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.spec.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.spec.ts
@@ -59,11 +59,11 @@ describe(AppInsightsTelemetryClient, () => {
         });
 
         it.each`
-            commonPropName | metadataPropName
+            commonPropName            | metadataPropName
             ${'extensionPublisherId'} | ${'publisherId'}
-            ${'extensionId'} | ${'extensionId'}
-            ${'extensionName'} | ${'extensionName'}
-            ${'extensionVersion'} | ${'extensionVersion'}
+            ${'extensionId'}          | ${'extensionId'}
+            ${'extensionName'}        | ${'extensionName'}
+            ${'extensionVersion'}     | ${'extensionVersion'}
             ${'extensionEnvironment'} | ${'environment'}
         `('reflects metadata property $metadataPropName as common property $commonPropName', ({ commonPropName, metadataPropName }) => {
             new AppInsightsTelemetryClient(mockAppInsights, stubConnectionString, mockLogger.object, stubMetadata, stubProcessEnv);
@@ -80,11 +80,11 @@ describe(AppInsightsTelemetryClient, () => {
         });
 
         it.each`
-            commonPropName | envVar
-            ${'adoTeamProjectId'} | ${'SYSTEM_TEAMPROJECTID'}
+            commonPropName               | envVar
+            ${'adoTeamProjectId'}        | ${'SYSTEM_TEAMPROJECTID'}
             ${'adoPipelineDefinitionId'} | ${'SYSTEM_DEFINITIONID'}
-            ${'adoPullRequestId'} | ${'SYSTEM_PULLREQUEST_PULLREQUESTID'}
-            ${'adoJobId'} | ${'SYSTEM_JOBID'}
+            ${'adoPullRequestId'}        | ${'SYSTEM_PULLREQUEST_PULLREQUESTID'}
+            ${'adoJobId'}                | ${'SYSTEM_JOBID'}
         `('reflects environment variable $envVar as common property $commonPropName', ({ commonPropName, envVar }) => {
             stubProcessEnv[envVar] = 'ENV VAR VALUE';
 
@@ -113,7 +113,13 @@ describe(AppInsightsTelemetryClient, () => {
 
     describe('trackEvent', () => {
         it("delegates to the underlying client's trackEvent with the expected envelope format", () => {
-            const testSubject = new AppInsightsTelemetryClient(mockAppInsights, stubConnectionString, mockLogger.object, stubMetadata, stubProcessEnv);
+            const testSubject = new AppInsightsTelemetryClient(
+                mockAppInsights,
+                stubConnectionString,
+                mockLogger.object,
+                stubMetadata,
+                stubProcessEnv,
+            );
             const testEvent: TelemetryEvent = { name: 'ScanStart', properties: { 'prop 1': 'value 1' } };
 
             testSubject.trackEvent(testEvent);
@@ -124,7 +130,13 @@ describe(AppInsightsTelemetryClient, () => {
 
     describe('flush', () => {
         it("delegates to the underlying client's flush", () => {
-            const testSubject = new AppInsightsTelemetryClient(mockAppInsights, stubConnectionString, mockLogger.object, stubMetadata, stubProcessEnv);
+            const testSubject = new AppInsightsTelemetryClient(
+                mockAppInsights,
+                stubConnectionString,
+                mockLogger.object,
+                stubMetadata,
+                stubProcessEnv,
+            );
 
             testSubject.flush();
 

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.spec.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.spec.ts
@@ -3,7 +3,7 @@
 import 'reflect-metadata';
 
 import type * as appInsights from '@microsoft/applicationinsights-web';
-import { AppInsightsTelemetryClient } from "./app-insights-telemetry-client";
+import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
 import { TelemetryEvent } from '@accessibility-insights-action/shared';
 
 class MockApplicationInsights {
@@ -33,7 +33,7 @@ describe(AppInsightsTelemetryClient, () => {
             expect(MockApplicationInsights.lastConstructedInstance?.snippet).toStrictEqual({
                 config: {
                     connectionString: 'test connection string',
-    
+
                     disableExceptionTracking: true,
                     disableFetchTracking: true,
                     disableAjaxTracking: true,
@@ -48,7 +48,7 @@ describe(AppInsightsTelemetryClient, () => {
         it("delegates to the underlying client's trackEvent", () => {
             const testSubject = new AppInsightsTelemetryClient(mockAppInsights, 'test connection string');
 
-            const testEvent: TelemetryEvent = { name: 'test event', properties: { 'prop 1': 'value 1' }};
+            const testEvent: TelemetryEvent = { name: 'test event', properties: { 'prop 1': 'value 1' } };
             testSubject.trackEvent(testEvent);
 
             expect(MockApplicationInsights.lastConstructedInstance?.trackEvent).toHaveBeenCalledWith(testEvent);

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.spec.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.spec.ts
@@ -5,6 +5,7 @@ import 'reflect-metadata';
 import type * as appInsights from '@microsoft/applicationinsights-web';
 import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
 import { TelemetryEvent } from '@accessibility-insights-action/shared';
+import { TelemetryEventName } from '@accessibility-insights-action/shared/dist/telemetry/telemetry-event';
 
 class MockApplicationInsights {
     public static lastConstructedInstance?: MockApplicationInsights;
@@ -48,7 +49,7 @@ describe(AppInsightsTelemetryClient, () => {
         it("delegates to the underlying client's trackEvent", () => {
             const testSubject = new AppInsightsTelemetryClient(mockAppInsights, 'test connection string');
 
-            const testEvent: TelemetryEvent = { name: 'test event', properties: { 'prop 1': 'value 1' } };
+            const testEvent: TelemetryEvent = { name: 'ScanStart', properties: { 'prop 1': 'value 1' } };
             testSubject.trackEvent(testEvent);
 
             expect(MockApplicationInsights.lastConstructedInstance?.trackEvent).toHaveBeenCalledWith(testEvent);

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.spec.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.spec.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import type * as appInsights from '@microsoft/applicationinsights-web';
+import { AppInsightsTelemetryClient } from "./app-insights-telemetry-client";
+import { TelemetryEvent } from '@accessibility-insights-action/shared';
+
+class MockApplicationInsights {
+    public static lastConstructedInstance?: MockApplicationInsights;
+
+    constructor(public readonly snippet: appInsights.Snippet) {
+        MockApplicationInsights.lastConstructedInstance = this;
+    }
+
+    public trackEvent = jest.fn();
+    public flush = jest.fn();
+}
+
+describe(AppInsightsTelemetryClient, () => {
+    let mockAppInsights: typeof appInsights;
+    beforeEach(() => {
+        mockAppInsights = {
+            ApplicationInsights: MockApplicationInsights as unknown as typeof appInsights.ApplicationInsights,
+        } as typeof appInsights;
+    });
+
+    describe('constructor', () => {
+        it('initializes an underlying client with the expected parameters', () => {
+            new AppInsightsTelemetryClient(mockAppInsights, 'test connection string');
+
+            expect(MockApplicationInsights.lastConstructedInstance).not.toBeUndefined();
+            expect(MockApplicationInsights.lastConstructedInstance?.snippet).toStrictEqual({
+                config: {
+                    connectionString: 'test connection string',
+    
+                    disableExceptionTracking: true,
+                    disableFetchTracking: true,
+                    disableAjaxTracking: true,
+                    disableCorrelationHeaders: true,
+                    disableCookiesUsage: true,
+                },
+            });
+        });
+    });
+
+    describe('trackEvent', () => {
+        it("delegates to the underlying client's trackEvent", () => {
+            const testSubject = new AppInsightsTelemetryClient(mockAppInsights, 'test connection string');
+
+            const testEvent: TelemetryEvent = { name: 'test event', properties: { 'prop 1': 'value 1' }};
+            testSubject.trackEvent(testEvent);
+
+            expect(MockApplicationInsights.lastConstructedInstance?.trackEvent).toHaveBeenCalledWith(testEvent);
+        });
+    });
+
+    describe('flush', () => {
+        it("delegates to the underlying client's flush (in sync mode)", () => {
+            const testSubject = new AppInsightsTelemetryClient(mockAppInsights, 'test connection string');
+
+            testSubject.flush();
+
+            expect(MockApplicationInsights.lastConstructedInstance?.flush).toHaveBeenCalledWith(/* async: */ false);
+        });
+    });
+});

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.spec.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.spec.ts
@@ -2,81 +2,90 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import type * as appInsights from '@microsoft/applicationinsights-web';
+import type * as appInsights from '@microsoft/applicationinsights-web-basic';
 import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
 import { Logger, TelemetryEvent } from '@accessibility-insights-action/shared';
 import { IMock, Mock } from 'typemoq';
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-class MockApplicationInsightsInitializer {
-    public static lastConstructedInitializer?: MockApplicationInsightsInitializer;
-    public static lastLoadedMock?: IMock<appInsights.IApplicationInsights>;
+class MockApplicationInsights {
+    public static lastConstructedInstance?: MockApplicationInsights;
 
-    constructor(public readonly snippet: appInsights.Snippet) {
-        MockApplicationInsightsInitializer.lastConstructedInitializer = this;
+    constructor(public readonly config: appInsights.IConfiguration) {
+        MockApplicationInsights.lastConstructedInstance = this;
     }
 
-    public loadAppInsights(): appInsights.IApplicationInsights {
-        const mockAppInsights = Mock.ofType<appInsights.IApplicationInsights>();
-        MockApplicationInsightsInitializer.lastLoadedMock = mockAppInsights;
-        return mockAppInsights.object;
-    }
+    public initialize = jest.fn();
+    public track = jest.fn();
+    public flush = jest.fn();
 }
 
 describe(AppInsightsTelemetryClient, () => {
     let mockAppInsights: typeof appInsights;
     let mockLogger: IMock<Logger>;
+    let mockDate: Date;
+    let exampleConnectionString: string;
+    let exampleInstrumentationKey: string;
 
     beforeEach(() => {
+        MockApplicationInsights.lastConstructedInstance = undefined;
+
         mockAppInsights = {
-            ApplicationInsights: MockApplicationInsightsInitializer as unknown as typeof appInsights.ApplicationInsights,
+            ApplicationInsights: MockApplicationInsights as unknown as typeof appInsights.ApplicationInsights,
         } as typeof appInsights;
         mockLogger = Mock.ofType<Logger>();
+        mockDate = new Date('2020-01-02T03:04:05.678Z');
+
+        exampleConnectionString =
+            'InstrumentationKey=1234ABCD-56ef-78ab-90cd-123456abcdef;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/';
+        exampleInstrumentationKey = '1234abcd-56ef-78ab-90cd-123456abcdef';
     });
 
     describe('constructor', () => {
         it('initializes an underlying client with the expected parameters', () => {
-            new AppInsightsTelemetryClient(mockAppInsights, 'test connection string', mockLogger.object);
+            new AppInsightsTelemetryClient(mockAppInsights, exampleConnectionString, mockLogger.object, () => mockDate);
 
-            expect(MockApplicationInsightsInitializer.lastConstructedInitializer).not.toBeUndefined();
-            expect(MockApplicationInsightsInitializer.lastConstructedInitializer?.snippet).toStrictEqual({
-                config: {
-                    connectionString: 'test connection string',
-
-                    disableExceptionTracking: true,
-                    disableFetchTracking: true,
-                    disableAjaxTracking: true,
-                    disableCorrelationHeaders: true,
-                    disableCookiesUsage: true,
-                },
+            expect(MockApplicationInsights.lastConstructedInstance).not.toBeUndefined();
+            expect(MockApplicationInsights.lastConstructedInstance?.config).toStrictEqual({
+                connectionString: exampleConnectionString,
+                instrumentationKey: exampleInstrumentationKey,
             });
+            expect(MockApplicationInsights.lastConstructedInstance!.initialize).toHaveBeenCalledTimes(1);
         });
     });
 
     describe('trackEvent', () => {
-        it("delegates to the underlying client's trackEvent", () => {
-            const testSubject = new AppInsightsTelemetryClient(mockAppInsights, 'test connection string', mockLogger.object);
+        it("delegates to the underlying client's trackEvent with the expected envelope format", () => {
+            const testSubject = new AppInsightsTelemetryClient(mockAppInsights, exampleConnectionString, mockLogger.object, () => mockDate);
 
             const testEvent: TelemetryEvent = { name: 'ScanStart', properties: { 'prop 1': 'value 1' } };
 
-            MockApplicationInsightsInitializer.lastLoadedMock!.setup((m) => m.trackEvent(testEvent)).verifiable();
+            const expectedEnvelope = {
+                name: `Microsoft.ApplicationInsights.${exampleInstrumentationKey}.Event`,
+                timestamp: '2020-01-02T03:04:05.678Z',
+                baseType: 'EventData',
+                baseData: {
+                    name: 'ScanStart',
+                    properties: {
+                        'prop 1': 'value 1',
+                    },
+                },
+            };
 
             testSubject.trackEvent(testEvent);
 
-            MockApplicationInsightsInitializer.lastLoadedMock!.verifyAll();
+            expect(MockApplicationInsights.lastConstructedInstance!.track).toHaveBeenCalledWith(expectedEnvelope);
         });
     });
 
     describe('flush', () => {
-        it("delegates to the underlying client's flush (in sync mode)", () => {
-            const testSubject = new AppInsightsTelemetryClient(mockAppInsights, 'test connection string', mockLogger.object);
-
-            MockApplicationInsightsInitializer.lastLoadedMock!.setup((m) => m.flush(/* async: */ false)).verifiable();
+        it("delegates to the underlying client's flush", () => {
+            const testSubject = new AppInsightsTelemetryClient(mockAppInsights, exampleConnectionString, mockLogger.object, () => mockDate);
 
             testSubject.flush();
 
-            MockApplicationInsightsInitializer.lastLoadedMock!.verifyAll();
+            expect(MockApplicationInsights.lastConstructedInstance!.flush).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.spec.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.spec.ts
@@ -4,7 +4,7 @@ import 'reflect-metadata';
 
 import type * as appInsights from '@microsoft/applicationinsights-web';
 import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
-import { TelemetryEvent } from '@accessibility-insights-action/shared';
+import { Logger, TelemetryEvent } from '@accessibility-insights-action/shared';
 import { IMock, Mock } from 'typemoq';
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
@@ -26,15 +26,18 @@ class MockApplicationInsightsInitializer {
 
 describe(AppInsightsTelemetryClient, () => {
     let mockAppInsights: typeof appInsights;
+    let mockLogger: IMock<Logger>;
+
     beforeEach(() => {
         mockAppInsights = {
             ApplicationInsights: MockApplicationInsightsInitializer as unknown as typeof appInsights.ApplicationInsights,
         } as typeof appInsights;
+        mockLogger = Mock.ofType<Logger>();
     });
 
     describe('constructor', () => {
         it('initializes an underlying client with the expected parameters', () => {
-            new AppInsightsTelemetryClient(mockAppInsights, 'test connection string');
+            new AppInsightsTelemetryClient(mockAppInsights, 'test connection string', mockLogger.object);
 
             expect(MockApplicationInsightsInitializer.lastConstructedInitializer).not.toBeUndefined();
             expect(MockApplicationInsightsInitializer.lastConstructedInitializer?.snippet).toStrictEqual({
@@ -53,7 +56,7 @@ describe(AppInsightsTelemetryClient, () => {
 
     describe('trackEvent', () => {
         it("delegates to the underlying client's trackEvent", () => {
-            const testSubject = new AppInsightsTelemetryClient(mockAppInsights, 'test connection string');
+            const testSubject = new AppInsightsTelemetryClient(mockAppInsights, 'test connection string', mockLogger.object);
 
             const testEvent: TelemetryEvent = { name: 'ScanStart', properties: { 'prop 1': 'value 1' } };
 
@@ -67,7 +70,7 @@ describe(AppInsightsTelemetryClient, () => {
 
     describe('flush', () => {
         it("delegates to the underlying client's flush (in sync mode)", () => {
-            const testSubject = new AppInsightsTelemetryClient(mockAppInsights, 'test connection string');
+            const testSubject = new AppInsightsTelemetryClient(mockAppInsights, 'test connection string', mockLogger.object);
 
             MockApplicationInsightsInitializer.lastLoadedMock!.setup((m) => m.flush(/* async: */ false)).verifiable();
 

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.spec.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.spec.ts
@@ -2,90 +2,148 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import type * as appInsights from '@microsoft/applicationinsights-web-basic';
+import type * as process from 'process';
+import * as appInsights from 'applicationinsights';
 import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
 import { Logger, TelemetryEvent } from '@accessibility-insights-action/shared';
 import { IMock, Mock } from 'typemoq';
+import { AdoExtensionMetadata } from '../ado-extension-metadata';
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-
-class MockApplicationInsights {
-    public static lastConstructedInstance?: MockApplicationInsights;
-
-    constructor(public readonly config: appInsights.IConfiguration) {
-        MockApplicationInsights.lastConstructedInstance = this;
-    }
-
-    public initialize = jest.fn();
-    public track = jest.fn();
-    public flush = jest.fn();
-}
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
 describe(AppInsightsTelemetryClient, () => {
     let mockAppInsights: typeof appInsights;
     let mockLogger: IMock<Logger>;
-    let mockDate: Date;
-    let exampleConnectionString: string;
-    let exampleInstrumentationKey: string;
+    let stubMetadata: AdoExtensionMetadata;
+    let stubProcessEnv: typeof process.env;
+    let stubConnectionString: string;
 
     beforeEach(() => {
-        MockApplicationInsights.lastConstructedInstance = undefined;
+        MockUnderlyingClient.lastConstructedInstance = undefined;
 
         mockAppInsights = {
-            ApplicationInsights: MockApplicationInsights as unknown as typeof appInsights.ApplicationInsights,
+            TelemetryClient: MockUnderlyingClient as unknown as typeof appInsights.TelemetryClient,
         } as typeof appInsights;
         mockLogger = Mock.ofType<Logger>();
-        mockDate = new Date('2020-01-02T03:04:05.678Z');
 
-        exampleConnectionString =
-            'InstrumentationKey=1234ABCD-56ef-78ab-90cd-123456abcdef;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/';
-        exampleInstrumentationKey = '1234abcd-56ef-78ab-90cd-123456abcdef';
+        stubConnectionString = 'stub connection string';
+        stubMetadata = {
+            environment: 'stub environment',
+            extensionId: 'stub extension id',
+            extensionName: 'stub extension name',
+            extensionVersion: 'stub extension version',
+            publisherId: 'stub publisher id',
+            appInsightsConnectionString: stubConnectionString,
+        };
+
+        stubProcessEnv = {};
     });
 
     describe('constructor', () => {
         it('initializes an underlying client with the expected parameters', () => {
-            new AppInsightsTelemetryClient(mockAppInsights, exampleConnectionString, mockLogger.object, () => mockDate);
+            new AppInsightsTelemetryClient(mockAppInsights, stubConnectionString, mockLogger.object, stubMetadata, stubProcessEnv);
 
-            expect(MockApplicationInsights.lastConstructedInstance).not.toBeUndefined();
-            expect(MockApplicationInsights.lastConstructedInstance?.config).toStrictEqual({
-                connectionString: exampleConnectionString,
-                instrumentationKey: exampleInstrumentationKey,
-            });
-            expect(MockApplicationInsights.lastConstructedInstance!.initialize).toHaveBeenCalledTimes(1);
+            expect(MockUnderlyingClient.lastConstructedInstance).not.toBeUndefined();
+            expect(MockUnderlyingClient.lastConstructedInstance?.config).toBe(stubConnectionString);
+        });
+
+        it('scrubs identifiable values App Insights populates by default', () => {
+            new AppInsightsTelemetryClient(mockAppInsights, stubConnectionString, mockLogger.object, stubMetadata, stubProcessEnv);
+            const underlying = MockUnderlyingClient.lastConstructedInstance!;
+            const contextKeys = appInsights.defaultClient.context.keys;
+
+            expect(underlying.context.tags[contextKeys.cloudRole]).toBe('');
+            expect(underlying.context.tags[contextKeys.cloudRoleInstance]).toBe('');
+            expect(underlying.context.tags[contextKeys.locationIp]).toBe('0.0.0.0');
+        });
+
+        it.each`
+            commonPropName | metadataPropName
+            ${'extensionPublisherId'} | ${'publisherId'}
+            ${'extensionId'} | ${'extensionId'}
+            ${'extensionName'} | ${'extensionName'}
+            ${'extensionVersion'} | ${'extensionVersion'}
+            ${'extensionEnvironment'} | ${'environment'}
+        `('reflects metadata property $metadataPropName as common property $commonPropName', ({ commonPropName, metadataPropName }) => {
+            new AppInsightsTelemetryClient(mockAppInsights, stubConnectionString, mockLogger.object, stubMetadata, stubProcessEnv);
+            const underlying = MockUnderlyingClient.lastConstructedInstance!;
+
+            expect(underlying.commonProperties![commonPropName]).toBe(stubMetadata[metadataPropName as keyof AdoExtensionMetadata]);
+        });
+
+        it('omits the app insights connection string from common properties', () => {
+            new AppInsightsTelemetryClient(mockAppInsights, stubConnectionString, mockLogger.object, stubMetadata, stubProcessEnv);
+            const underlying = MockUnderlyingClient.lastConstructedInstance!;
+
+            expect(Object.values(underlying.commonProperties!)).not.toContain(stubConnectionString);
+        });
+
+        it.each`
+            commonPropName | envVar
+            ${'adoTeamProjectId'} | ${'SYSTEM_TEAMPROJECTID'}
+            ${'adoPipelineDefinitionId'} | ${'SYSTEM_DEFINITIONID'}
+            ${'adoPullRequestId'} | ${'SYSTEM_PULLREQUEST_PULLREQUESTID'}
+            ${'adoJobId'} | ${'SYSTEM_JOBID'}
+        `('reflects environment variable $envVar as common property $commonPropName', ({ commonPropName, envVar }) => {
+            stubProcessEnv[envVar] = 'ENV VAR VALUE';
+
+            new AppInsightsTelemetryClient(mockAppInsights, stubConnectionString, mockLogger.object, stubMetadata, stubProcessEnv);
+            const underlying = MockUnderlyingClient.lastConstructedInstance!;
+
+            expect(underlying.commonProperties![commonPropName]).toBe('ENV VAR VALUE');
+        });
+
+        it('reflects environment variables of interest as empty strings if they are not set', () => {
+            new AppInsightsTelemetryClient(mockAppInsights, stubConnectionString, mockLogger.object, stubMetadata, stubProcessEnv);
+            const underlying = MockUnderlyingClient.lastConstructedInstance!;
+
+            expect(underlying.commonProperties!['adoTeamProjectId']).toBe('');
+        });
+
+        it("omits environment variables we don't specifically mean to track", () => {
+            stubProcessEnv['NOT_TRACKED'] = 'ENV VAR VALUE';
+
+            new AppInsightsTelemetryClient(mockAppInsights, stubConnectionString, mockLogger.object, stubMetadata, stubProcessEnv);
+            const underlying = MockUnderlyingClient.lastConstructedInstance!;
+
+            expect(underlying.commonProperties).not.toHaveProperty('NOT_TRACKED');
         });
     });
 
     describe('trackEvent', () => {
         it("delegates to the underlying client's trackEvent with the expected envelope format", () => {
-            const testSubject = new AppInsightsTelemetryClient(mockAppInsights, exampleConnectionString, mockLogger.object, () => mockDate);
-
+            const testSubject = new AppInsightsTelemetryClient(mockAppInsights, stubConnectionString, mockLogger.object, stubMetadata, stubProcessEnv);
             const testEvent: TelemetryEvent = { name: 'ScanStart', properties: { 'prop 1': 'value 1' } };
-
-            const expectedEnvelope = {
-                name: `Microsoft.ApplicationInsights.${exampleInstrumentationKey}.Event`,
-                timestamp: '2020-01-02T03:04:05.678Z',
-                baseType: 'EventData',
-                baseData: {
-                    name: 'ScanStart',
-                    properties: {
-                        'prop 1': 'value 1',
-                    },
-                },
-            };
 
             testSubject.trackEvent(testEvent);
 
-            expect(MockApplicationInsights.lastConstructedInstance!.track).toHaveBeenCalledWith(expectedEnvelope);
+            expect(MockUnderlyingClient.lastConstructedInstance!.trackEvent).toHaveBeenCalledWith(testEvent);
         });
     });
 
     describe('flush', () => {
         it("delegates to the underlying client's flush", () => {
-            const testSubject = new AppInsightsTelemetryClient(mockAppInsights, exampleConnectionString, mockLogger.object, () => mockDate);
+            const testSubject = new AppInsightsTelemetryClient(mockAppInsights, stubConnectionString, mockLogger.object, stubMetadata, stubProcessEnv);
 
             testSubject.flush();
 
-            expect(MockApplicationInsights.lastConstructedInstance!.flush).toHaveBeenCalledTimes(1);
+            expect(MockUnderlyingClient.lastConstructedInstance!.flush).toHaveBeenCalledTimes(1);
         });
     });
 });
+
+class MockUnderlyingClient {
+    public static lastConstructedInstance?: MockUnderlyingClient;
+
+    public commonProperties?: { [key: string]: string };
+    public context: { tags: { [key: string]: string } };
+
+    constructor(public readonly config: string) {
+        MockUnderlyingClient.lastConstructedInstance = this;
+        this.context = appInsights.defaultClient.context;
+    }
+
+    public trackEvent = jest.fn();
+    public flush = jest.fn();
+}

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
@@ -1,81 +1,62 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import type * as appInsights from '@microsoft/applicationinsights-web-basic';
+import type * as appInsights from 'applicationinsights';
 import { TelemetryClient, TelemetryEvent } from '@accessibility-insights-action/shared';
 import { Logger } from '@accessibility-insights-action/shared';
+import { AdoExtensionMetadata } from '../ado-extension-metadata';
 
-// This is based on the "Light SKU" of the Application Insights SDK, which has
-// significantly different usage from the normal SKU that's documented at
-// https://github.com/microsoft/ApplicationInsights-JS. We do this primarily
-// because we don't want any of the automatic reporting included with the full
-// SDK and secondarily because it's 1/4 the size.
+// App Insights telemetry must *only* be sent for Microsoft-internal releases of
+// the extension, for internal accessibility compliance tracking purposes.
 //
-// Reference sample for light SDK usage:
-// https://github.com/Azure-Samples/applicationinsights-web-sample1/blob/master/testlightsku.html
+// Public/external releases should use a NullTelemetryClient instead.
 export class AppInsightsTelemetryClient implements TelemetryClient {
-    private underlyingClient: appInsights.ApplicationInsights;
-    private instrumentationKey: string;
+    private underlyingClient: appInsights.TelemetryClient;
 
     public constructor(
         appInsightsObj: typeof appInsights,
         connectionString: string,
         private readonly logger: Logger,
-        private readonly timestampProvider: () => Date,
+        extensionMetadata: AdoExtensionMetadata,
+        processEnv: typeof process.env,
     ) {
-        this.instrumentationKey = extractInstrumentationKeyFromConnectionString(connectionString);
-        this.underlyingClient = new appInsightsObj.ApplicationInsights({
-            // connectionString,
+        // It's very important that we invoke new TelemetryClient and *not* setup()
+        // The latter initializes a bunch of auto-collectors that we don't want to run
+        this.underlyingClient = new appInsightsObj.TelemetryClient(connectionString);
 
-            // The docs for the basic SDK suggest that connectionString should be sufficient
-            // on its own, since it contains the instrumentation key, but this is not the
-            // case in actual use.
-            instrumentationKey: this.instrumentationKey,
-        });
-        //this.underlyingClient.initialize();
+        // This disables collection of the local machine's hostname
+        this.underlyingClient.context.tags[this.underlyingClient.context.keys.cloudRole] = '';
+        this.underlyingClient.context.tags[this.underlyingClient.context.keys.cloudRoleInstance] = '';
+
+        // This disables client location telemetry that is otherwise automatically gathered
+        // via geolocation against the sending IP
+        this.underlyingClient.context.tags[this.underlyingClient.context.keys.locationIp] = '0.0.0.0';
+
+        this.underlyingClient.commonProperties = {
+            extensionPublisherId: extensionMetadata.publisherId,
+            extensionId: extensionMetadata.extensionId,
+            extensionName: extensionMetadata.extensionName,
+            extensionVersion: extensionMetadata.extensionVersion,
+            extensionEnvironment: extensionMetadata.environment,
+
+            adoTeamProjectId: processEnv['SYSTEM_TEAMPROJECTID'] ?? '',
+            adoPipelineDefinitionId: processEnv['SYSTEM_DEFINITIONID'] ?? '',
+            adoPullRequestId: processEnv['SYSTEM_PULLREQUEST_PULLREQUESTID'] ?? '',
+            adoJobId: processEnv['SYSTEM_JOBID'] ?? '',
+        };
     }
 
     public trackEvent(event: TelemetryEvent): void {
         this.logger.logDebug(`AppInsightsTelemetryClient.trackEvent: ${JSON.stringify(event)}`);
-
-        // const utcTimestamp = this.timestampProvider().toISOString(); // Should use format '2018-07-19T02:17:12.993Z'
-
-        // This format is derived from https://github.com/Azure-Samples/applicationinsights-web-sample1/blob/8160801c59bc2e191ffc7e9fe35201fc5c926c7b/testlightsku.html#L41
-        const eventItem = {
-            name: `Microsoft.ApplicationInsights.${this.instrumentationKey}.Event`,
-            // timestamp: utcTimestamp,
-            baseType: 'EventData',
-            baseData: {
-                name: event.name,
-                properties: {
-                    ...event.properties,
-                },
-            },
-        };
-
-        this.logger.logDebug(`ApplicaitonInsights.track: ${JSON.stringify(eventItem)}`);
-
-        this.underlyingClient.track(eventItem);
+        this.underlyingClient.trackEvent(event)
     }
 
-    public flush(): void {
+    public async flush(): Promise<void> {
         this.logger.logDebug(`AppInsightsTelemetryClient.flush`);
-        this.underlyingClient.flush();
+        await new Promise<void>(resolve => {
+            this.underlyingClient.flush({
+                callback: () => resolve()
+            });
+        });
     }
-}
-
-function extractInstrumentationKeyFromConnectionString(connectionString: string): string {
-    // Example connection string: InstrumentationKey=1234abcd-56ef-78ab-90cd-123456abcdef;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/
-    const instrumentationKeyFromConnectionStringRegex =
-        /InstrumentationKey=([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})/;
-    const regexMatch = instrumentationKeyFromConnectionStringRegex.exec(connectionString);
-    if (regexMatch == null) {
-        throw new Error('Could not extract instrumentation key from connection string');
-    }
-
-    // The example formats suggested by
-    // https://github.com/Azure-Samples/applicationinsights-web-sample1/blob/master/testlightsku.html#L41
-    // suggest that we should be using toUpperCase, but the library actually enforces
-    // that we give the instrumentationKey in lowerCase.
-    return regexMatch[1].toLowerCase();
 }

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
@@ -5,10 +5,10 @@ import type * as appInsights from '@microsoft/applicationinsights-web';
 import { TelemetryClient, TelemetryEvent } from '@accessibility-insights-action/shared';
 
 export class AppInsightsTelemetryClient implements TelemetryClient {
-    private underlyingClient: appInsights.ApplicationInsights;
+    private underlyingClient: appInsights.IApplicationInsights;
 
     public constructor(appInsightsObj: typeof appInsights, connectionString: string) {
-        this.underlyingClient = new appInsightsObj.ApplicationInsights({
+        const appInsightsInitializer = new appInsightsObj.ApplicationInsights({
             config: {
                 connectionString,
 
@@ -19,6 +19,8 @@ export class AppInsightsTelemetryClient implements TelemetryClient {
                 disableCookiesUsage: true,
             },
         });
+
+        this.underlyingClient = appInsightsInitializer.loadAppInsights();
     }
 
     public trackEvent(event: TelemetryEvent): void {

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import type * as appInsights from '@microsoft/applicationinsights-web';
+import { TelemetryClient, TelemetryEvent } from '@accessibility-insights-action/shared';
+
+export class AppInsightsTelemetryClient implements TelemetryClient {
+    private underlyingClient: appInsights.ApplicationInsights;
+
+    public constructor(appInsightsObj: typeof appInsights, connectionString: string) {
+        this.underlyingClient = new appInsightsObj.ApplicationInsights({
+            config: {
+                connectionString,
+
+                disableExceptionTracking: true,
+                disableFetchTracking: true,
+                disableAjaxTracking: true,
+                disableCorrelationHeaders: true,
+                disableCookiesUsage: true,
+            },
+        });
+
+        /* TODO:
+        this.underlyingClient.commonProperties = {
+            BUILD_ID: this.processObj.env['BUILD_ID'],
+        };
+        */
+    }
+
+    public trackEvent(event: TelemetryEvent): void {
+        this.underlyingClient.trackEvent(event);
+    }
+
+    public flush(): void {
+        this.underlyingClient.flush(/* async: */ false);
+    }
+}

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
@@ -19,12 +19,6 @@ export class AppInsightsTelemetryClient implements TelemetryClient {
                 disableCookiesUsage: true,
             },
         });
-
-        /* TODO:
-        this.underlyingClient.commonProperties = {
-            BUILD_ID: this.processObj.env['BUILD_ID'],
-        };
-        */
     }
 
     public trackEvent(event: TelemetryEvent): void {

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
@@ -48,14 +48,14 @@ export class AppInsightsTelemetryClient implements TelemetryClient {
 
     public trackEvent(event: TelemetryEvent): void {
         this.logger.logDebug(`[Telemetry] tracking a '${event.name}' event`);
-        this.underlyingClient.trackEvent(event)
+        this.underlyingClient.trackEvent(event);
     }
 
     public async flush(): Promise<void> {
         this.logger.logDebug(`[Telemetry] flushing telemetry`);
-        await new Promise<void>(resolve => {
+        await new Promise<void>((resolve) => {
             this.underlyingClient.flush({
-                callback: () => resolve()
+                callback: () => resolve(),
             });
         });
     }

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
@@ -3,11 +3,12 @@
 
 import type * as appInsights from '@microsoft/applicationinsights-web';
 import { TelemetryClient, TelemetryEvent } from '@accessibility-insights-action/shared';
+import { Logger } from '@accessibility-insights-action/shared';
 
 export class AppInsightsTelemetryClient implements TelemetryClient {
     private underlyingClient: appInsights.IApplicationInsights;
 
-    public constructor(appInsightsObj: typeof appInsights, connectionString: string) {
+    public constructor(appInsightsObj: typeof appInsights, connectionString: string, private readonly logger: Logger) {
         const appInsightsInitializer = new appInsightsObj.ApplicationInsights({
             config: {
                 connectionString,
@@ -24,10 +25,12 @@ export class AppInsightsTelemetryClient implements TelemetryClient {
     }
 
     public trackEvent(event: TelemetryEvent): void {
+        this.logger.logDebug(`AppInsightsTelemetryClient.trackEvent: ${JSON.stringify(event)}`);
         this.underlyingClient.trackEvent(event);
     }
 
     public flush(): void {
+        this.logger.logDebug(`AppInsightsTelemetryClient.flush`);
         this.underlyingClient.flush(/* async: */ false);
     }
 }

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
@@ -47,12 +47,12 @@ export class AppInsightsTelemetryClient implements TelemetryClient {
     }
 
     public trackEvent(event: TelemetryEvent): void {
-        this.logger.logDebug(`AppInsightsTelemetryClient.trackEvent: ${JSON.stringify(event)}`);
+        this.logger.logDebug(`[Telemetry] tracking a '${event.name}' event`);
         this.underlyingClient.trackEvent(event)
     }
 
     public async flush(): Promise<void> {
-        this.logger.logDebug(`AppInsightsTelemetryClient.flush`);
+        this.logger.logDebug(`[Telemetry] flushing telemetry`);
         await new Promise<void>(resolve => {
             this.underlyingClient.flush({
                 callback: () => resolve()

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
@@ -1,36 +1,81 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import type * as appInsights from '@microsoft/applicationinsights-web';
+import type * as appInsights from '@microsoft/applicationinsights-web-basic';
 import { TelemetryClient, TelemetryEvent } from '@accessibility-insights-action/shared';
 import { Logger } from '@accessibility-insights-action/shared';
 
+// This is based on the "Light SKU" of the Application Insights SDK, which has
+// significantly different usage from the normal SKU that's documented at
+// https://github.com/microsoft/ApplicationInsights-JS. We do this primarily
+// because we don't want any of the automatic reporting included with the full
+// SDK and secondarily because it's 1/4 the size.
+//
+// Reference sample for light SDK usage:
+// https://github.com/Azure-Samples/applicationinsights-web-sample1/blob/master/testlightsku.html
 export class AppInsightsTelemetryClient implements TelemetryClient {
-    private underlyingClient: appInsights.IApplicationInsights;
+    private underlyingClient: appInsights.ApplicationInsights;
+    private instrumentationKey: string;
 
-    public constructor(appInsightsObj: typeof appInsights, connectionString: string, private readonly logger: Logger) {
-        const appInsightsInitializer = new appInsightsObj.ApplicationInsights({
-            config: {
-                connectionString,
+    public constructor(
+        appInsightsObj: typeof appInsights,
+        connectionString: string,
+        private readonly logger: Logger,
+        private readonly timestampProvider: () => Date,
+    ) {
+        this.instrumentationKey = extractInstrumentationKeyFromConnectionString(connectionString);
+        this.underlyingClient = new appInsightsObj.ApplicationInsights({
+            // connectionString,
 
-                disableExceptionTracking: true,
-                disableFetchTracking: true,
-                disableAjaxTracking: true,
-                disableCorrelationHeaders: true,
-                disableCookiesUsage: true,
-            },
+            // The docs for the basic SDK suggest that connectionString should be sufficient
+            // on its own, since it contains the instrumentation key, but this is not the
+            // case in actual use.
+            instrumentationKey: this.instrumentationKey,
         });
-
-        this.underlyingClient = appInsightsInitializer.loadAppInsights();
+        //this.underlyingClient.initialize();
     }
 
     public trackEvent(event: TelemetryEvent): void {
         this.logger.logDebug(`AppInsightsTelemetryClient.trackEvent: ${JSON.stringify(event)}`);
-        this.underlyingClient.trackEvent(event);
+
+        // const utcTimestamp = this.timestampProvider().toISOString(); // Should use format '2018-07-19T02:17:12.993Z'
+
+        // This format is derived from https://github.com/Azure-Samples/applicationinsights-web-sample1/blob/8160801c59bc2e191ffc7e9fe35201fc5c926c7b/testlightsku.html#L41
+        const eventItem = {
+            name: `Microsoft.ApplicationInsights.${this.instrumentationKey}.Event`,
+            // timestamp: utcTimestamp,
+            baseType: 'EventData',
+            baseData: {
+                name: event.name,
+                properties: {
+                    ...event.properties,
+                },
+            },
+        };
+
+        this.logger.logDebug(`ApplicaitonInsights.track: ${JSON.stringify(eventItem)}`);
+
+        this.underlyingClient.track(eventItem);
     }
 
     public flush(): void {
         this.logger.logDebug(`AppInsightsTelemetryClient.flush`);
-        this.underlyingClient.flush(/* async: */ false);
+        this.underlyingClient.flush();
     }
+}
+
+function extractInstrumentationKeyFromConnectionString(connectionString: string): string {
+    // Example connection string: InstrumentationKey=1234abcd-56ef-78ab-90cd-123456abcdef;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/
+    const instrumentationKeyFromConnectionStringRegex =
+        /InstrumentationKey=([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})/;
+    const regexMatch = instrumentationKeyFromConnectionStringRegex.exec(connectionString);
+    if (regexMatch == null) {
+        throw new Error('Could not extract instrumentation key from connection string');
+    }
+
+    // The example formats suggested by
+    // https://github.com/Azure-Samples/applicationinsights-web-sample1/blob/master/testlightsku.html#L41
+    // suggest that we should be using toUpperCase, but the library actually enforces
+    // that we give the instrumentationKey in lowerCase.
+    return regexMatch[1].toLowerCase();
 }

--- a/packages/ado-extension/src/telemetry/telemetry-client-factory.spec.ts
+++ b/packages/ado-extension/src/telemetry/telemetry-client-factory.spec.ts
@@ -2,18 +2,13 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import * as appInsights from '@microsoft/applicationinsights-web-basic';
+import type * as appInsights from 'applicationinsights';
+import type * as process from 'process';
 import { Logger, NullTelemetryClient } from '@accessibility-insights-action/shared';
 import { AdoExtensionMetadata, AdoExtensionMetadataProvider } from '../ado-extension-metadata';
 import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
 import { TelemetryClientFactory } from './telemetry-client-factory';
 import { IMock, Mock } from 'typemoq';
-
-class StubApplicationInsights {
-    public initialize(): void {
-        /* no-op */
-    }
-}
 
 describe(TelemetryClientFactory, () => {
     let testSubject: TelemetryClientFactory;
@@ -21,17 +16,20 @@ describe(TelemetryClientFactory, () => {
     let mockMetadataProvider: AdoExtensionMetadataProvider;
     let mockAppInsights: typeof appInsights;
     let mockLogger: IMock<Logger>;
+    let mockProcess: IMock<typeof process>;
 
     beforeEach(() => {
         mockAppInsights = {
-            ApplicationInsights: StubApplicationInsights,
+            TelemetryClient: StubTelemetryClient,
         } as unknown as typeof appInsights;
         mockMetadata = {} as AdoExtensionMetadata;
         mockMetadataProvider = {
             readMetadata: () => mockMetadata,
         } as AdoExtensionMetadataProvider;
         mockLogger = Mock.ofType<Logger>();
-        testSubject = new TelemetryClientFactory(mockAppInsights, mockMetadataProvider, mockLogger.object);
+        mockProcess = Mock.ofType<typeof process>();
+
+        testSubject = new TelemetryClientFactory(mockAppInsights, mockMetadataProvider, mockLogger.object, mockProcess.object);
     });
 
     it('returns a NullTelemetryClient if metadata contains no connection string', () => {
@@ -51,3 +49,5 @@ describe(TelemetryClientFactory, () => {
         expect(telemetryClient).toBeInstanceOf(AppInsightsTelemetryClient);
     });
 });
+
+class StubTelemetryClient { }

--- a/packages/ado-extension/src/telemetry/telemetry-client-factory.spec.ts
+++ b/packages/ado-extension/src/telemetry/telemetry-client-factory.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import * as appInsights from '@microsoft/applicationinsights-web';
+import * as appInsights from '@microsoft/applicationinsights-web-basic';
 import { Logger, NullTelemetryClient } from '@accessibility-insights-action/shared';
 import { AdoExtensionMetadata, AdoExtensionMetadataProvider } from '../ado-extension-metadata';
 import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
@@ -10,8 +10,8 @@ import { TelemetryClientFactory } from './telemetry-client-factory';
 import { IMock, Mock } from 'typemoq';
 
 class StubApplicationInsights {
-    loadAppInsights(): appInsights.IApplicationInsights {
-        return {} as appInsights.IApplicationInsights;
+    public initialize(): void {
+        /* no-op */
     }
 }
 
@@ -43,7 +43,8 @@ describe(TelemetryClientFactory, () => {
     });
 
     it('returns an AppInsightsTelemetryClient if metadata contains a connection string', () => {
-        mockMetadata.appInsightsConnectionString = 'test connection string';
+        mockMetadata.appInsightsConnectionString =
+            'InstrumentationKey=1234abcd-56ef-78ab-90cd-123456abcdef;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/';
 
         const telemetryClient = testSubject.createTelemetryClient();
 

--- a/packages/ado-extension/src/telemetry/telemetry-client-factory.spec.ts
+++ b/packages/ado-extension/src/telemetry/telemetry-client-factory.spec.ts
@@ -50,4 +50,4 @@ describe(TelemetryClientFactory, () => {
     });
 });
 
-class StubTelemetryClient { }
+class StubTelemetryClient {}

--- a/packages/ado-extension/src/telemetry/telemetry-client-factory.spec.ts
+++ b/packages/ado-extension/src/telemetry/telemetry-client-factory.spec.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as appInsights from '@microsoft/applicationinsights-web';
+import { NullTelemetryClient } from '@accessibility-insights-action/shared';
+import { AdoExtensionMetadata, AdoExtensionMetadataProvider } from '../ado-extension-metadata';
+import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
+import { TelemetryClientFactory } from './telemetry-client-factory';
+
+class StubApplicationInsights {}
+
+describe(TelemetryClientFactory, () => {
+    let testSubject: TelemetryClientFactory;
+    let mockMetadata: AdoExtensionMetadata;
+    let mockMetadataProvider: AdoExtensionMetadataProvider;
+    let mockAppInsights: typeof appInsights;
+
+    beforeEach(() => {
+        mockAppInsights = {
+            ApplicationInsights: StubApplicationInsights,
+        } as unknown as typeof appInsights;
+        mockMetadata = {} as AdoExtensionMetadata;
+        mockMetadataProvider = {
+            readMetadata: () => mockMetadata,
+        } as AdoExtensionMetadataProvider;
+        testSubject = new TelemetryClientFactory(mockAppInsights, mockMetadataProvider);
+    });
+
+    it('returns a NullTelemetryClient if metadata contains no connection string', () => {
+        mockMetadata.appInsightsConnectionString = null;
+
+        const telemetryClient = testSubject.createTelemetryClient();
+
+        expect(telemetryClient).toBeInstanceOf(NullTelemetryClient);
+    });
+
+    it('returns an AppInsightsTelemetryClient if metadata contains a connection string', () => {
+        mockMetadata.appInsightsConnectionString = 'test connection string';
+
+        const telemetryClient = testSubject.createTelemetryClient();
+
+        expect(telemetryClient).toBeInstanceOf(AppInsightsTelemetryClient);
+    });
+});

--- a/packages/ado-extension/src/telemetry/telemetry-client-factory.spec.ts
+++ b/packages/ado-extension/src/telemetry/telemetry-client-factory.spec.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import 'reflect-metadata';
 
 import * as appInsights from '@microsoft/applicationinsights-web';
 import { NullTelemetryClient } from '@accessibility-insights-action/shared';

--- a/packages/ado-extension/src/telemetry/telemetry-client-factory.spec.ts
+++ b/packages/ado-extension/src/telemetry/telemetry-client-factory.spec.ts
@@ -8,7 +8,11 @@ import { AdoExtensionMetadata, AdoExtensionMetadataProvider } from '../ado-exten
 import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
 import { TelemetryClientFactory } from './telemetry-client-factory';
 
-class StubApplicationInsights {}
+class StubApplicationInsights {
+    loadAppInsights(): appInsights.IApplicationInsights {
+        return {} as appInsights.IApplicationInsights;
+    }
+}
 
 describe(TelemetryClientFactory, () => {
     let testSubject: TelemetryClientFactory;

--- a/packages/ado-extension/src/telemetry/telemetry-client-factory.spec.ts
+++ b/packages/ado-extension/src/telemetry/telemetry-client-factory.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import type * as appInsights from 'applicationinsights';
+import * as appInsights from 'applicationinsights';
 import type * as process from 'process';
 import { Logger, NullTelemetryClient } from '@accessibility-insights-action/shared';
 import { AdoExtensionMetadata, AdoExtensionMetadataProvider } from '../ado-extension-metadata';
@@ -50,4 +50,12 @@ describe(TelemetryClientFactory, () => {
     });
 });
 
-class StubTelemetryClient {}
+class StubTelemetryClient {
+    public context: unknown;
+    constructor() {
+        this.context = {
+            keys: new appInsights.Contracts.ContextTagKeys(),
+            tags: {},
+        };
+    }
+}

--- a/packages/ado-extension/src/telemetry/telemetry-client-factory.spec.ts
+++ b/packages/ado-extension/src/telemetry/telemetry-client-factory.spec.ts
@@ -3,10 +3,11 @@
 import 'reflect-metadata';
 
 import * as appInsights from '@microsoft/applicationinsights-web';
-import { NullTelemetryClient } from '@accessibility-insights-action/shared';
+import { Logger, NullTelemetryClient } from '@accessibility-insights-action/shared';
 import { AdoExtensionMetadata, AdoExtensionMetadataProvider } from '../ado-extension-metadata';
 import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
 import { TelemetryClientFactory } from './telemetry-client-factory';
+import { IMock, Mock } from 'typemoq';
 
 class StubApplicationInsights {
     loadAppInsights(): appInsights.IApplicationInsights {
@@ -19,6 +20,7 @@ describe(TelemetryClientFactory, () => {
     let mockMetadata: AdoExtensionMetadata;
     let mockMetadataProvider: AdoExtensionMetadataProvider;
     let mockAppInsights: typeof appInsights;
+    let mockLogger: IMock<Logger>;
 
     beforeEach(() => {
         mockAppInsights = {
@@ -28,7 +30,8 @@ describe(TelemetryClientFactory, () => {
         mockMetadataProvider = {
             readMetadata: () => mockMetadata,
         } as AdoExtensionMetadataProvider;
-        testSubject = new TelemetryClientFactory(mockAppInsights, mockMetadataProvider);
+        mockLogger = Mock.ofType<Logger>();
+        testSubject = new TelemetryClientFactory(mockAppInsights, mockMetadataProvider, mockLogger.object);
     });
 
     it('returns a NullTelemetryClient if metadata contains no connection string', () => {

--- a/packages/ado-extension/src/telemetry/telemetry-client-factory.ts
+++ b/packages/ado-extension/src/telemetry/telemetry-client-factory.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import type * as appInsights from '@microsoft/applicationinsights-web';
+import type * as appInsights from '@microsoft/applicationinsights-web-basic';
 import { Logger, NullTelemetryClient, TelemetryClient } from '@accessibility-insights-action/shared';
 import { AdoExtensionMetadataProvider } from '../ado-extension-metadata';
 import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
@@ -23,7 +23,7 @@ export class TelemetryClientFactory {
         if (maybeConnectionString == null) {
             return new NullTelemetryClient();
         } else {
-            return new AppInsightsTelemetryClient(this.appInsightsObj, maybeConnectionString, this.logger);
+            return new AppInsightsTelemetryClient(this.appInsightsObj, maybeConnectionString, this.logger, () => new Date());
         }
     }
 }

--- a/packages/ado-extension/src/telemetry/telemetry-client-factory.ts
+++ b/packages/ado-extension/src/telemetry/telemetry-client-factory.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import type * as appInsights from '@microsoft/applicationinsights-web';
-import { NullTelemetryClient, TelemetryClient } from '@accessibility-insights-action/shared';
+import { Logger, NullTelemetryClient, TelemetryClient } from '@accessibility-insights-action/shared';
 import { AdoExtensionMetadataProvider } from '../ado-extension-metadata';
 import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
 import { inject, injectable } from 'inversify';
@@ -13,6 +13,7 @@ export class TelemetryClientFactory {
     constructor(
         @inject(AdoIocTypes.AppInsights) private readonly appInsightsObj: typeof appInsights,
         @inject(AdoExtensionMetadataProvider) private readonly metadataProvider: AdoExtensionMetadataProvider,
+        @inject(Logger) private readonly logger: Logger,
     ) {}
 
     public createTelemetryClient(): TelemetryClient {
@@ -22,7 +23,7 @@ export class TelemetryClientFactory {
         if (maybeConnectionString == null) {
             return new NullTelemetryClient();
         } else {
-            return new AppInsightsTelemetryClient(this.appInsightsObj, maybeConnectionString);
+            return new AppInsightsTelemetryClient(this.appInsightsObj, maybeConnectionString, this.logger);
         }
     }
 }

--- a/packages/ado-extension/src/telemetry/telemetry-client-factory.ts
+++ b/packages/ado-extension/src/telemetry/telemetry-client-factory.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import type * as appInsights from '@microsoft/applicationinsights-web-basic';
-import { Logger, NullTelemetryClient, TelemetryClient } from '@accessibility-insights-action/shared';
+import type * as appInsights from 'applicationinsights';
+import type * as process from 'process';
+import { iocTypes, Logger, NullTelemetryClient, TelemetryClient } from '@accessibility-insights-action/shared';
 import { AdoExtensionMetadataProvider } from '../ado-extension-metadata';
 import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
 import { inject, injectable } from 'inversify';
@@ -14,6 +15,7 @@ export class TelemetryClientFactory {
         @inject(AdoIocTypes.AppInsights) private readonly appInsightsObj: typeof appInsights,
         @inject(AdoExtensionMetadataProvider) private readonly metadataProvider: AdoExtensionMetadataProvider,
         @inject(Logger) private readonly logger: Logger,
+        @inject(iocTypes.Process) private readonly processObj: typeof process,
     ) {}
 
     public createTelemetryClient(): TelemetryClient {
@@ -23,7 +25,7 @@ export class TelemetryClientFactory {
         if (maybeConnectionString == null) {
             return new NullTelemetryClient();
         } else {
-            return new AppInsightsTelemetryClient(this.appInsightsObj, maybeConnectionString, this.logger, () => new Date());
+            return new AppInsightsTelemetryClient(this.appInsightsObj, maybeConnectionString, this.logger, metadata, this.processObj.env);
         }
     }
 }

--- a/packages/ado-extension/src/telemetry/telemetry-client-factory.ts
+++ b/packages/ado-extension/src/telemetry/telemetry-client-factory.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import type * as appInsights from '@microsoft/applicationinsights-web';
+import { NullTelemetryClient, TelemetryClient } from '@accessibility-insights-action/shared';
+import { AdoExtensionMetadataProvider } from '../ado-extension-metadata';
+import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
+import { inject, injectable } from 'inversify';
+import { AdoIocTypes } from '../ioc/ado-ioc-types';
+
+@injectable()
+export class TelemetryClientFactory {
+    constructor(
+        @inject(AdoIocTypes.AppInsights) private readonly appInsightsObj: typeof appInsights,
+        @inject(AdoExtensionMetadataProvider) private readonly metadataProvider: AdoExtensionMetadataProvider,
+    ) {}
+
+    public createTelemetryClient(): TelemetryClient {
+        const metadata = this.metadataProvider.readMetadata();
+        const maybeConnectionString = metadata.appInsightsConnectionString;
+
+        if (maybeConnectionString == null) {
+            return new NullTelemetryClient();
+        } else {
+            return new AppInsightsTelemetryClient(this.appInsightsObj, maybeConnectionString);
+        }
+    }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,3 +18,6 @@ export { hookStdout } from './output-hooks/hook-stdout';
 export { hookStderr } from './output-hooks/hook-stderr';
 export { StreamTransformer } from './output-hooks/stream-transformer';
 export { ExitCode } from './exit-code';
+export { TelemetryClient } from './telemetry/telemetry-client';
+export { TelemetryEvent } from './telemetry/telemetry-event';
+export { NullTelemetryClient } from './telemetry/null-telemetry-client';

--- a/packages/shared/src/ioc/ioc-types.ts
+++ b/packages/shared/src/ioc/ioc-types.ts
@@ -11,4 +11,5 @@ export const iocTypes = {
     TaskConfig: 'TaskConfig',
     ProgressReporters: 'ProgressReporters',
     ArtifactsInfoProvider: 'ArtifactsInfoProvider',
+    TelemetryClient: 'TelemetryClient',
 };

--- a/packages/shared/src/ioc/setup-ioc-container.spec.ts
+++ b/packages/shared/src/ioc/setup-ioc-container.spec.ts
@@ -12,6 +12,7 @@ import { iocTypes } from './ioc-types';
 import { setupSharedIocContainer, setupIocContainer } from './setup-ioc-container';
 import { TaskConfig } from '../task-config';
 import { ProgressReporter } from '../progress-reporter/progress-reporter';
+import { NullTelemetryClient } from '../telemetry/null-telemetry-client';
 
 describe(setupSharedIocContainer, () => {
     let testSubject: Container;
@@ -23,6 +24,7 @@ describe(setupSharedIocContainer, () => {
     test.each([Scanner, Logger])('verify singleton resolution %p', (key: any) => {
         verifySingletonDependencyResolution(testSubject, key);
     });
+
     test.each([
         { key: iocTypes.Console, value: console },
         { key: iocTypes.Process, value: process },
@@ -34,6 +36,10 @@ describe(setupSharedIocContainer, () => {
         { key: iocTypes.ProgressReporters, value: [ProgressReporter] },
     ])('verify constant value resolution %s', (pair: { key: string; value: any }) => {
         expect(testSubject.get(pair.key)).toEqual(pair.value);
+    });
+
+    test('TelemetryClient should resolve as a NullTelemetryClient', () => {
+        expect(testSubject.get(iocTypes.TelemetryClient)).toBeInstanceOf(NullTelemetryClient);
     });
 
     function verifySingletonDependencyResolution(container: Container, key: any): void {

--- a/packages/shared/src/ioc/setup-ioc-container.ts
+++ b/packages/shared/src/ioc/setup-ioc-container.ts
@@ -14,6 +14,7 @@ import { iocTypes } from './ioc-types';
 import { setupCliContainer } from 'accessibility-insights-scan';
 import { ProgressReporter } from '../progress-reporter/progress-reporter';
 import { ArtifactsInfoProvider } from '../artifacts-info-provider';
+import { NullTelemetryClient } from '../telemetry/null-telemetry-client';
 
 export function setupIocContainer(container = new inversify.Container({ autoBindInjectable: true })): inversify.Container {
     setupSharedIocContainer(container);
@@ -35,6 +36,7 @@ export function setupSharedIocContainer(container = new inversify.Container({ au
     container.bind(iocTypes.Express).toConstantValue(express);
     container.bind(iocTypes.ServeStatic).toConstantValue(serveStatic);
     container.bind(iocTypes.ReportFactory).toConstantValue(reporterFactory);
+    container.bind(iocTypes.TelemetryClient).to(NullTelemetryClient);
 
     container
         .bind(Logger)

--- a/packages/shared/src/scanner/scanner.spec.ts
+++ b/packages/shared/src/scanner/scanner.spec.ts
@@ -163,7 +163,7 @@ describe(Scanner, () => {
             verifyMocks();
         });
 
-        it('emits a StartScan telemetry event and flush telemetry when complete', async () => {
+        it('emits the expected pattern of telemetry', async () => {
             setupMocksForSuccessfulScan();
             setupWaitForPromiseToReturnOriginalPromise();
 

--- a/packages/shared/src/scanner/scanner.spec.ts
+++ b/packages/shared/src/scanner/scanner.spec.ts
@@ -167,8 +167,8 @@ describe(Scanner, () => {
             setupMocksForSuccessfulScan();
             setupWaitForPromiseToReturnOriginalPromise();
 
-            telemetryClientMock.setup(m => m.trackEvent({ name: 'ScanStart' }));
-            telemetryClientMock.setup(m => m.flush());
+            telemetryClientMock.setup((m) => m.trackEvent({ name: 'ScanStart' }));
+            telemetryClientMock.setup((m) => m.flush());
 
             await scanner.scan();
 

--- a/packages/shared/src/scanner/scanner.spec.ts
+++ b/packages/shared/src/scanner/scanner.spec.ts
@@ -26,6 +26,7 @@ import { CrawlArgumentHandler } from './crawl-argument-handler';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 import { TaskConfig } from '../task-config';
 import * as fs from 'fs';
+import { TelemetryClient } from '../telemetry/telemetry-client';
 
 describe(Scanner, () => {
     let aiCrawlerMock: IMock<AICrawler>;
@@ -41,6 +42,7 @@ describe(Scanner, () => {
     let crawlerParametersBuilder: IMock<CrawlerParametersBuilder>;
     let baselineOptionsBuilderMock: IMock<BaselineOptionsBuilder>;
     let baselineFileUpdaterMock: IMock<BaselineFileUpdater>;
+    let telemetryClientMock: IMock<TelemetryClient>;
     let fsMock: IMock<typeof fs>;
     let scanner: Scanner;
     let combinedScanResult: CombinedScanResult;
@@ -63,6 +65,7 @@ describe(Scanner, () => {
         crawlerParametersBuilder = Mock.ofType<CrawlerParametersBuilder>();
         baselineOptionsBuilderMock = Mock.ofType<BaselineOptionsBuilder>(null, MockBehavior.Strict);
         baselineFileUpdaterMock = Mock.ofType<BaselineFileUpdater>();
+        telemetryClientMock = Mock.ofType<TelemetryClient>();
         fsMock = Mock.ofType<typeof fs>();
         scanner = new Scanner(
             aiCrawlerMock.object,
@@ -78,6 +81,7 @@ describe(Scanner, () => {
             crawlerParametersBuilder.object,
             baselineOptionsBuilderMock.object,
             baselineFileUpdaterMock.object,
+            telemetryClientMock.object,
             fsMock.object,
         );
         combinedScanResult = {
@@ -155,6 +159,18 @@ describe(Scanner, () => {
             setupWaitForPromiseToReturnOriginalPromise();
 
             await expect(scanner.scan()).resolves.toBe(false);
+
+            verifyMocks();
+        });
+
+        it('emits a StartScan telemetry event and flush telemetry when complete', async () => {
+            setupMocksForSuccessfulScan();
+            setupWaitForPromiseToReturnOriginalPromise();
+
+            telemetryClientMock.setup(m => m.trackEvent({ name: 'ScanStart' }));
+            telemetryClientMock.setup(m => m.flush());
+
+            await scanner.scan();
 
             verifyMocks();
         });
@@ -267,6 +283,7 @@ describe(Scanner, () => {
         promiseUtilsMock.verifyAll();
         baselineOptionsBuilderMock.verifyAll();
         baselineFileUpdaterMock.verifyAll();
+        telemetryClientMock.verifyAll();
         fsMock.verifyAll();
     }
 });

--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -100,7 +100,7 @@ export class Scanner {
         } finally {
             this.fileServer.stop();
             this.logger.logInfo(`Accessibility scanning of URL ${scanArguments?.url} completed`);
-            this.telemetryClient.flush();
+            await this.telemetryClient.flush();
         }
 
         return Promise.resolve(false);

--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -22,6 +22,7 @@ import { AxeInfo } from '../axe/axe-info';
 import { ConsolidatedReportGenerator } from '../report/consolidated-report-generator';
 import { CrawlArgumentHandler } from './crawl-argument-handler';
 import { TaskConfig } from '../task-config';
+import { TelemetryClient } from '../telemetry/telemetry-client';
 import { isEmpty } from 'lodash';
 import * as fs from 'fs';
 
@@ -43,6 +44,7 @@ export class Scanner {
         @inject(CrawlerParametersBuilder) private readonly crawlerParametersBuilder: CrawlerParametersBuilder,
         @inject(BaselineOptionsBuilder) private readonly baselineOptionsBuilder: BaselineOptionsBuilder,
         @inject(BaselineFileUpdater) private readonly baselineFileUpdater: BaselineFileUpdater,
+        @inject(iocTypes.TelemetryClient) private readonly telemetryClient: TelemetryClient,
         private readonly fileSystemObj: typeof fs = fs,
     ) {}
 
@@ -73,6 +75,8 @@ export class Scanner {
 
             scanArguments = this.crawlArgumentHandler.processScanArguments(localServerUrl);
 
+            this.telemetryClient.trackEvent({ name: 'ScanStart' });
+
             this.logger.logStartGroup(`Scanning URL ${scanArguments.url}`);
             this.logger.logDebug(`Starting accessibility scanning of URL ${scanArguments.url}`);
             this.logger.logDebug(`Chrome app executable: ${scanArguments.chromePath ?? 'system default'}`);
@@ -96,6 +100,7 @@ export class Scanner {
         } finally {
             this.fileServer.stop();
             this.logger.logInfo(`Accessibility scanning of URL ${scanArguments?.url} completed`);
+            this.telemetryClient.flush();
         }
 
         return Promise.resolve(false);

--- a/packages/shared/src/task-config.ts
+++ b/packages/shared/src/task-config.ts
@@ -1,9 +1,8 @@
-import { iocTypes } from './ioc/ioc-types';
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
+import { iocTypes } from './ioc/ioc-types';
 
 @injectable()
 export abstract class TaskConfig {

--- a/packages/shared/src/telemetry/null-telemetry-client.spec.ts
+++ b/packages/shared/src/telemetry/null-telemetry-client.spec.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { NullTelemetryClient } from './null-telemetry-client';
+
+describe(NullTelemetryClient, () => {
+    describe('trackEvent', () => {
+        it('succeeds silently', () => {
+            const testSubject = new NullTelemetryClient();
+
+            expect(() => testSubject.trackEvent({ name: 'irrelevant '})).not.toThrow();
+        })
+    })
+
+    describe('flush', () => {
+        it('succeeds silently', () => {
+            const testSubject = new NullTelemetryClient();
+
+            expect(() => testSubject.flush()).not.toThrow();
+        })
+    })
+})

--- a/packages/shared/src/telemetry/null-telemetry-client.spec.ts
+++ b/packages/shared/src/telemetry/null-telemetry-client.spec.ts
@@ -15,10 +15,10 @@ describe(NullTelemetryClient, () => {
     });
 
     describe('flush', () => {
-        it('succeeds silently', () => {
+        it('succeeds silently', async () => {
             const testSubject = new NullTelemetryClient();
 
-            expect(() => testSubject.flush()).not.toThrow();
+            await expect(testSubject.flush()).resolves.not.toThrow();
         });
     });
 });

--- a/packages/shared/src/telemetry/null-telemetry-client.spec.ts
+++ b/packages/shared/src/telemetry/null-telemetry-client.spec.ts
@@ -1,14 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import 'reflect-metadata';
 
 import { NullTelemetryClient } from './null-telemetry-client';
+import { TelemetryEventName } from './telemetry-event';
 
 describe(NullTelemetryClient, () => {
     describe('trackEvent', () => {
         it('succeeds silently', () => {
             const testSubject = new NullTelemetryClient();
 
-            expect(() => testSubject.trackEvent({ name: 'irrelevant ' })).not.toThrow();
+            expect(() => testSubject.trackEvent({ name: 'irrelevant' as TelemetryEventName })).not.toThrow();
         });
     });
 

--- a/packages/shared/src/telemetry/null-telemetry-client.spec.ts
+++ b/packages/shared/src/telemetry/null-telemetry-client.spec.ts
@@ -8,15 +8,15 @@ describe(NullTelemetryClient, () => {
         it('succeeds silently', () => {
             const testSubject = new NullTelemetryClient();
 
-            expect(() => testSubject.trackEvent({ name: 'irrelevant '})).not.toThrow();
-        })
-    })
+            expect(() => testSubject.trackEvent({ name: 'irrelevant ' })).not.toThrow();
+        });
+    });
 
     describe('flush', () => {
         it('succeeds silently', () => {
             const testSubject = new NullTelemetryClient();
 
             expect(() => testSubject.flush()).not.toThrow();
-        })
-    })
-})
+        });
+    });
+});

--- a/packages/shared/src/telemetry/null-telemetry-client.ts
+++ b/packages/shared/src/telemetry/null-telemetry-client.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { TelemetryClient } from './telemetry-client';
+import { TelemetryEvent } from './telemetry-event';
+
+export class NullTelemetryClient implements TelemetryClient {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    public trackEvent(event: TelemetryEvent): void {
+        // no-op
+    }
+
+    public flush(): void {
+        // no-op
+    }
+}

--- a/packages/shared/src/telemetry/null-telemetry-client.ts
+++ b/packages/shared/src/telemetry/null-telemetry-client.ts
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { injectable } from 'inversify';
 import { TelemetryClient } from './telemetry-client';
 import { TelemetryEvent } from './telemetry-event';
 
+@injectable()
 export class NullTelemetryClient implements TelemetryClient {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public trackEvent(event: TelemetryEvent): void {

--- a/packages/shared/src/telemetry/null-telemetry-client.ts
+++ b/packages/shared/src/telemetry/null-telemetry-client.ts
@@ -12,7 +12,7 @@ export class NullTelemetryClient implements TelemetryClient {
         // no-op
     }
 
-    public flush(): void {
+    public async flush(): Promise<void> {
         // no-op
     }
 }

--- a/packages/shared/src/telemetry/telemetry-client.ts
+++ b/packages/shared/src/telemetry/telemetry-client.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { TelemetryEvent } from './telemetry-event';
+
+export interface TelemetryClient {
+    trackEvent(event: TelemetryEvent): void;
+    flush(): void;
+}

--- a/packages/shared/src/telemetry/telemetry-client.ts
+++ b/packages/shared/src/telemetry/telemetry-client.ts
@@ -5,5 +5,5 @@ import { TelemetryEvent } from './telemetry-event';
 
 export interface TelemetryClient {
     trackEvent(event: TelemetryEvent): void;
-    flush(): void;
+    flush(): Promise<void>;
 }

--- a/packages/shared/src/telemetry/telemetry-event.ts
+++ b/packages/shared/src/telemetry/telemetry-event.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+export type TelemetryEventName = 'ScanStart';
+
 export type TelemetryEvent = {
-    name: string;
+    name: TelemetryEventName;
     properties?: { [key: string]: string };
 };

--- a/packages/shared/src/telemetry/telemetry-event.ts
+++ b/packages/shared/src/telemetry/telemetry-event.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export type TelemetryEvent = {
+    name: string;
+    properties?: { [key: string]: string };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1543,16 +1543,6 @@
   resolved "https://registry.yarnpkg.com/@medv/finder/-/finder-2.1.0.tgz#5c53cdaac3b87057b9e5579ca1282b2397624016"
   integrity sha512-Egrg5XO4kLol24b1Kv50HDfi5hW0yQ6aWSsO0Hea1eJ4rogKElIN0M86FdVnGF4XIGYyA7QWx0MgbOzVPA0qkA==
 
-"@microsoft/applicationinsights-analytics-js@2.7.4":
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.7.4.tgz#7366584151773562ce91322a6c61b25cb63c5701"
-  integrity sha512-jX5qbqAQRbWcSRLSyPe8uITWGz+aVLYnyHuX5MLjIMJ/JXtWkfOY8n8YTGQaZ0VH0oHmMioHtBqvw/IchUSZ4Q==
-  dependencies:
-    "@microsoft/applicationinsights-common" "2.7.4"
-    "@microsoft/applicationinsights-core-js" "2.7.4"
-    "@microsoft/applicationinsights-shims" "2.0.1"
-    "@microsoft/dynamicproto-js" "^1.1.4"
-
 "@microsoft/applicationinsights-channel-js@2.7.4":
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.7.4.tgz#3174eb0eed3438fb57d970dc5b6f3cccefdb0349"
@@ -1580,42 +1570,19 @@
     "@microsoft/applicationinsights-shims" "2.0.1"
     "@microsoft/dynamicproto-js" "^1.1.4"
 
-"@microsoft/applicationinsights-dependencies-js@2.7.4":
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.7.4.tgz#2abe645c73e3238fd4e2e2e931fd07eb8ee4efb8"
-  integrity sha512-rwJWZ4a3k943fwejgT8Lr3sfXZRrLcho7V9Q+EIZdzxZkDzVJxj33CF6Kb8TIISgxgG9yqr3rDBsG/GLhgQ2iA==
-  dependencies:
-    "@microsoft/applicationinsights-common" "2.7.4"
-    "@microsoft/applicationinsights-core-js" "2.7.4"
-    "@microsoft/applicationinsights-shims" "2.0.1"
-    "@microsoft/dynamicproto-js" "^1.1.4"
-
-"@microsoft/applicationinsights-properties-js@2.7.4":
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.7.4.tgz#56ae0a6fda1e0a1a2269b0bf4e5f0baf4d725d37"
-  integrity sha512-kqYpQxMuK+EGoD2Q1rY+7NiEUsIRO3gepxBVn+ptUDtOsQGgAra/v/x5FqiKWcdVWyyESl/9e1FKoiMe9MKdlA==
-  dependencies:
-    "@microsoft/applicationinsights-common" "2.7.4"
-    "@microsoft/applicationinsights-core-js" "2.7.4"
-    "@microsoft/applicationinsights-shims" "2.0.1"
-    "@microsoft/dynamicproto-js" "^1.1.4"
-
 "@microsoft/applicationinsights-shims@2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.1.tgz#5d72fb7aaf4056c4fda54f9d7c93ccf8ca9bcbfd"
   integrity sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ==
 
-"@microsoft/applicationinsights-web@^2.7.4":
+"@microsoft/applicationinsights-web-basic@^2.7.4":
   version "2.7.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-web/-/applicationinsights-web-2.7.4.tgz#711186d39c35e2f9f799611477686e7090087644"
-  integrity sha512-9IncUpF80vndiyOHLhYkSJZwdFXkELOhIdtr+EiVWzVSsbpJvU5jVn0IzOXGMnuhY3e61nTyJxCVovLCXnrKtQ==
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-2.7.4.tgz#796555211005f5d0012ab2ec776547e6b9f21617"
+  integrity sha512-jTQ7fSI3vhnVIl/R+AwHvv8i/NFY3ooEwKfIIrP8wqno3W7q/rceHHpY+rez+z0uoibRmYajUtC55SA66JnW0w==
   dependencies:
-    "@microsoft/applicationinsights-analytics-js" "2.7.4"
     "@microsoft/applicationinsights-channel-js" "2.7.4"
     "@microsoft/applicationinsights-common" "2.7.4"
     "@microsoft/applicationinsights-core-js" "2.7.4"
-    "@microsoft/applicationinsights-dependencies-js" "2.7.4"
-    "@microsoft/applicationinsights-properties-js" "2.7.4"
     "@microsoft/applicationinsights-shims" "2.0.1"
     "@microsoft/dynamicproto-js" "^1.1.4"
 
@@ -4240,9 +4207,9 @@ css-select@~1.2.0:
     nth-check "~1.0.1"
 
 css-what@2.1, css-what@>=5.0.1, css-what@^5.0.0:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.0.1.tgz#3be33be55b9f302f710ba3a9c3abc1e2a63fc7eb"
-  integrity sha512-z93ZGFLNc6yaoXAmVhqoSIb+BduplteCt1fepvwhBUQK6MNE4g6fgjpuZKJKp0esUe+vXWlIkwZZjNWoOKw0ZA==
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
 cssom@^0.4.4:
   version "0.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1543,6 +1543,87 @@
   resolved "https://registry.yarnpkg.com/@medv/finder/-/finder-2.1.0.tgz#5c53cdaac3b87057b9e5579ca1282b2397624016"
   integrity sha512-Egrg5XO4kLol24b1Kv50HDfi5hW0yQ6aWSsO0Hea1eJ4rogKElIN0M86FdVnGF4XIGYyA7QWx0MgbOzVPA0qkA==
 
+"@microsoft/applicationinsights-analytics-js@2.7.4":
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.7.4.tgz#7366584151773562ce91322a6c61b25cb63c5701"
+  integrity sha512-jX5qbqAQRbWcSRLSyPe8uITWGz+aVLYnyHuX5MLjIMJ/JXtWkfOY8n8YTGQaZ0VH0oHmMioHtBqvw/IchUSZ4Q==
+  dependencies:
+    "@microsoft/applicationinsights-common" "2.7.4"
+    "@microsoft/applicationinsights-core-js" "2.7.4"
+    "@microsoft/applicationinsights-shims" "2.0.1"
+    "@microsoft/dynamicproto-js" "^1.1.4"
+
+"@microsoft/applicationinsights-channel-js@2.7.4":
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.7.4.tgz#3174eb0eed3438fb57d970dc5b6f3cccefdb0349"
+  integrity sha512-pcKn2fbF+hDbmWITsE8aN07FVRVZn/NxAUKbouudG6QWNvSNSpMuep88yxlU8mSP2imWjuXIFP6NuGNOEXec8w==
+  dependencies:
+    "@microsoft/applicationinsights-common" "2.7.4"
+    "@microsoft/applicationinsights-core-js" "2.7.4"
+    "@microsoft/applicationinsights-shims" "2.0.1"
+    "@microsoft/dynamicproto-js" "^1.1.4"
+
+"@microsoft/applicationinsights-common@2.7.4":
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-common/-/applicationinsights-common-2.7.4.tgz#eb30d1e53b9bfe1f8d45b43d7a5528a0dc6f2b02"
+  integrity sha512-tLcU9AHTescd09/EZ4uXoEVCOCMjkTgzblc7lZECOU7mm51VQrDCdlYQ3Br9lnNnyOrFw0+f3o+O9ock55I05g==
+  dependencies:
+    "@microsoft/applicationinsights-core-js" "2.7.4"
+    "@microsoft/applicationinsights-shims" "2.0.1"
+    "@microsoft/dynamicproto-js" "^1.1.4"
+
+"@microsoft/applicationinsights-core-js@2.7.4":
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.7.4.tgz#9271fadf01863b3f28bfc45aaa630229ee28a0f4"
+  integrity sha512-PlJ/ITQjvDhirdo7CSloSx5UTDntou9MF+nYgc+W/wM9vPYnz3gFfiuY59L30si3C3zSBMmUTLuDnXRvgLGRAw==
+  dependencies:
+    "@microsoft/applicationinsights-shims" "2.0.1"
+    "@microsoft/dynamicproto-js" "^1.1.4"
+
+"@microsoft/applicationinsights-dependencies-js@2.7.4":
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.7.4.tgz#2abe645c73e3238fd4e2e2e931fd07eb8ee4efb8"
+  integrity sha512-rwJWZ4a3k943fwejgT8Lr3sfXZRrLcho7V9Q+EIZdzxZkDzVJxj33CF6Kb8TIISgxgG9yqr3rDBsG/GLhgQ2iA==
+  dependencies:
+    "@microsoft/applicationinsights-common" "2.7.4"
+    "@microsoft/applicationinsights-core-js" "2.7.4"
+    "@microsoft/applicationinsights-shims" "2.0.1"
+    "@microsoft/dynamicproto-js" "^1.1.4"
+
+"@microsoft/applicationinsights-properties-js@2.7.4":
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.7.4.tgz#56ae0a6fda1e0a1a2269b0bf4e5f0baf4d725d37"
+  integrity sha512-kqYpQxMuK+EGoD2Q1rY+7NiEUsIRO3gepxBVn+ptUDtOsQGgAra/v/x5FqiKWcdVWyyESl/9e1FKoiMe9MKdlA==
+  dependencies:
+    "@microsoft/applicationinsights-common" "2.7.4"
+    "@microsoft/applicationinsights-core-js" "2.7.4"
+    "@microsoft/applicationinsights-shims" "2.0.1"
+    "@microsoft/dynamicproto-js" "^1.1.4"
+
+"@microsoft/applicationinsights-shims@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.1.tgz#5d72fb7aaf4056c4fda54f9d7c93ccf8ca9bcbfd"
+  integrity sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ==
+
+"@microsoft/applicationinsights-web@^2.7.4":
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-web/-/applicationinsights-web-2.7.4.tgz#711186d39c35e2f9f799611477686e7090087644"
+  integrity sha512-9IncUpF80vndiyOHLhYkSJZwdFXkELOhIdtr+EiVWzVSsbpJvU5jVn0IzOXGMnuhY3e61nTyJxCVovLCXnrKtQ==
+  dependencies:
+    "@microsoft/applicationinsights-analytics-js" "2.7.4"
+    "@microsoft/applicationinsights-channel-js" "2.7.4"
+    "@microsoft/applicationinsights-common" "2.7.4"
+    "@microsoft/applicationinsights-core-js" "2.7.4"
+    "@microsoft/applicationinsights-dependencies-js" "2.7.4"
+    "@microsoft/applicationinsights-properties-js" "2.7.4"
+    "@microsoft/applicationinsights-shims" "2.0.1"
+    "@microsoft/dynamicproto-js" "^1.1.4"
+
+"@microsoft/dynamicproto-js@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.4.tgz#40e1c0ad20743fcee1604a7df2c57faf0aa1af87"
+  integrity sha512-Ot53G927ykMF8cQ3/zq4foZtdk+Tt1YpX7aUTHxBU7UHNdkEiBvBfZSq+rnlUmKCJ19VatwPG4mNzvcGpBj4og==
+
 "@microsoft/load-themed-styles@^1.10.26":
   version "1.10.225"
   resolved "https://registry.yarnpkg.com/@microsoft/load-themed-styles/-/load-themed-styles-1.10.225.tgz#5cd8657725201e5d9760bf5ded27cac88fb2d8a5"
@@ -1848,11 +1929,6 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@socket.io/base64-arraybuffer@~1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@socket.io/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#568d9beae00b0d835f4f8c53fd55714986492e61"
-  integrity sha512-dOlCBKnDw4iShaIsH/bxujKTM18+2TOAsYz+KSc11Am38H4q5Xw8Bbz97ZYdrVNM+um3p7w86Bvvmcn9q+5+eQ==
-
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.5.tgz#bfbd50211e9dfa51ba07da58a14cdfd333205152"
@@ -1941,16 +2017,6 @@
   integrity sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==
   dependencies:
     "@types/node" "*"
-
-"@types/cookie@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
-  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
-
-"@types/cors@^2.8.12":
-  version "2.8.12"
-  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
-  integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
 
 "@types/domhandler@^2.4.1":
   version "2.4.1"
@@ -2135,11 +2201,6 @@
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.6.1.tgz#32d43390d5c62c5b6ec486a9bc9c59544de39a08"
   integrity sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==
-
-"@types/node@>=10.0.0":
-  version "17.0.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
-  integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
 
 "@types/node@^10.0.3":
   version "10.17.60"
@@ -2748,6 +2809,11 @@ add-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
   integrity sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=
 
+after@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
+  integrity sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
+
 agent-base@5:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
@@ -2828,7 +2894,17 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^2.0.0, ansi-regex@^4.1.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+ansi-regex@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
+
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
+ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -2877,10 +2953,63 @@ apify-client@^0.6.0:
     type-check "^0.3.2"
     underscore "^1.9.1"
 
-apify-shared@>=0.5.0, apify-shared@^0.1.45, apify-shared@^0.5.0, apify-shared@^0.6.0:
+apify-shared@>=0.5.0:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/apify-shared/-/apify-shared-0.7.6.tgz#1a813cd650adae0d70968976cbe34ec482f30026"
   integrity sha512-KkCHpzB/2BaVhHhcquxltRyn9qE42/T5T7XJMYIK0j9h0eECfmbxJ2g1YlD5AHVXvcK1J8qmLLfmSkgzJbdCwg==
+  dependencies:
+    axios "^0.21.1"
+    chalk "^4.0.0"
+    cherow "^1.6.9"
+    clone "^2.1.1"
+    countries-list "^2.6.1"
+    create-hmac "^1.1.7"
+    git-url-parse "^11.4.4"
+    is-buffer "^2.0.5"
+    marked "^2.0.0"
+    match-all "^1.2.6"
+    moment "^2.29.1"
+    request "^2.88.0"
+    underscore "^1.11.0"
+    url "^0.11.0"
+
+apify-shared@^0.1.45:
+  version "0.1.72"
+  resolved "https://registry.yarnpkg.com/apify-shared/-/apify-shared-0.1.72.tgz#d7ce18c8020462c5cee2c1962c367798c98ee31d"
+  integrity sha512-zpuh+S9XUvwQOG3A+IVZAZowplefmSKoZDXINqlShO84BDVVY6LdwmEMSwC7QyELYAMP+Dg9OvY8lgK9g1yMKA==
+  dependencies:
+    bluebird "^3.7.2"
+    clone "^2.1.1"
+    is-buffer "^2.0.3"
+    request "^2.88.0"
+    slugg "^1.2.1"
+    underscore "^1.9.1"
+    url "^0.11.0"
+
+apify-shared@^0.5.0:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/apify-shared/-/apify-shared-0.5.9.tgz#2645e5505dd0ec4729b7d40238b88ac0e460fea0"
+  integrity sha512-SSxZSLhRAA3RlMtGarCrtDYd4cMMrCpQxsBidX3UkheLa8L7kVYdtprLbEq+WdgxNe2r8sZOs1wcl+ku4yDj4g==
+  dependencies:
+    axios "^0.21.1"
+    chalk "^4.0.0"
+    cherow "^1.6.9"
+    clone "^2.1.1"
+    countries-list "^2.6.1"
+    create-hmac "^1.1.7"
+    git-url-parse "^11.4.4"
+    is-buffer "^2.0.5"
+    marked "^1.2.4"
+    match-all "^1.2.6"
+    moment "^2.29.1"
+    request "^2.88.0"
+    underscore "^1.11.0"
+    url "^0.11.0"
+
+apify-shared@^0.6.0:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/apify-shared/-/apify-shared-0.6.3.tgz#71e5dfedddab63860cdd8a0cacfaedf2ea35437d"
+  integrity sha512-34J5LWt9sjIFP52nPuz9z8IWecxGsuLEhjOxTZII4XRtmMylRecYFmVxVIltV+h7PHNuQzL2LUjjkQ372QvV4Q==
   dependencies:
     axios "^0.21.1"
     chalk "^4.0.0"
@@ -3038,6 +3167,11 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
+arraybuffer.slice@~0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
+  integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
+
 arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -3137,12 +3271,12 @@ axe-core@^4.2.3:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.3.tgz#b55cd8e8ddf659fe89b064680e1c6a4dceab0325"
   integrity sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
 
-axios@>=0.21.1, axios@^0.21.1:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
-  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+axios@^0.21.1:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
-    follow-redirects "^1.14.8"
+    follow-redirects "^1.14.0"
 
 azure-devops-node-api@^10.2.2:
   version "10.2.2"
@@ -3226,17 +3360,27 @@ babel-preset-jest@^27.5.1:
     babel-plugin-jest-hoist "^27.5.1"
     babel-preset-current-node-syntax "^1.0.0"
 
+backo2@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
+  integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+base64-arraybuffer@0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz#9818c79e059b1355f97e0428a017c838e90ba812"
+  integrity sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=
 
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-base64id@2.0.0, base64id@~2.0.0:
+base64id@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-2.0.0.tgz#2770ac6bc47d312af97a8bf9a634342e0cd25cb6"
   integrity sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==
@@ -3275,10 +3419,20 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
+blob@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
+  integrity sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
+
 bluebird@^2.9.34:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
   integrity sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=
+
+bluebird@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 body-parser@1.19.2:
   version "1.19.2"
@@ -3610,7 +3764,7 @@ chokidar@3.5.3, chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chownr@^1.1.1:
+chownr@^1.1.1, chownr@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
@@ -3861,10 +4015,25 @@ compare-func@^2.0.0:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
 
+component-bind@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
+  integrity sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=
+
+component-emitter@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+  integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
+
 component-emitter@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
+component-inherit@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
+  integrity sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=
 
 compress-commons@^1.2.0:
   version "1.2.2"
@@ -4046,14 +4215,6 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cors@~2.8.5:
-  version "2.8.5"
-  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
-  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
-  dependencies:
-    object-assign "^4"
-    vary "^1"
-
 cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
@@ -4158,10 +4319,15 @@ css-select@~1.2.0:
     domutils "1.5.1"
     nth-check "~1.0.1"
 
-css-what@2.1, css-what@>=5.0.1, css-what@^5.0.0:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.0.1.tgz#3be33be55b9f302f710ba3a9c3abc1e2a63fc7eb"
-  integrity sha512-z93ZGFLNc6yaoXAmVhqoSIb+BduplteCt1fepvwhBUQK6MNE4g6fgjpuZKJKp0esUe+vXWlIkwZZjNWoOKw0ZA==
+css-what@2.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
+  integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
+
+css-what@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.1.0.tgz#3f7b707aadf633baf62c2ceb8579b545bb40f7fe"
+  integrity sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==
 
 cssom@^0.4.4:
   version "0.4.4"
@@ -4238,12 +4404,19 @@ debug@4, debug@4.3.3, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, de
   dependencies:
     ms "2.1.2"
 
-debug@~4.3.2:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+debug@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
-    ms "2.1.2"
+    ms "2.0.0"
+
+debug@~4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -4622,28 +4795,45 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   dependencies:
     once "^1.4.0"
 
-engine.io-parser@~5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.0.3.tgz#ca1f0d7b11e290b4bfda251803baea765ed89c09"
-  integrity sha512-BtQxwF27XUNnSafQLvDi0dQ8s3i6VgzSoQMJacpIcGNrlUdfHSKbgm3jmjCVvQluGzqwujQMPAoMai3oYSTurg==
+engine.io-client@~3.5.0:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.5.2.tgz#0ef473621294004e9ceebe73cef0af9e36f2f5fa"
+  integrity sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==
   dependencies:
-    "@socket.io/base64-arraybuffer" "~1.0.2"
+    component-emitter "~1.3.0"
+    component-inherit "0.0.3"
+    debug "~3.1.0"
+    engine.io-parser "~2.2.0"
+    has-cors "1.1.0"
+    indexof "0.0.1"
+    parseqs "0.0.6"
+    parseuri "0.0.6"
+    ws "~7.4.2"
+    xmlhttprequest-ssl "~1.6.2"
+    yeast "0.1.2"
 
-engine.io@~6.1.0:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.1.3.tgz#f156293d011d99a3df5691ac29d63737c3302e6f"
-  integrity sha512-rqs60YwkvWTLLnfazqgZqLa/aKo+9cueVfEi/dZ8PyGyaf8TLOxj++4QMIgeG3Gn0AhrWiFXvghsoY9L9h25GA==
+engine.io-parser@~2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-2.2.1.tgz#57ce5611d9370ee94f99641b589f94c97e4f5da7"
+  integrity sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==
   dependencies:
-    "@types/cookie" "^0.4.1"
-    "@types/cors" "^2.8.12"
-    "@types/node" ">=10.0.0"
+    after "0.8.2"
+    arraybuffer.slice "~0.0.7"
+    base64-arraybuffer "0.1.4"
+    blob "0.0.5"
+    has-binary2 "~1.0.2"
+
+engine.io@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-3.5.0.tgz#9d6b985c8a39b1fe87cd91eb014de0552259821b"
+  integrity sha512-21HlvPUKaitDGE4GXNtQ7PLP0Sz4aWLddMPw2VTyFz1FVZqu/kZsJUO8WNpKuE/OCL7nkfRaOui2ZCJloGznGA==
+  dependencies:
     accepts "~1.3.4"
     base64id "2.0.0"
     cookie "~0.4.1"
-    cors "~2.8.5"
-    debug "~4.3.1"
-    engine.io-parser "~5.0.3"
-    ws "~8.2.3"
+    debug "~4.1.0"
+    engine.io-parser "~2.2.0"
+    ws "~7.4.2"
 
 enhanced-resolve@^5.0.0, enhanced-resolve@^5.9.2:
   version "5.9.2"
@@ -5259,7 +5449,7 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
-follow-redirects@^1.14.8:
+follow-redirects@^1.14.0:
   version "1.14.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
@@ -5376,6 +5566,13 @@ fs-extra@^9.0.0, fs-extra@^9.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^2.0.0"
+
+fs-minipass@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
+  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
+  dependencies:
+    minipass "^2.6.0"
 
 fs-minipass@^2.0.0, fs-minipass@^2.1.0:
   version "2.1.0"
@@ -5694,6 +5891,18 @@ has-bigints@^1.0.1:
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
   integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
 
+has-binary2@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-binary2/-/has-binary2-1.0.3.tgz#7776ac627f3ea77250cfc332dab7ddf5e4f5d11d"
+  integrity sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==
+  dependencies:
+    isarray "2.0.1"
+
+has-cors@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
+  integrity sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -5742,12 +5951,17 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hosted-git-info@>=3.0.8, hosted-git-info@^2.1.4, hosted-git-info@^4.0.0, hosted-git-info@^4.0.1:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-5.0.0.tgz#df7a06678b4ebd722139786303db80fdf302ea56"
-  integrity sha512-rRnjWu0Bxj+nIfUOkz0695C0H6tRrN5iYIzYejb0tDEefe2AekHu/U5Kn9pEie5vsJqpNQU02az7TGSH3qpz4Q==
+hosted-git-info@^2.1.4:
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
+
+hosted-git-info@^4.0.0, hosted-git-info@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz#827b82867e9ff1c8d0c4d9d53880397d2c86d224"
+  integrity sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==
   dependencies:
-    lru-cache "^7.5.1"
+    lru-cache "^6.0.0"
 
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
@@ -5846,14 +6060,14 @@ http-response-object@^3.0.1:
   dependencies:
     "@types/node" "^10.0.3"
 
-http-signature@>=1.3.1, http-signature@~1.2.0:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.3.6.tgz#cb6fbfdf86d1c974f343be94e87f7fc128662cf9"
-  integrity sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  integrity sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
   dependencies:
     assert-plus "^1.0.0"
-    jsprim "^2.0.2"
-    sshpk "^1.14.1"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
 
 http2-wrapper@^1.0.0-beta.5.2:
   version "1.0.3"
@@ -5977,6 +6191,11 @@ indent-string@^5.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-5.0.0.tgz#4fd2980fccaf8622d14c64d694f4cf33c81951a5"
   integrity sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==
 
+indexof@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
+  integrity sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
+
 infer-owner@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
@@ -6090,7 +6309,7 @@ is-boolean-object@^1.1.0:
   dependencies:
     call-bind "^1.0.2"
 
-is-buffer@^2.0.5:
+is-buffer@^2.0.3, is-buffer@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
@@ -6297,6 +6516,11 @@ is-weakref@^1.0.1:
   integrity sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==
   dependencies:
     call-bind "^1.0.0"
+
+isarray@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
+  integrity sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -6990,10 +7214,10 @@ jsonparse@^1.2.0, jsonparse@^1.3.1:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-jsprim@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-2.0.2.tgz#77ca23dbcd4135cd364800d22ff82c2185803d4d"
-  integrity sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==
+jsprim@^1.2.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
+  integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
   dependencies:
     assert-plus "1.0.0"
     extsprintf "1.3.0"
@@ -7326,11 +7550,6 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lru-cache@^7.5.1:
-  version "7.7.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.7.1.tgz#03d2846b1ad2dcc7931a9340b8711d9798fcb0c6"
-  integrity sha512-cRffBiTW8s73eH4aTXqBcTLU0xQnwGV3/imttRHGWCrbergmnK4D6JXQd8qin5z43HnDwRI+o7mVW0LEB+tpAw==
-
 luxon@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.0.2.tgz#11f2cd4a11655fdf92e076b5782d7ede5bcdd133"
@@ -7443,7 +7662,17 @@ marked-terminal@^4.2.0:
     node-emoji "^1.10.0"
     supports-hyperlinks "^2.1.0"
 
-marked@>=2.0.0, marked@^2.0.0, marked@^4.0.12:
+marked@^1.2.4:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.9.tgz#53786f8b05d4c01a2a5a76b7d1ec9943d29d72dc"
+  integrity sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==
+
+marked@^2.0.0:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.3.tgz#bd017cef6431724fd4b27e0657f5ceb14bff3753"
+  integrity sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==
+
+marked@^4.0.12:
   version "4.0.12"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.12.tgz#2262a4e6fd1afd2f13557726238b69a48b982f7d"
   integrity sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==
@@ -7602,7 +7831,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -7654,6 +7883,14 @@ minipass-sized@^1.0.3:
   dependencies:
     minipass "^3.0.0"
 
+minipass@^2.6.0, minipass@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
 minipass@^3.0.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
@@ -7667,6 +7904,13 @@ minipass@^3.1.0, minipass@^3.1.1, minipass@^3.1.3:
   integrity sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==
   dependencies:
     yallist "^4.0.0"
+
+minizlib@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
+  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
+  dependencies:
+    minipass "^2.9.0"
 
 minizlib@^2.0.0, minizlib@^2.1.1:
   version "2.1.2"
@@ -7696,6 +7940,13 @@ mkdirp@^0.5.1:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mkdirp@^0.5.5:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
 
 mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
@@ -7762,7 +8013,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.0.0:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -8084,12 +8335,19 @@ npmlog@^4.1.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nth-check@>=2.0.1, nth-check@^2.0.0, nth-check@~1.0.1:
+nth-check@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2"
   integrity sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==
   dependencies:
     boolbase "^1.0.0"
+
+nth-check@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
+  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
+  dependencies:
+    boolbase "~1.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -8106,7 +8364,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -8457,6 +8715,16 @@ parse5@^3.0.1:
   integrity sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
   dependencies:
     "@types/node" "*"
+
+parseqs@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.6.tgz#8e4bb5a19d1cdc844a08ac974d34e273afa670d5"
+  integrity sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==
+
+parseuri@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/parseuri/-/parseuri-0.0.6.tgz#e1496e829e3ac2ff47f39a4dd044b32823c4a25a"
+  integrity sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==
 
 parseurl@~1.3.3:
   version "1.3.3"
@@ -9290,7 +9558,7 @@ rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -9413,10 +9681,17 @@ serialize-error@^8.0.1, serialize-error@^8.1.0:
   dependencies:
     type-fest "^0.20.2"
 
-serialize-javascript@6.0.0, serialize-javascript@>=3.1.0, serialize-javascript@^5.0.1:
+serialize-javascript@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
   integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
+  dependencies:
+    randombytes "^2.1.0"
+
+serialize-javascript@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
+  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
   dependencies:
     randombytes "^2.1.0"
 
@@ -9551,17 +9826,39 @@ slide@^1.1.6:
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
   integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
 
+slugg@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/slugg/-/slugg-1.2.1.tgz#e752af2241af3f2714463c5de225cea47608740a"
+  integrity sha1-51KvIkGvPycURjxd4iXOpHYIdAo=
+
 smart-buffer@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-socket.io-adapter@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz#4d6111e4d42e9f7646e365b4f578269821f13486"
-  integrity sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==
+socket.io-adapter@~1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz#ab3f0d6f66b8fc7fca3959ab5991f82221789be9"
+  integrity sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g==
 
-socket.io-parser@*, socket.io-parser@~4.0.4:
+socket.io-client@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.4.0.tgz#aafb5d594a3c55a34355562fc8aea22ed9119a35"
+  integrity sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==
+  dependencies:
+    backo2 "1.0.2"
+    component-bind "1.0.0"
+    component-emitter "~1.3.0"
+    debug "~3.1.0"
+    engine.io-client "~3.5.0"
+    has-binary2 "~1.0.2"
+    indexof "0.0.1"
+    parseqs "0.0.6"
+    parseuri "0.0.6"
+    socket.io-parser "~3.3.0"
+    to-array "0.1.4"
+
+socket.io-parser@*:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.0.4.tgz#9ea21b0d61508d18196ef04a2c6b9ab630f4c2b0"
   integrity sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==
@@ -9570,17 +9867,35 @@ socket.io-parser@*, socket.io-parser@~4.0.4:
     component-emitter "~1.3.0"
     debug "~4.3.1"
 
-socket.io@>=2.4.0, socket.io@^2.3.0:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.4.1.tgz#cd6de29e277a161d176832bb24f64ee045c56ab8"
-  integrity sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==
+socket.io-parser@~3.3.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.2.tgz#ef872009d0adcf704f2fbe830191a14752ad50b6"
+  integrity sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==
   dependencies:
-    accepts "~1.3.4"
-    base64id "~2.0.0"
-    debug "~4.3.2"
-    engine.io "~6.1.0"
-    socket.io-adapter "~2.3.3"
-    socket.io-parser "~4.0.4"
+    component-emitter "~1.3.0"
+    debug "~3.1.0"
+    isarray "2.0.1"
+
+socket.io-parser@~3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.4.1.tgz#b06af838302975837eab2dc980037da24054d64a"
+  integrity sha512-11hMgzL+WCLWf1uFtHSNvliI++tcRUWdoeYuwIl+Axvwy9z2gQM+7nJyN3STj1tLj5JyIUH8/gpDGxzAlDdi0A==
+  dependencies:
+    component-emitter "1.2.1"
+    debug "~4.1.0"
+    isarray "2.0.1"
+
+socket.io@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-2.4.1.tgz#95ad861c9a52369d7f1a68acf0d4a1b16da451d2"
+  integrity sha512-Si18v0mMXGAqLqCVpTxBa8MGqriHGQh8ccEOhmsmNS3thNCGBwO8WGrwMibANsWtQQ5NStdZwHqZR3naJVFc3w==
+  dependencies:
+    debug "~4.1.0"
+    engine.io "~3.5.0"
+    has-binary2 "~1.0.2"
+    socket.io-adapter "~1.1.0"
+    socket.io-client "2.4.0"
+    socket.io-parser "~3.4.0"
 
 socks-proxy-agent@^5.0.0:
   version "5.0.1"
@@ -9702,7 +10017,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sshpk@^1.14.1:
+sshpk@^1.7.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.17.0.tgz#578082d92d4fe612b13007496e543fa0fbcbe4c5"
   integrity sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==
@@ -10052,7 +10367,20 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@>=6.1.9, tar@^4.4.12, tar@^6.0.2, tar@^6.1.0:
+tar@^4.4.12:
+  version "4.4.19"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.19.tgz#2e4d7263df26f2b914dee10c825ab132123742f3"
+  integrity sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==
+  dependencies:
+    chownr "^1.1.4"
+    fs-minipass "^1.2.7"
+    minipass "^2.9.0"
+    minizlib "^1.3.3"
+    mkdirp "^0.5.5"
+    safe-buffer "^5.2.1"
+    yallist "^3.1.1"
+
+tar@^6.0.2, tar@^6.1.0:
   version "6.1.11"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
   integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
@@ -10235,6 +10563,11 @@ tmpl@1.0.x:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
   integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
+
+to-array@0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
+  integrity sha1-F+bBH3PdTz10zaek/zI46a2b+JA=
 
 to-buffer@^1.1.1:
   version "1.1.1"
@@ -10506,7 +10839,12 @@ unbzip2-stream@^1.3.3:
     buffer "^5.2.1"
     through "^2.3.8"
 
-underscore@1.12.1, underscore@>=1.12.1, underscore@^1.11.0, underscore@^1.12.1, underscore@^1.9.1:
+underscore@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
+  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
+
+underscore@^1.11.0, underscore@^1.12.1, underscore@^1.9.1:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.2.tgz#276cea1e8b9722a8dbed0100a407dda572125881"
   integrity sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==
@@ -10651,7 +10989,7 @@ validator@^13.7.0:
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
   integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
 
-vary@^1, vary@~1.1.2:
+vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
@@ -10969,15 +11307,10 @@ write-pkg@^4.0.0:
     type-fest "^0.4.1"
     write-json-file "^3.2.0"
 
-ws@^7.2.3, ws@^7.3.0, ws@^7.4.5:
+ws@^7.2.3, ws@^7.3.0, ws@^7.4.5, ws@~7.4.2:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
-
-ws@~8.2.3:
-  version "8.2.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.3.tgz#63a56456db1b04367d0b721a0b80cae6d8becbba"
-  integrity sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==
 
 wtfnode@^0.9.0:
   version "0.9.1"
@@ -11012,12 +11345,22 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
+xmlhttprequest-ssl@~1.6.2:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz#03b713873b01659dfa2c1c5d056065b27ddc2de6"
+  integrity sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==
+
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-y18n@>=5.0.5, y18n@^4.0.0, y18n@^5.0.5:
+y18n@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
+  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
+
+y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
@@ -11026,6 +11369,11 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+
+yallist@^3.0.0, yallist@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yallist@^4.0.0:
   version "4.0.0"
@@ -11119,6 +11467,11 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yeast@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
+  integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
 
 yocto-queue@^0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1929,6 +1929,11 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@socket.io/base64-arraybuffer@~1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@socket.io/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#568d9beae00b0d835f4f8c53fd55714986492e61"
+  integrity sha512-dOlCBKnDw4iShaIsH/bxujKTM18+2TOAsYz+KSc11Am38H4q5Xw8Bbz97ZYdrVNM+um3p7w86Bvvmcn9q+5+eQ==
+
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.5.tgz#bfbd50211e9dfa51ba07da58a14cdfd333205152"
@@ -2017,6 +2022,16 @@
   integrity sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==
   dependencies:
     "@types/node" "*"
+
+"@types/cookie@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
+
+"@types/cors@^2.8.12":
+  version "2.8.12"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
+  integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
 
 "@types/domhandler@^2.4.1":
   version "2.4.1"
@@ -2201,6 +2216,11 @@
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.6.1.tgz#32d43390d5c62c5b6ec486a9bc9c59544de39a08"
   integrity sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==
+
+"@types/node@>=10.0.0":
+  version "17.0.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
+  integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
 
 "@types/node@^10.0.3":
   version "10.17.60"
@@ -2809,11 +2829,6 @@ add-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
   integrity sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=
 
-after@0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
-  integrity sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
-
 agent-base@5:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
@@ -2894,17 +2909,7 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
-
-ansi-regex@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
-  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
-
-ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+ansi-regex@^2.0.0, ansi-regex@^4.1.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -2953,63 +2958,10 @@ apify-client@^0.6.0:
     type-check "^0.3.2"
     underscore "^1.9.1"
 
-apify-shared@>=0.5.0:
+apify-shared@>=0.5.0, apify-shared@^0.1.45, apify-shared@^0.5.0, apify-shared@^0.6.0:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/apify-shared/-/apify-shared-0.7.6.tgz#1a813cd650adae0d70968976cbe34ec482f30026"
   integrity sha512-KkCHpzB/2BaVhHhcquxltRyn9qE42/T5T7XJMYIK0j9h0eECfmbxJ2g1YlD5AHVXvcK1J8qmLLfmSkgzJbdCwg==
-  dependencies:
-    axios "^0.21.1"
-    chalk "^4.0.0"
-    cherow "^1.6.9"
-    clone "^2.1.1"
-    countries-list "^2.6.1"
-    create-hmac "^1.1.7"
-    git-url-parse "^11.4.4"
-    is-buffer "^2.0.5"
-    marked "^2.0.0"
-    match-all "^1.2.6"
-    moment "^2.29.1"
-    request "^2.88.0"
-    underscore "^1.11.0"
-    url "^0.11.0"
-
-apify-shared@^0.1.45:
-  version "0.1.72"
-  resolved "https://registry.yarnpkg.com/apify-shared/-/apify-shared-0.1.72.tgz#d7ce18c8020462c5cee2c1962c367798c98ee31d"
-  integrity sha512-zpuh+S9XUvwQOG3A+IVZAZowplefmSKoZDXINqlShO84BDVVY6LdwmEMSwC7QyELYAMP+Dg9OvY8lgK9g1yMKA==
-  dependencies:
-    bluebird "^3.7.2"
-    clone "^2.1.1"
-    is-buffer "^2.0.3"
-    request "^2.88.0"
-    slugg "^1.2.1"
-    underscore "^1.9.1"
-    url "^0.11.0"
-
-apify-shared@^0.5.0:
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/apify-shared/-/apify-shared-0.5.9.tgz#2645e5505dd0ec4729b7d40238b88ac0e460fea0"
-  integrity sha512-SSxZSLhRAA3RlMtGarCrtDYd4cMMrCpQxsBidX3UkheLa8L7kVYdtprLbEq+WdgxNe2r8sZOs1wcl+ku4yDj4g==
-  dependencies:
-    axios "^0.21.1"
-    chalk "^4.0.0"
-    cherow "^1.6.9"
-    clone "^2.1.1"
-    countries-list "^2.6.1"
-    create-hmac "^1.1.7"
-    git-url-parse "^11.4.4"
-    is-buffer "^2.0.5"
-    marked "^1.2.4"
-    match-all "^1.2.6"
-    moment "^2.29.1"
-    request "^2.88.0"
-    underscore "^1.11.0"
-    url "^0.11.0"
-
-apify-shared@^0.6.0:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/apify-shared/-/apify-shared-0.6.3.tgz#71e5dfedddab63860cdd8a0cacfaedf2ea35437d"
-  integrity sha512-34J5LWt9sjIFP52nPuz9z8IWecxGsuLEhjOxTZII4XRtmMylRecYFmVxVIltV+h7PHNuQzL2LUjjkQ372QvV4Q==
   dependencies:
     axios "^0.21.1"
     chalk "^4.0.0"
@@ -3167,11 +3119,6 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
-arraybuffer.slice@~0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
-  integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
-
 arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -3271,12 +3218,12 @@ axe-core@^4.2.3:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.3.tgz#b55cd8e8ddf659fe89b064680e1c6a4dceab0325"
   integrity sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
 
-axios@^0.21.1:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+axios@>=0.21.1, axios@^0.21.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
   dependencies:
-    follow-redirects "^1.14.0"
+    follow-redirects "^1.14.8"
 
 azure-devops-node-api@^10.2.2:
   version "10.2.2"
@@ -3360,27 +3307,17 @@ babel-preset-jest@^27.5.1:
     babel-plugin-jest-hoist "^27.5.1"
     babel-preset-current-node-syntax "^1.0.0"
 
-backo2@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
-  integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
-
-base64-arraybuffer@0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz#9818c79e059b1355f97e0428a017c838e90ba812"
-  integrity sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=
 
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-base64id@2.0.0:
+base64id@2.0.0, base64id@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-2.0.0.tgz#2770ac6bc47d312af97a8bf9a634342e0cd25cb6"
   integrity sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==
@@ -3419,20 +3356,10 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-blob@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
-  integrity sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
-
 bluebird@^2.9.34:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
   integrity sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=
-
-bluebird@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
-  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 body-parser@1.19.2:
   version "1.19.2"
@@ -3764,7 +3691,7 @@ chokidar@3.5.3, chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chownr@^1.1.1, chownr@^1.1.4:
+chownr@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
@@ -4015,25 +3942,10 @@ compare-func@^2.0.0:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
 
-component-bind@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
-  integrity sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=
-
-component-emitter@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
-  integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
-
 component-emitter@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
-
-component-inherit@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
-  integrity sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=
 
 compress-commons@^1.2.0:
   version "1.2.2"
@@ -4215,6 +4127,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cors@~2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
@@ -4319,15 +4239,10 @@ css-select@~1.2.0:
     domutils "1.5.1"
     nth-check "~1.0.1"
 
-css-what@2.1:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
-  integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
-
-css-what@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.1.0.tgz#3f7b707aadf633baf62c2ceb8579b545bb40f7fe"
-  integrity sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==
+css-what@2.1, css-what@>=5.0.1, css-what@^5.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.0.1.tgz#3be33be55b9f302f710ba3a9c3abc1e2a63fc7eb"
+  integrity sha512-z93ZGFLNc6yaoXAmVhqoSIb+BduplteCt1fepvwhBUQK6MNE4g6fgjpuZKJKp0esUe+vXWlIkwZZjNWoOKw0ZA==
 
 cssom@^0.4.4:
   version "0.4.4"
@@ -4404,19 +4319,12 @@ debug@4, debug@4.3.3, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, de
   dependencies:
     ms "2.1.2"
 
-debug@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+debug@~4.3.2:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
-    ms "2.0.0"
-
-debug@~4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
-  dependencies:
-    ms "^2.1.1"
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -4795,45 +4703,28 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   dependencies:
     once "^1.4.0"
 
-engine.io-client@~3.5.0:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.5.2.tgz#0ef473621294004e9ceebe73cef0af9e36f2f5fa"
-  integrity sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==
+engine.io-parser@~5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.0.3.tgz#ca1f0d7b11e290b4bfda251803baea765ed89c09"
+  integrity sha512-BtQxwF27XUNnSafQLvDi0dQ8s3i6VgzSoQMJacpIcGNrlUdfHSKbgm3jmjCVvQluGzqwujQMPAoMai3oYSTurg==
   dependencies:
-    component-emitter "~1.3.0"
-    component-inherit "0.0.3"
-    debug "~3.1.0"
-    engine.io-parser "~2.2.0"
-    has-cors "1.1.0"
-    indexof "0.0.1"
-    parseqs "0.0.6"
-    parseuri "0.0.6"
-    ws "~7.4.2"
-    xmlhttprequest-ssl "~1.6.2"
-    yeast "0.1.2"
+    "@socket.io/base64-arraybuffer" "~1.0.2"
 
-engine.io-parser@~2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-2.2.1.tgz#57ce5611d9370ee94f99641b589f94c97e4f5da7"
-  integrity sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==
+engine.io@~6.1.0:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.1.3.tgz#f156293d011d99a3df5691ac29d63737c3302e6f"
+  integrity sha512-rqs60YwkvWTLLnfazqgZqLa/aKo+9cueVfEi/dZ8PyGyaf8TLOxj++4QMIgeG3Gn0AhrWiFXvghsoY9L9h25GA==
   dependencies:
-    after "0.8.2"
-    arraybuffer.slice "~0.0.7"
-    base64-arraybuffer "0.1.4"
-    blob "0.0.5"
-    has-binary2 "~1.0.2"
-
-engine.io@~3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-3.5.0.tgz#9d6b985c8a39b1fe87cd91eb014de0552259821b"
-  integrity sha512-21HlvPUKaitDGE4GXNtQ7PLP0Sz4aWLddMPw2VTyFz1FVZqu/kZsJUO8WNpKuE/OCL7nkfRaOui2ZCJloGznGA==
-  dependencies:
+    "@types/cookie" "^0.4.1"
+    "@types/cors" "^2.8.12"
+    "@types/node" ">=10.0.0"
     accepts "~1.3.4"
     base64id "2.0.0"
     cookie "~0.4.1"
-    debug "~4.1.0"
-    engine.io-parser "~2.2.0"
-    ws "~7.4.2"
+    cors "~2.8.5"
+    debug "~4.3.1"
+    engine.io-parser "~5.0.3"
+    ws "~8.2.3"
 
 enhanced-resolve@^5.0.0, enhanced-resolve@^5.9.2:
   version "5.9.2"
@@ -5449,7 +5340,7 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
-follow-redirects@^1.14.0:
+follow-redirects@^1.14.8:
   version "1.14.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
@@ -5566,13 +5457,6 @@ fs-extra@^9.0.0, fs-extra@^9.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^2.0.0"
-
-fs-minipass@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
 
 fs-minipass@^2.0.0, fs-minipass@^2.1.0:
   version "2.1.0"
@@ -5891,18 +5775,6 @@ has-bigints@^1.0.1:
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
   integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
 
-has-binary2@~1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has-binary2/-/has-binary2-1.0.3.tgz#7776ac627f3ea77250cfc332dab7ddf5e4f5d11d"
-  integrity sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==
-  dependencies:
-    isarray "2.0.1"
-
-has-cors@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
-  integrity sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=
-
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -5951,17 +5823,12 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hosted-git-info@^2.1.4:
-  version "2.8.9"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
-  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
-
-hosted-git-info@^4.0.0, hosted-git-info@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz#827b82867e9ff1c8d0c4d9d53880397d2c86d224"
-  integrity sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==
+hosted-git-info@>=3.0.8, hosted-git-info@^2.1.4, hosted-git-info@^4.0.0, hosted-git-info@^4.0.1:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-5.0.0.tgz#df7a06678b4ebd722139786303db80fdf302ea56"
+  integrity sha512-rRnjWu0Bxj+nIfUOkz0695C0H6tRrN5iYIzYejb0tDEefe2AekHu/U5Kn9pEie5vsJqpNQU02az7TGSH3qpz4Q==
   dependencies:
-    lru-cache "^6.0.0"
+    lru-cache "^7.5.1"
 
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
@@ -6060,14 +5927,14 @@ http-response-object@^3.0.1:
   dependencies:
     "@types/node" "^10.0.3"
 
-http-signature@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
-  integrity sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
+http-signature@>=1.3.1, http-signature@~1.2.0:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.3.6.tgz#cb6fbfdf86d1c974f343be94e87f7fc128662cf9"
+  integrity sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==
   dependencies:
     assert-plus "^1.0.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
+    jsprim "^2.0.2"
+    sshpk "^1.14.1"
 
 http2-wrapper@^1.0.0-beta.5.2:
   version "1.0.3"
@@ -6191,11 +6058,6 @@ indent-string@^5.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-5.0.0.tgz#4fd2980fccaf8622d14c64d694f4cf33c81951a5"
   integrity sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==
 
-indexof@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
-  integrity sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
-
 infer-owner@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
@@ -6309,7 +6171,7 @@ is-boolean-object@^1.1.0:
   dependencies:
     call-bind "^1.0.2"
 
-is-buffer@^2.0.3, is-buffer@^2.0.5:
+is-buffer@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
@@ -6516,11 +6378,6 @@ is-weakref@^1.0.1:
   integrity sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==
   dependencies:
     call-bind "^1.0.0"
-
-isarray@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
-  integrity sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -7214,10 +7071,10 @@ jsonparse@^1.2.0, jsonparse@^1.3.1:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-jsprim@^1.2.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
-  integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
+jsprim@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-2.0.2.tgz#77ca23dbcd4135cd364800d22ff82c2185803d4d"
+  integrity sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==
   dependencies:
     assert-plus "1.0.0"
     extsprintf "1.3.0"
@@ -7550,6 +7407,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru-cache@^7.5.1:
+  version "7.7.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.7.3.tgz#98cd19eef89ce6a4a3c4502c17c833888677c252"
+  integrity sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==
+
 luxon@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.0.2.tgz#11f2cd4a11655fdf92e076b5782d7ede5bcdd133"
@@ -7662,17 +7524,7 @@ marked-terminal@^4.2.0:
     node-emoji "^1.10.0"
     supports-hyperlinks "^2.1.0"
 
-marked@^1.2.4:
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.9.tgz#53786f8b05d4c01a2a5a76b7d1ec9943d29d72dc"
-  integrity sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==
-
-marked@^2.0.0:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.3.tgz#bd017cef6431724fd4b27e0657f5ceb14bff3753"
-  integrity sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==
-
-marked@^4.0.12:
+marked@>=2.0.0, marked@^2.0.0, marked@^4.0.12:
   version "4.0.12"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.12.tgz#2262a4e6fd1afd2f13557726238b69a48b982f7d"
   integrity sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==
@@ -7831,7 +7683,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -7883,14 +7735,6 @@ minipass-sized@^1.0.3:
   dependencies:
     minipass "^3.0.0"
 
-minipass@^2.6.0, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
 minipass@^3.0.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
@@ -7904,13 +7748,6 @@ minipass@^3.1.0, minipass@^3.1.1, minipass@^3.1.3:
   integrity sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==
   dependencies:
     yallist "^4.0.0"
-
-minizlib@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
 
 minizlib@^2.0.0, minizlib@^2.1.1:
   version "2.1.2"
@@ -7940,13 +7777,6 @@ mkdirp@^0.5.1:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
-
-mkdirp@^0.5.5:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
-  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
-  dependencies:
-    minimist "^1.2.6"
 
 mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
@@ -8013,7 +7843,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
+ms@2.1.3, ms@^2.0.0:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -8335,19 +8165,12 @@ npmlog@^4.1.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nth-check@^2.0.0:
+nth-check@>=2.0.1, nth-check@^2.0.0, nth-check@~1.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2"
   integrity sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==
   dependencies:
     boolbase "^1.0.0"
-
-nth-check@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
-  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
-  dependencies:
-    boolbase "~1.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -8364,7 +8187,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -8715,16 +8538,6 @@ parse5@^3.0.1:
   integrity sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
   dependencies:
     "@types/node" "*"
-
-parseqs@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.6.tgz#8e4bb5a19d1cdc844a08ac974d34e273afa670d5"
-  integrity sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==
-
-parseuri@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/parseuri/-/parseuri-0.0.6.tgz#e1496e829e3ac2ff47f39a4dd044b32823c4a25a"
-  integrity sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==
 
 parseurl@~1.3.3:
   version "1.3.3"
@@ -9558,7 +9371,7 @@ rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -9681,17 +9494,10 @@ serialize-error@^8.0.1, serialize-error@^8.1.0:
   dependencies:
     type-fest "^0.20.2"
 
-serialize-javascript@6.0.0:
+serialize-javascript@6.0.0, serialize-javascript@>=3.1.0, serialize-javascript@^5.0.1:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
   integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
-  dependencies:
-    randombytes "^2.1.0"
-
-serialize-javascript@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
-  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
   dependencies:
     randombytes "^2.1.0"
 
@@ -9826,39 +9632,17 @@ slide@^1.1.6:
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
   integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
 
-slugg@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/slugg/-/slugg-1.2.1.tgz#e752af2241af3f2714463c5de225cea47608740a"
-  integrity sha1-51KvIkGvPycURjxd4iXOpHYIdAo=
-
 smart-buffer@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-socket.io-adapter@~1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz#ab3f0d6f66b8fc7fca3959ab5991f82221789be9"
-  integrity sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g==
+socket.io-adapter@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz#4d6111e4d42e9f7646e365b4f578269821f13486"
+  integrity sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==
 
-socket.io-client@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.4.0.tgz#aafb5d594a3c55a34355562fc8aea22ed9119a35"
-  integrity sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==
-  dependencies:
-    backo2 "1.0.2"
-    component-bind "1.0.0"
-    component-emitter "~1.3.0"
-    debug "~3.1.0"
-    engine.io-client "~3.5.0"
-    has-binary2 "~1.0.2"
-    indexof "0.0.1"
-    parseqs "0.0.6"
-    parseuri "0.0.6"
-    socket.io-parser "~3.3.0"
-    to-array "0.1.4"
-
-socket.io-parser@*:
+socket.io-parser@*, socket.io-parser@~4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.0.4.tgz#9ea21b0d61508d18196ef04a2c6b9ab630f4c2b0"
   integrity sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==
@@ -9867,35 +9651,17 @@ socket.io-parser@*:
     component-emitter "~1.3.0"
     debug "~4.3.1"
 
-socket.io-parser@~3.3.0:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.2.tgz#ef872009d0adcf704f2fbe830191a14752ad50b6"
-  integrity sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==
+socket.io@>=2.4.0, socket.io@^2.3.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.4.1.tgz#cd6de29e277a161d176832bb24f64ee045c56ab8"
+  integrity sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==
   dependencies:
-    component-emitter "~1.3.0"
-    debug "~3.1.0"
-    isarray "2.0.1"
-
-socket.io-parser@~3.4.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.4.1.tgz#b06af838302975837eab2dc980037da24054d64a"
-  integrity sha512-11hMgzL+WCLWf1uFtHSNvliI++tcRUWdoeYuwIl+Axvwy9z2gQM+7nJyN3STj1tLj5JyIUH8/gpDGxzAlDdi0A==
-  dependencies:
-    component-emitter "1.2.1"
-    debug "~4.1.0"
-    isarray "2.0.1"
-
-socket.io@^2.3.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-2.4.1.tgz#95ad861c9a52369d7f1a68acf0d4a1b16da451d2"
-  integrity sha512-Si18v0mMXGAqLqCVpTxBa8MGqriHGQh8ccEOhmsmNS3thNCGBwO8WGrwMibANsWtQQ5NStdZwHqZR3naJVFc3w==
-  dependencies:
-    debug "~4.1.0"
-    engine.io "~3.5.0"
-    has-binary2 "~1.0.2"
-    socket.io-adapter "~1.1.0"
-    socket.io-client "2.4.0"
-    socket.io-parser "~3.4.0"
+    accepts "~1.3.4"
+    base64id "~2.0.0"
+    debug "~4.3.2"
+    engine.io "~6.1.0"
+    socket.io-adapter "~2.3.3"
+    socket.io-parser "~4.0.4"
 
 socks-proxy-agent@^5.0.0:
   version "5.0.1"
@@ -10017,7 +9783,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sshpk@^1.7.0:
+sshpk@^1.14.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.17.0.tgz#578082d92d4fe612b13007496e543fa0fbcbe4c5"
   integrity sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==
@@ -10367,20 +10133,7 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^4.4.12:
-  version "4.4.19"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.19.tgz#2e4d7263df26f2b914dee10c825ab132123742f3"
-  integrity sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==
-  dependencies:
-    chownr "^1.1.4"
-    fs-minipass "^1.2.7"
-    minipass "^2.9.0"
-    minizlib "^1.3.3"
-    mkdirp "^0.5.5"
-    safe-buffer "^5.2.1"
-    yallist "^3.1.1"
-
-tar@^6.0.2, tar@^6.1.0:
+tar@>=6.1.9, tar@^4.4.12, tar@^6.0.2, tar@^6.1.0:
   version "6.1.11"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
   integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
@@ -10563,11 +10316,6 @@ tmpl@1.0.x:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
   integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
-
-to-array@0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
-  integrity sha1-F+bBH3PdTz10zaek/zI46a2b+JA=
 
 to-buffer@^1.1.1:
   version "1.1.1"
@@ -10839,12 +10587,7 @@ unbzip2-stream@^1.3.3:
     buffer "^5.2.1"
     through "^2.3.8"
 
-underscore@1.12.1:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
-  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
-
-underscore@^1.11.0, underscore@^1.12.1, underscore@^1.9.1:
+underscore@1.12.1, underscore@>=1.12.1, underscore@^1.11.0, underscore@^1.12.1, underscore@^1.9.1:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.2.tgz#276cea1e8b9722a8dbed0100a407dda572125881"
   integrity sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==
@@ -10989,7 +10732,7 @@ validator@^13.7.0:
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
   integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
@@ -11307,10 +11050,15 @@ write-pkg@^4.0.0:
     type-fest "^0.4.1"
     write-json-file "^3.2.0"
 
-ws@^7.2.3, ws@^7.3.0, ws@^7.4.5, ws@~7.4.2:
+ws@^7.2.3, ws@^7.3.0, ws@^7.4.5:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@~8.2.3:
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.3.tgz#63a56456db1b04367d0b721a0b80cae6d8becbba"
+  integrity sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==
 
 wtfnode@^0.9.0:
   version "0.9.1"
@@ -11345,22 +11093,12 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmlhttprequest-ssl@~1.6.2:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz#03b713873b01659dfa2c1c5d056065b27ddc2de6"
-  integrity sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==
-
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-y18n@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
-  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
-
-y18n@^5.0.5:
+y18n@>=5.0.5, y18n@^4.0.0, y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
@@ -11369,11 +11107,6 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
-
-yallist@^3.0.0, yallist@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
-  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yallist@^4.0.0:
   version "4.0.0"
@@ -11467,11 +11200,6 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
-
-yeast@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
-  integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
 
 yocto-queue@^0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1543,54 +1543,6 @@
   resolved "https://registry.yarnpkg.com/@medv/finder/-/finder-2.1.0.tgz#5c53cdaac3b87057b9e5579ca1282b2397624016"
   integrity sha512-Egrg5XO4kLol24b1Kv50HDfi5hW0yQ6aWSsO0Hea1eJ4rogKElIN0M86FdVnGF4XIGYyA7QWx0MgbOzVPA0qkA==
 
-"@microsoft/applicationinsights-channel-js@2.7.4":
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.7.4.tgz#3174eb0eed3438fb57d970dc5b6f3cccefdb0349"
-  integrity sha512-pcKn2fbF+hDbmWITsE8aN07FVRVZn/NxAUKbouudG6QWNvSNSpMuep88yxlU8mSP2imWjuXIFP6NuGNOEXec8w==
-  dependencies:
-    "@microsoft/applicationinsights-common" "2.7.4"
-    "@microsoft/applicationinsights-core-js" "2.7.4"
-    "@microsoft/applicationinsights-shims" "2.0.1"
-    "@microsoft/dynamicproto-js" "^1.1.4"
-
-"@microsoft/applicationinsights-common@2.7.4":
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-common/-/applicationinsights-common-2.7.4.tgz#eb30d1e53b9bfe1f8d45b43d7a5528a0dc6f2b02"
-  integrity sha512-tLcU9AHTescd09/EZ4uXoEVCOCMjkTgzblc7lZECOU7mm51VQrDCdlYQ3Br9lnNnyOrFw0+f3o+O9ock55I05g==
-  dependencies:
-    "@microsoft/applicationinsights-core-js" "2.7.4"
-    "@microsoft/applicationinsights-shims" "2.0.1"
-    "@microsoft/dynamicproto-js" "^1.1.4"
-
-"@microsoft/applicationinsights-core-js@2.7.4":
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.7.4.tgz#9271fadf01863b3f28bfc45aaa630229ee28a0f4"
-  integrity sha512-PlJ/ITQjvDhirdo7CSloSx5UTDntou9MF+nYgc+W/wM9vPYnz3gFfiuY59L30si3C3zSBMmUTLuDnXRvgLGRAw==
-  dependencies:
-    "@microsoft/applicationinsights-shims" "2.0.1"
-    "@microsoft/dynamicproto-js" "^1.1.4"
-
-"@microsoft/applicationinsights-shims@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.1.tgz#5d72fb7aaf4056c4fda54f9d7c93ccf8ca9bcbfd"
-  integrity sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ==
-
-"@microsoft/applicationinsights-web-basic@^2.7.4":
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-2.7.4.tgz#796555211005f5d0012ab2ec776547e6b9f21617"
-  integrity sha512-jTQ7fSI3vhnVIl/R+AwHvv8i/NFY3ooEwKfIIrP8wqno3W7q/rceHHpY+rez+z0uoibRmYajUtC55SA66JnW0w==
-  dependencies:
-    "@microsoft/applicationinsights-channel-js" "2.7.4"
-    "@microsoft/applicationinsights-common" "2.7.4"
-    "@microsoft/applicationinsights-core-js" "2.7.4"
-    "@microsoft/applicationinsights-shims" "2.0.1"
-    "@microsoft/dynamicproto-js" "^1.1.4"
-
-"@microsoft/dynamicproto-js@^1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.4.tgz#40e1c0ad20743fcee1604a7df2c57faf0aa1af87"
-  integrity sha512-Ot53G927ykMF8cQ3/zq4foZtdk+Tt1YpX7aUTHxBU7UHNdkEiBvBfZSq+rnlUmKCJ19VatwPG4mNzvcGpBj4og==
-
 "@microsoft/load-themed-styles@^1.10.26":
   version "1.10.225"
   resolved "https://registry.yarnpkg.com/@microsoft/load-themed-styles/-/load-themed-styles-1.10.225.tgz#5cd8657725201e5d9760bf5ded27cac88fb2d8a5"
@@ -2988,6 +2940,21 @@ applicationinsights@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-2.2.1.tgz#89d509b26a4f9dce6e3351da73061c986565d1b0"
   integrity sha512-N6panMyjw6E6ayCgjFDBmL/NkaolgBgeX1iJ0jh50E6wrncVJBCa+I4IelwwOfJ4Dl9BWzOSLjp84wTiUyhNwg==
+  dependencies:
+    "@azure/core-http" "^2.2.3"
+    "@opentelemetry/api" "^1.0.4"
+    "@opentelemetry/core" "^1.0.1"
+    "@opentelemetry/sdk-trace-base" "^1.0.1"
+    "@opentelemetry/semantic-conventions" "^1.0.1"
+    cls-hooked "^4.2.2"
+    continuation-local-storage "^3.2.1"
+    diagnostic-channel "1.1.0"
+    diagnostic-channel-publishers "1.0.4"
+
+applicationinsights@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-2.2.2.tgz#6e9f65aa3dc72a734c6f58dcac3182a517accdc3"
+  integrity sha512-X6cNOoTNJKSki8/U+eI1yqKbP7HtM1qIMcJtYp0E5rCllaYKYfN6w4gKARWuHLMQrzgiQoAfNTyZU8hVbIao1w==
   dependencies:
     "@azure/core-http" "^2.2.3"
     "@opentelemetry/api" "^1.0.4"


### PR DESCRIPTION
#### Details

This PR creates an initial implementation of App Insights telemetry based on the `AdoExtensionMetadata` added in #1107. The major pieces are:

* The `shared` package contains a `TelemetryClient` interface which can track `TelemetryEvent`s. It contains a `NullTelemetryClient` which no-ops telemetry events by default. The GitHub Action does not override this behavior, so it always no-ops telemetry.
* The `shared` `scanner.ts` implementation is updated to send a single `ScanStart` event with no properties. A future PR will add a `ScanEnd` event that includes properties about number of failures/baselining state/etc
* The `ado-extension` adds a reference to the `accessibilityinsights` package and implements an `AppInsightsTelemetryClient` based on it. I have set up the client such that it omits all autocollected data not requested by the feature spec, and to include as `commonProperties` all ADO environment properties requested by the spec, plus some data from the `AdoExtensionMetadata` so we can distinguish which environment telemetry is coming from
* The `ado-extension` adds a `TelemetryClientFactory` which decides whether to use an `AppInsightsTelemetryClient` or a `NullTelemetryClient` based on the presence of an `appInsightsConnectionString` property in the release environment's metadata. The intention is that it will only use App Insights telemetry in release environments whose ADO release variable groups explicitly contain an app insights connection string; this should be omitted in any future public releases.
* I've updated the `run-locally.js` tool to support the new `AdoExtensionMetadata` stuff - this can be used for testing telemetry locally.

I've used the run-locally support to validate that telemetry makes its way to our new dev app insights instance; team members should have permissions to view the dev app insights instance already and can find instructions by looking up `a11y-insights-action-dev-telemetry-app-insights` in our team OneNote.

##### Motivation

Feature work (feature 1893588 / story 1930551)

##### Context

Out of scope: a future PR will be finalizing the specific data (# failures, baseline info, etc) that we log from the scanner

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: story 1930551
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
