### PR TITLE
feat(ado-ext-telemetry): add telemetry sender progress reporter

### DIFF
--- a/packages/ado-extension/scripts/local-ado-extension-metadata.json
+++ b/packages/ado-extension/scripts/local-ado-extension-metadata.json
@@ -4,5 +4,5 @@
     "extensionName": "Local dev build (run-locally.js)",
     "extensionVersion": "0.0.0",
     "environment": "dev",
-    "appInsightsConnectionString": ""
+    "appInsightsConnectionString": "testAppInsightsConnectionString"
 }

--- a/packages/ado-extension/src/ioc/setup-ioc-container.spec.ts
+++ b/packages/ado-extension/src/ioc/setup-ioc-container.spec.ts
@@ -27,6 +27,7 @@ describe(setupIocContainer, () => {
     );
 
     test('verify progress reporter resolution', () => {
+        testSubject.bind(TelemetryClientFactory).to(StubTelemetryClientFactory);
         verifySingletonDependencyResolution(testSubject, iocTypes.ProgressReporters);
     });
 

--- a/packages/ado-extension/src/ioc/setup-ioc-container.ts
+++ b/packages/ado-extension/src/ioc/setup-ioc-container.ts
@@ -12,6 +12,7 @@ import { ADOArtifactsInfoProvider } from '../ado-artifacts-info-provider';
 import { WorkflowEnforcer } from '../progress-reporter/enforcement/workflow-enforcer';
 import { AdoConsoleCommentCreator } from '../progress-reporter/console/ado-console-comment-creator';
 import { TelemetryClientFactory } from '../telemetry/telemetry-client-factory';
+import { TelemetrySender } from '../progress-reporter/telemetry/telemetry-sender';
 
 export function setupIocContainer(container = new inversify.Container({ autoBindInjectable: true })): inversify.Container {
     container = setupSharedIocContainer(container);
@@ -21,10 +22,15 @@ export function setupIocContainer(container = new inversify.Container({ autoBind
     container.bind(iocTypes.TaskConfig).to(ADOTaskConfig).inSingletonScope();
     container.bind(AdoConsoleCommentCreator).toSelf().inSingletonScope();
     container.bind(WorkflowEnforcer).toSelf().inSingletonScope();
+    container.bind(TelemetrySender).toSelf().inSingletonScope();
     container
         .bind(iocTypes.ProgressReporters)
         .toDynamicValue((context) => {
-            return [context.container.get(AdoConsoleCommentCreator), context.container.get(WorkflowEnforcer)];
+            return [
+                context.container.get(AdoConsoleCommentCreator),
+                context.container.get(TelemetrySender),
+                context.container.get(WorkflowEnforcer),
+            ];
         })
         .inSingletonScope();
     container.bind(iocTypes.ArtifactsInfoProvider).to(ADOArtifactsInfoProvider).inSingletonScope();

--- a/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.spec.ts
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { Mock, IMock, MockBehavior, It, Times } from 'typemoq';
+import { ADOTaskConfig } from '../../task-config/ado-task-config';
+import { CombinedReportParameters, HowToFixData, AxeRuleData, FailuresGroup } from 'accessibility-insights-report';
+import { BaselineEvaluation, BaselineFileContent } from 'accessibility-insights-scan';
+import { TelemetrySender } from './telemetry-sender';
+import { TelemetryClient } from '@accessibility-insights-action/shared';
+
+describe(TelemetrySender, () => {
+    let adoTaskConfigMock: IMock<ADOTaskConfig>;
+    let telemetryClientMock: IMock<TelemetryClient>;
+    let telemetrySender: TelemetrySender;
+
+    beforeEach(() => {
+        adoTaskConfigMock = Mock.ofType<ADOTaskConfig>(undefined, MockBehavior.Strict);
+        telemetryClientMock = Mock.ofType<TelemetryClient>(undefined, MockBehavior.Strict);
+
+        adoTaskConfigMock.setup((x) => x.getTeamProject()).returns(() => 'test-team-project');
+        adoTaskConfigMock.setup((x) => x.getRunId()).returns(() => 7);
+
+        telemetryClientMock.setup((x) => x.trackEvent(It.isAny())).verifiable(Times.once());
+    });
+
+    describe('constructor', () => {
+        it('initializes', () => {
+            telemetrySender = buildTelemetrySenderWithMocks();
+
+            verifyAllMocks();
+        });
+    });
+
+    describe('completeRun', () => {
+        it('logs correct error if accessibility error occurred', async () => {
+            const reportStub = {
+                results: {
+                    resultsByRule: {
+                        failed: [makeFailuresGroup('failed-rule-1'), makeFailuresGroup('failed-rule-2')],
+                    },
+                },
+            } as unknown as CombinedReportParameters;
+            const baselineEvaluationStub = {} as BaselineEvaluation;
+
+            const telemetrySender = buildTelemetrySenderWithMocks();
+
+            await telemetrySender.completeRun(reportStub, baselineEvaluationStub);
+
+            verifyAllMocks();
+        });
+
+        it('logs correct error if baseline needs to be updated', async () => {
+            const reportStub = {} as CombinedReportParameters;
+            const baselineEvaluationStub = {
+                suggestedBaselineUpdate: {} as BaselineFileContent,
+            } as BaselineEvaluation;
+
+            const telemetrySender = buildTelemetrySenderWithMocks();
+
+            await telemetrySender.completeRun(reportStub, baselineEvaluationStub);
+
+            verifyAllMocks();
+        });
+
+        it('succeeds in happy path (baseline enabled)', async () => {
+            const reportStub = {} as CombinedReportParameters;
+            const baselineEvaluationStub = {} as BaselineEvaluation;
+
+            const telemetrySender = buildTelemetrySenderWithMocks();
+
+            await telemetrySender.completeRun(reportStub, baselineEvaluationStub);
+
+            verifyAllMocks();
+        });
+
+        it('succeeds in happy path (baselineEvaluation not provided)', async () => {
+            const reportStub = {} as CombinedReportParameters;
+            telemetrySender = buildTelemetrySenderWithMocks();
+            await telemetrySender.completeRun(reportStub);
+
+            verifyAllMocks();
+        });
+
+        function makeFailuresGroup(ruleId: string): FailuresGroup {
+            return {
+                key: ruleId,
+                failed: [
+                    {
+                        rule: makeRule(ruleId),
+                        elementSelector: `.${ruleId}-selector-1`,
+                        fix: makeHowToFixData(ruleId, 1),
+                        snippet: `<div>snippet 1</div>`,
+                        urls: [`https://example.com/${ruleId}/only-violation`],
+                    },
+                    {
+                        rule: makeRule(ruleId),
+                        elementSelector: `.${ruleId}-selector-2`,
+                        fix: makeHowToFixData(ruleId, 2),
+                        snippet: `<div>snippet 2</div>`,
+                        urls: [
+                            `https://example.com/${ruleId}/violations/1`,
+                            `https://example.com/${ruleId}/violations/2`,
+                            `https://example.com/${ruleId}/violations/3`,
+                        ],
+                    },
+                ],
+            };
+        }
+
+        function makeHowToFixData(ruleId: string, failureId: number): HowToFixData {
+            return {
+                any: [],
+                all: [],
+                none: [],
+                failureSummary: `Violation ${failureId} of rule ${ruleId}`,
+            };
+        }
+
+        function makeRule(ruleId: string): AxeRuleData {
+            return {
+                ruleId,
+                description: `${ruleId} description`,
+                ruleUrl: `https://example.com/rules/${ruleId}`,
+                tags: ['common-tag', `${ruleId}-specific-tag`],
+            };
+        }
+    });
+
+    const buildTelemetrySenderWithMocks = () => new TelemetrySender(adoTaskConfigMock.object, telemetryClientMock.object);
+
+    const verifyAllMocks = () => {
+        adoTaskConfigMock.verifyAll();
+        telemetryClientMock.verifyAll();
+    };
+});

--- a/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.spec.ts
@@ -13,23 +13,12 @@ describe(TelemetrySender, () => {
     let adoTaskConfigMock: IMock<ADOTaskConfig>;
     let telemetryClientMock: IMock<TelemetryClient>;
     let telemetrySender: TelemetrySender;
-    const teamProjectIdentifier = 'test-team-project';
-    const runId = 7;
     const baselineFailuresFixed = 3;
     const baselineNewFailures = 1;
 
     beforeEach(() => {
         adoTaskConfigMock = Mock.ofType<ADOTaskConfig>(undefined, MockBehavior.Strict);
         telemetryClientMock = Mock.ofType<TelemetryClient>(undefined, MockBehavior.Strict);
-
-        adoTaskConfigMock
-            .setup((x) => x.getTeamProject())
-            .returns(() => teamProjectIdentifier)
-            .verifiable(Times.once());
-        adoTaskConfigMock
-            .setup((x) => x.getRunId())
-            .returns(() => runId)
-            .verifiable(Times.once());
     });
 
     describe('constructor', () => {
@@ -122,8 +111,6 @@ describe(TelemetrySender, () => {
         function setupTelemetryClientWithEvent(generateWithBaselineEnabled: boolean): void {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const eventProperties: { [key: string]: any } = {};
-            eventProperties.teamProject = teamProjectIdentifier;
-            eventProperties.runId = runId;
 
             eventProperties.rulesFailedListWithCounts = [
                 { ruleId: 'failed-rule-1', failureCount: 4 },

--- a/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import { Mock, IMock, MockBehavior, It, Times } from 'typemoq';
+import { Mock, IMock, MockBehavior, Times } from 'typemoq';
 import { ADOTaskConfig } from '../../task-config/ado-task-config';
 import { CombinedReportParameters, HowToFixData, AxeRuleData, FailuresGroup } from 'accessibility-insights-report';
 import { BaselineEvaluation } from 'accessibility-insights-scan';

--- a/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.ts
+++ b/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.ts
@@ -27,7 +27,7 @@ export class TelemetrySender extends ProgressReporter {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const eventProperties: { [key: string]: any } = {};
         eventProperties.teamProject = this.adoTaskConfig.getTeamProject() ?? '';
-        eventProperties.runId = this.adoTaskConfig.getRunId()?.toString() ?? '';
+        eventProperties.runId = this.adoTaskConfig.getRunId() ?? '';
 
         eventProperties.rulesFailedListWithCounts = combinedReportResult.results.resultsByRule.failed.map((failuresGroup) => {
             const failureCount = failuresGroup.failed.reduce((a, b) => a + (b.urls ? b.urls.length : 0), 0);
@@ -44,7 +44,7 @@ export class TelemetrySender extends ProgressReporter {
         }
 
         this.telemetryClient.trackEvent({
-            name: 'ScanStart',
+            name: 'ScanCompleted',
             properties: eventProperties,
         } as TelemetryEvent);
     }

--- a/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.ts
+++ b/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ADOTaskConfig } from '../../task-config/ado-task-config';
+import { inject, injectable } from 'inversify';
+import { iocTypes, ProgressReporter, TelemetryClient, TelemetryEvent } from '@accessibility-insights-action/shared';
+import { CombinedReportParameters } from 'accessibility-insights-report';
+import { BaselineEvaluation } from 'accessibility-insights-scan';
+
+@injectable()
+export class TelemetrySender extends ProgressReporter {
+    private scanSucceeded = true;
+
+    constructor(
+        @inject(ADOTaskConfig) private readonly adoTaskConfig: ADOTaskConfig,
+        @inject(iocTypes.TelemetryClient) private readonly telemetryClient: TelemetryClient,
+    ) {
+        super();
+    }
+
+    public async start(): Promise<void> {
+        // We don't send anything for telemetry
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public async completeRun(combinedReportResult: CombinedReportParameters, baselineEvaluation?: BaselineEvaluation): Promise<void> {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const eventProperties: { [key: string]: any } = {};
+        eventProperties.teamProject = this.adoTaskConfig.getTeamProject() ?? '';
+        eventProperties.runId = this.adoTaskConfig.getRunId()?.toString() ?? '';
+
+        eventProperties.rulesFailedListWithCounts = combinedReportResult.results.resultsByRule.failed.map((failuresGroup) => {
+            const failureCount = failuresGroup.failed.reduce((a, b) => a + (b.urls ? b.urls.length : 0), 0);
+            const ruleId = failuresGroup.failed[0].rule.ruleId;
+            return { ruleId, failureCount };
+        });
+
+        eventProperties.baselineIsEnabled = false;
+
+        if (baselineEvaluation !== undefined) {
+            eventProperties.baselineIsEnabled = true;
+            eventProperties.baselineFailuresFixed = baselineEvaluation.totalFixedViolations;
+            eventProperties.baselineNewFailures = baselineEvaluation.totalNewViolations;
+        }
+
+        this.telemetryClient.trackEvent({
+            name: 'ScanStart',
+            properties: eventProperties,
+        } as TelemetryEvent);
+    }
+
+    public async failRun(): Promise<void> {
+        // We don't send anything for failed runs
+    }
+
+    public didScanSucceed(): Promise<boolean> {
+        return Promise.resolve(this.scanSucceeded);
+    }
+}

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -130,6 +130,9 @@ export class ADOTaskConfig extends TaskConfig {
         return this.adoTaskObj.getBoolInput('uploadResultAsArtifact');
     }
 
+    // This allows us to pull in predefined Azure Pipelines variables listed here:
+    // https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+    // Note, these variables are not case-sensitive.
     public getVariable(definedVariableName: string): string | undefined {
         return this.adoTaskObj.getVariable(definedVariableName);
     }

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
@@ -48,13 +48,10 @@ export class AppInsightsTelemetryClient implements TelemetryClient {
 
     public trackEvent(event: TelemetryEvent): void {
         this.logger.logDebug(`[Telemetry] tracking a '${event.name}' event`);
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        this.logger.logInfo(JSON.stringify(event.properties));
         this.underlyingClient.trackEvent(event);
     }
 
     public async flush(): Promise<void> {
-        this.logger.logInfo(`[Telemetry] flushing telemetry`);
         await new Promise<void>((resolve) => {
             this.underlyingClient.flush({
                 callback: () => resolve(),

--- a/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
+++ b/packages/ado-extension/src/telemetry/app-insights-telemetry-client.ts
@@ -48,11 +48,13 @@ export class AppInsightsTelemetryClient implements TelemetryClient {
 
     public trackEvent(event: TelemetryEvent): void {
         this.logger.logDebug(`[Telemetry] tracking a '${event.name}' event`);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        this.logger.logInfo(JSON.stringify(event.properties));
         this.underlyingClient.trackEvent(event);
     }
 
     public async flush(): Promise<void> {
-        this.logger.logDebug(`[Telemetry] flushing telemetry`);
+        this.logger.logInfo(`[Telemetry] flushing telemetry`);
         await new Promise<void>((resolve) => {
             this.underlyingClient.flush({
                 callback: () => resolve(),

--- a/packages/shared/src/scanner/scanner.spec.ts
+++ b/packages/shared/src/scanner/scanner.spec.ts
@@ -206,9 +206,11 @@ describe(Scanner, () => {
                 .verifiable(Times.once());
 
             fsMock
+                // eslint-disable-next-line security/detect-non-literal-fs-filename
                 .setup((fsm) => fsm.existsSync(reportOutDir))
                 .returns(() => false)
                 .verifiable();
+            // eslint-disable-next-line security/detect-non-literal-fs-filename
             fsMock.setup((fsm) => fsm.mkdirSync(reportOutDir)).verifiable();
 
             const crawlerParams: CrawlerRunOptions = {

--- a/packages/shared/src/telemetry/telemetry-event.ts
+++ b/packages/shared/src/telemetry/telemetry-event.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export type TelemetryEventName = 'ScanStart';
+export type TelemetryEventName = 'ScanStart' | 'ScanCompleted';
 
 export type TelemetryEvent = {
     name: TelemetryEventName;

--- a/packages/shared/src/telemetry/telemetry-event.ts
+++ b/packages/shared/src/telemetry/telemetry-event.ts
@@ -5,5 +5,6 @@ export type TelemetryEventName = 'ScanStart';
 
 export type TelemetryEvent = {
     name: TelemetryEventName;
-    properties?: { [key: string]: string };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    properties?: { [key: string]: any };
 };


### PR DESCRIPTION
#### Details

This introduces a new progress reporter in the ADO Extension that collects the relevant data points and tracks the event via the `TelemetryClient`. This also changes `TelemetryEvent.properties` to accept property values of `any` type instead of strictly `string`. This makes it easier for us to pass data of all kinds. I verified that this is supported by the ApplicationInsights API based off the documentation found here: https://docs.microsoft.com/en-us/azure/azure-monitor/app/api-custom-events-metrics#properties

##### Motivation

Feature work

##### Context

We considered putting this logic in `scanner.ts` in the `shared` package, but it seemed like it would be the wrong abstraction as the data points needed and where to get them will likely differ between the Github Action and the ADO Extension. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
