### PR TITLE
feat(ado-ext-telemetry): update staging validation pipeline with v2 changes

### DIFF
--- a/pipelines/ado-extension-staging-validation.yaml
+++ b/pipelines/ado-extension-staging-validation.yaml
@@ -49,21 +49,21 @@ steps:
       inputs:
           staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
           failOnAccessibilityError: false
-          artifactName: accessibility-reports-case-2
+          outputArtifactName: accessibility-reports-case-2
       condition: succeededOrFailed()
 
     - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should fail] case 3: url, no baseline'
       inputs:
           url: 'http://localhost:5858'
-          artifactName: 'accessibility-reports-case-3'
+          outputArtifactName: 'accessibility-reports-case-3'
       condition: succeededOrFailed()
 
     - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should succeed] case 4: up-to-date baseline'
       inputs:
           url: 'http://localhost:5858'
-          artifactName: 'accessibility-reports-case-4'
+          outputArtifactName: 'accessibility-reports-case-4'
           baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/up-to-date-5858.baseline'
       condition: succeededOrFailed()
 
@@ -71,7 +71,7 @@ steps:
       displayName: '[should fail] case 5: baseline missing failures'
       inputs:
           url: 'http://localhost:5858'
-          artifactName: 'accessibility-reports-case-5'
+          outputArtifactName: 'accessibility-reports-case-5'
           baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/missing-failures-5858.baseline'
       condition: succeededOrFailed()
       continueOnError: true
@@ -80,7 +80,7 @@ steps:
       displayName: '[should fail] case 6: baseline with resolved failures'
       inputs:
           url: 'http://localhost:5858'
-          artifactName: 'accessibility-reports-case-6'
+          outputArtifactName: 'accessibility-reports-case-6'
           baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/with-resolved-failures-5858.baseline'
       condition: succeededOrFailed()
       continueOnError: true
@@ -89,7 +89,7 @@ steps:
       displayName: '[should fail] case 7: new baseline file'
       inputs:
           staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
-          artifactName: 'accessibility-reports-case-7'
+          outputArtifactName: 'accessibility-reports-case-7'
           baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/doesnt-exist.baseline'
       condition: succeededOrFailed()
       continueOnError: true
@@ -98,7 +98,7 @@ steps:
       displayName: '[should fail] case 8: url, custom artifact upload step'
       inputs:
           url: 'http://localhost:5858'
-          uploadResultAsArtifact: false
+          uploadOutputArtifact: false
           outputDir: '_accessibility-reports-case-8'
       condition: succeededOrFailed()
 
@@ -110,7 +110,7 @@ steps:
     - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should fail] case 9: invalid inputs (no site specified)'
       inputs:
-          artifactName: 'accessibility-reports-case-9'
+          outputArtifactName: 'accessibility-reports-case-9'
       condition: succeededOrFailed()
 
     - task: accessibility-insights.staging.task.accessibility-insights@2
@@ -118,7 +118,7 @@ steps:
       inputs:
           url: 'http://localhost:5858'
           staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
-          artifactName: 'accessibility-reports-case-10'
+          outputArtifactName: 'accessibility-reports-case-10'
       condition: succeededOrFailed()
 
     - task: accessibility-insights.staging.task.accessibility-insights@2

--- a/pipelines/ado-extension-staging-validation.yaml
+++ b/pipelines/ado-extension-staging-validation.yaml
@@ -38,94 +38,93 @@ steps:
       displayName: 'Start /dev/website-root test server at http://localhost:5858'
 
     - task: accessibility-insights.staging.task.accessibility-insights@2
-      displayName: '[should succeed] case 1: staticSiteDir, no baseline'
+      displayName: '[should fail] case 1: staticSiteDir, no baseline'
       inputs:
           staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
-          # intentionally omits outputDir; should go to default _accessibility-reports
-      condition: succeededOrFailed()
-
-    - publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports'
-      displayName: 'case 1: upload report artifact'
-      artifact: 'accessibility-reports-case-1'
+          # intentionally omits artifactName; should go to default accessibility-reports
       condition: succeededOrFailed()
 
     - task: accessibility-insights.staging.task.accessibility-insights@2
-      displayName: '[should succeed] case 2: url, no baseline'
+      displayName: '[should succeed] case 2: staticSiteDir, no baseline, failOnAccessibilityError:false'
       inputs:
-          url: 'http://localhost:5858'
-          outputDir: '_accessibility-reports-case-2'
-      condition: succeededOrFailed()
-
-    - publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-2'
-      displayName: 'case 2: upload report artifact'
-      artifact: 'accessibility-reports-case-2'
+          staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
+          failOnAccessibilityError: false
+          artifactName: accessibility-reports-case-2
       condition: succeededOrFailed()
 
     - task: accessibility-insights.staging.task.accessibility-insights@2
-      displayName: '[should succeed] case 3: up-to-date baseline'
+      displayName: '[should fail] case 3: url, no baseline'
       inputs:
           url: 'http://localhost:5858'
-          outputDir: '_accessibility-reports-case-3'
+          artifactName: 'accessibility-reports-case-3'
+      condition: succeededOrFailed()
+
+    - task: accessibility-insights.staging.task.accessibility-insights@2
+      displayName: '[should succeed] case 4: up-to-date baseline'
+      inputs:
+          url: 'http://localhost:5858'
+          artifactName: 'accessibility-reports-case-4'
           baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/up-to-date-5858.baseline'
       condition: succeededOrFailed()
 
-    - publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-3'
-      displayName: 'case 3: upload report artifact'
-      artifact: 'accessibility-reports-case-3'
-      condition: succeededOrFailed()
-
     - task: accessibility-insights.staging.task.accessibility-insights@2
-      displayName: '[should fail] case 4: baseline missing failures'
+      displayName: '[should fail] case 5: baseline missing failures'
       inputs:
           url: 'http://localhost:5858'
-          outputDir: '_accessibility-reports-case-4'
+          artifactName: 'accessibility-reports-case-5'
           baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/missing-failures-5858.baseline'
       condition: succeededOrFailed()
       continueOnError: true
 
-    - publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-4'
-      displayName: 'case 4: upload report artifact'
-      artifact: 'accessibility-reports-case-4'
-      condition: succeededOrFailed()
-
     - task: accessibility-insights.staging.task.accessibility-insights@2
-      displayName: '[should fail] case 5: baseline with resolved failures'
+      displayName: '[should fail] case 6: baseline with resolved failures'
       inputs:
           url: 'http://localhost:5858'
-          outputDir: '_accessibility-reports-case-5'
+          artifactName: 'accessibility-reports-case-6'
           baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/with-resolved-failures-5858.baseline'
       condition: succeededOrFailed()
       continueOnError: true
 
-    - publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-5'
-      displayName: 'case 5: upload report artifact'
-      artifact: 'accessibility-reports-case-5'
-      condition: succeededOrFailed()
-
     - task: accessibility-insights.staging.task.accessibility-insights@2
-      displayName: '[should fail] case 6: new baseline file'
+      displayName: '[should fail] case 7: new baseline file'
       inputs:
           staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
-          outputDir: '_accessibility-reports-case-6'
+          artifactName: 'accessibility-reports-case-7'
           baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/doesnt-exist.baseline'
       condition: succeededOrFailed()
       continueOnError: true
 
-    - publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-6'
-      displayName: 'case 6: upload report artifact'
-      artifact: 'accessibility-reports-case-6'
+    - task: accessibility-insights.staging.task.accessibility-insights@2
+      displayName: '[should fail] case 8: url, custom artifact upload step'
+      inputs:
+          url: 'http://localhost:5858'
+          uploadReportAsArtifact: false
+          outputDir: '_accessibility-reports-case-8'
+      condition: succeededOrFailed()
+
+    - publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-8'
+      displayName: 'custom report artifact upload for case 8'
+      artifact: 'accessibility-reports-case-8'
       condition: succeededOrFailed()
 
     - task: accessibility-insights.staging.task.accessibility-insights@2
-      displayName: '[should fail] case 7: failOnAccessibilityError'
+      displayName: '[should fail] case 9: invalid inputs (no site specified)'
+      inputs:
+          artifactName: 'accessibility-reports-case-9'
+      condition: succeededOrFailed()
+
+    - task: accessibility-insights.staging.task.accessibility-insights@2
+      displayName: '[should fail] case 10: invalid inputs (both url and staticSiteDir specified)'
       inputs:
           url: 'http://localhost:5858'
-          failOnAccessibilityError: true
-          outputDir: '_accessibility-reports-case-7'
+          staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
+          artifactName: 'accessibility-reports-case-10'
       condition: succeededOrFailed()
-      continueOnError: true
 
-    - publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-7'
-      displayName: 'case 7: upload report artifact'
-      artifact: 'accessibility-reports-case-7'
+    - task: accessibility-insights.staging.task.accessibility-insights@2
+      displayName: '[should fail] case 11: v1 inputs specified'
+      inputs:
+          repoServiceConnectionName: 'this isnt used anymore'
+          # siteDir instead of staticSiteDir
+          siteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
       condition: succeededOrFailed()

--- a/pipelines/ado-extension-staging-validation.yaml
+++ b/pipelines/ado-extension-staging-validation.yaml
@@ -43,6 +43,7 @@ steps:
           staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
           # intentionally omits artifactName; should go to default accessibility-reports
       condition: succeededOrFailed()
+      continueOnError: true
 
     - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should succeed] case 2: staticSiteDir, no baseline, failOnAccessibilityError:false'
@@ -58,6 +59,7 @@ steps:
           url: 'http://localhost:5858'
           outputArtifactName: 'accessibility-reports-case-3'
       condition: succeededOrFailed()
+      continueOnError: true
 
     - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should succeed] case 4: up-to-date baseline'
@@ -101,6 +103,7 @@ steps:
           uploadOutputArtifact: false
           outputDir: '_accessibility-reports-case-8'
       condition: succeededOrFailed()
+      continueOnError: true
 
     - publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-8'
       displayName: 'custom report artifact upload for case 8'
@@ -112,6 +115,7 @@ steps:
       inputs:
           outputArtifactName: 'accessibility-reports-case-9'
       condition: succeededOrFailed()
+      continueOnError: true
 
     - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should fail] case 10: invalid inputs (both url and staticSiteDir specified)'
@@ -120,6 +124,7 @@ steps:
           staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
           outputArtifactName: 'accessibility-reports-case-10'
       condition: succeededOrFailed()
+      continueOnError: true
 
     - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should fail] case 11: v1 inputs specified'
@@ -128,3 +133,4 @@ steps:
           # siteDir instead of staticSiteDir
           siteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
       condition: succeededOrFailed()
+      continueOnError: true

--- a/pipelines/ado-extension-staging-validation.yaml
+++ b/pipelines/ado-extension-staging-validation.yaml
@@ -98,7 +98,7 @@ steps:
       displayName: '[should fail] case 8: url, custom artifact upload step'
       inputs:
           url: 'http://localhost:5858'
-          uploadReportAsArtifact: false
+          uploadResultAsArtifact: false
           outputDir: '_accessibility-reports-case-8'
       condition: succeededOrFailed()
 

--- a/pipelines/ado-extension-staging-validation.yaml
+++ b/pipelines/ado-extension-staging-validation.yaml
@@ -37,7 +37,7 @@ steps:
     - script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &
       displayName: 'Start /dev/website-root test server at http://localhost:5858'
 
-    - task: accessibility-insights.staging.task.accessibility-insights@1
+    - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should succeed] case 1: staticSiteDir, no baseline'
       inputs:
           staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
@@ -49,7 +49,7 @@ steps:
       artifact: 'accessibility-reports-case-1'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@1
+    - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should succeed] case 2: url, no baseline'
       inputs:
           url: 'http://localhost:5858'
@@ -61,7 +61,7 @@ steps:
       artifact: 'accessibility-reports-case-2'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@1
+    - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should succeed] case 3: up-to-date baseline'
       inputs:
           url: 'http://localhost:5858'
@@ -74,7 +74,7 @@ steps:
       artifact: 'accessibility-reports-case-3'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@1
+    - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should fail] case 4: baseline missing failures'
       inputs:
           url: 'http://localhost:5858'
@@ -88,7 +88,7 @@ steps:
       artifact: 'accessibility-reports-case-4'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@1
+    - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should fail] case 5: baseline with resolved failures'
       inputs:
           url: 'http://localhost:5858'
@@ -102,7 +102,7 @@ steps:
       artifact: 'accessibility-reports-case-5'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@1
+    - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should fail] case 6: new baseline file'
       inputs:
           staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
@@ -116,7 +116,7 @@ steps:
       artifact: 'accessibility-reports-case-6'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@1
+    - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should fail] case 7: failOnAccessibilityError'
       inputs:
           url: 'http://localhost:5858'


### PR DESCRIPTION
#### Details

Release 2.0.0 bumped the major version of the staging extension to 2.0.0, but our staging validation workflow is still running against version `@1`. This updates the validation template to match the updated number.

Several of the scenarios were impacted by breaking changes, and there were a few new scenarios that make sense for us to validate. This PR also updates the scenarios to be based on the new v2 functionality.

##### Motivation

Enable release validation for 2.0.0

##### Context

The syntax in the template was updated already in #1122

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Story 1927731
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
