### PR TITLE
feat(ado-ext-telemetry): add a v1 to v2 migration guide for the ADO extension

### DIFF
--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -186,7 +186,7 @@ Version 2.x of the extension contains several breaking changes from version 1.x:
         - Rename your existing `siteDir` input to `staticSiteDir`
         - Rename your existing `port` input to `staticSitePort` (if specified)
         - Rename your existing `urlRelativePath` input to `staticSiteUrlRelativePath` (if specified)
-    - If you previously specified *both* `url` and `siteDir`, you had a misconfiguration - these inputs were mutually exclusive, and the `url` input was being silently ignored. Remove the `url` input and follow the instructions above for `siteDir`.
+    - If you previously specified _both_ `url` and `siteDir`, you had a misconfiguration - these inputs were mutually exclusive, and the `url` input was being silently ignored. Remove the `url` input and follow the instructions above for `siteDir`.
     - If you previously specified just `url` and not `siteDir`, you should leave the original `url` input as-is
 2. Publishing a pipeline artifact containing scan results is now built into the Accessibility Insights task, instead of being a separate step you must add yourself afterwards
     - If you previously used a separate `publish` step to upload the `_accessibility-reports` folder, you can delete that `publish` step
@@ -203,7 +203,7 @@ Version 2.x of the extension contains several breaking changes from version 1.x:
         - The "Site Directory", "Localhost Port" and "Scan URL Relative Path" task inputs now appear only when `staticSite` is selected
     - If you previously specified a "Website URL", select the `dynamicSite` "Hosting Mode"
         - The "Website URL" option now appears only when `dynamicSite` is selected
-    - If you previously specified *both* as "Site Directory" and a "Website URL", you had a misconfiguration - these options were mutually exclusive, and the "Website URL" options was being silently ignored. Select `staticSite` mode and ignore your old "Website URL" input
+    - If you previously specified _both_ as "Site Directory" and a "Website URL", you had a misconfiguration - these options were mutually exclusive, and the "Website URL" options was being silently ignored. Select `staticSite` mode and ignore your old "Website URL" input
 2. Publishing a pipeline artifact containing scan results is now built into the Accessibility Insights task, instead of being a separate step you must add yourself afterwards
     - If you previously used a separate "Publish" step to upload the `_accessibility-reports` folder, you can delete that "Publish" step
     - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, uncheck the "Upload Results as Artifact" option to skip the new automatic artifact uploading

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -177,7 +177,7 @@ If you want to run the extension multiple times in a single pipeline, you will n
 
 ## Migrating from version 1 to version 2
 
-Version 2.x of the extension contains several breaking changes from version 1.x:
+Version 2.x of the extension contains several breaking changes from version 1.x. To migrate, you will need to make a few adjustments based on whether your pipeline is defined using a YAML file or the "Classic" Pipelines web interface:
 
 ### Migrating a YAML Pipeline definition
 

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -182,11 +182,11 @@ Version 2.x of the extension contains several breaking changes from version 1.x.
 ### Migrating a YAML Pipeline definition
 
 1. The `repoServiceConnectionName` input has been removed. If you previously created a Service Connection specfically for this task, you should delete it under your Azure DevOps Project's "Service Connections" settings.
-2. The task inputs related to specifying a "static" site to scan (`siteDir`, `port`, and `urlRelativePath`) have changed to make it more clear that they are related (and mutually exclusive with `url`).
+2. The task inputs related to specifying a "static" site to scan (`siteDir`, `localhostPort`, and `scanUrlRelativePath`) have changed to make it more clear that they are related (and mutually exclusive with `url`).
     - If you previously specified a `siteDir`, you should:
         - Rename your existing `siteDir` input to `staticSiteDir`
-        - Rename your existing `port` input to `staticSitePort` (if specified)
-        - Rename your existing `urlRelativePath` input to `staticSiteUrlRelativePath` (if specified)
+        - Rename your existing `localhostPort` input to `staticSitePort` (if specified)
+        - Rename your existing `scanUrlRelativePath` input to `staticSiteUrlRelativePath` (if specified)
     - If you previously specified _both_ `url` and `siteDir`, you had a misconfiguration - these inputs were mutually exclusive, and the `url` input was being silently ignored. Remove the `url` input and follow the instructions above for `siteDir`.
     - If you previously specified just `url` and not `siteDir`, you should leave the original `url` input as-is
 3. Publishing a pipeline artifact containing scan results is now built into the Accessibility Insights task, instead of being a separate step you must add yourself afterwards

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -5,6 +5,11 @@ Licensed under the MIT License.
 
 # How to use the Azure DevOps extension
 
+These instructions are for version 2 of the extension.
+
+-   To migrate from version 1, see [Migrating from version 1 to version 2](#migrating-from-version-1-to-version-2)
+-   For version 1 docs, see [the version of this document as of the v1.1.1 release](https://github.com/microsoft/accessibility-insights-action/blob/v1.1.1-sources-ado/docs/ado-extension-usage.md)
+
 ## Prerequisites
 
 ### Tools
@@ -169,6 +174,42 @@ You can choose to block pull requests if the extension finds accessibility issue
 ## Running multiple times in a single pipeline
 
 If you want to run the extension multiple times in a single pipeline, you will need to ensure that unique `artifactName` and `outputDir` inputs are specified in your YAML file for each task. Artifact names and the output directory must be unique across all tasks in a pipeline.
+
+## Migrating from version 1 to version 2
+
+Version 2.x of the extension contains several breaking changes from version 1.x:
+
+### Migrating a YAML Pipeline definition
+
+1. The task inputs related to specifying a "static" site to scan (`siteDir`, `port`, and `urlRelativePath`) have changed to make it more clear that they are related (and mutually exclusive with `url`).
+    - If you previously specified a `siteDir`, you should:
+        - Rename your existing `siteDir` input to `staticSiteDir`
+        - Rename your existing `port` input to `staticSitePort` (if specified)
+        - Rename your existing `urlRelativePath` input to `staticSiteUrlRelativePath` (if specified)
+    - If you previously specified *both* `url` and `siteDir`, you had a misconfiguration - these inputs were mutually exclusive, and the `url` input was being silently ignored. Remove the `url` input and follow the instructions above for `siteDir`.
+    - If you previously specified just `url` and not `siteDir`, you should leave the original `url` input as-is
+2. Publishing a pipeline artifact containing scan results is now built into the Accessibility Insights task, instead of being a separate step you must add yourself afterwards
+    - If you previously used a separate `publish` step to upload the `_accessibility-reports` folder, you can delete that `publish` step
+    - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, specify `uploadResultsAsArtifact: false` to skip the new automatic artifact uploading
+    - See [Report Artifacts](#report-artifacts) for more details, including how to customize the artifact name
+3. By default, the task now fails if it detects an accessibility failure (unless the failure is a known issue tracked by a [Baseline File](#using-a-baseline-file))
+    - If you previously specified `failOnAccessibilityError: true`, you can remove it (this is now the default behavior)
+    - If you would prefer to keep the old behavior, where accessibility issues are not treated as a task failure, you can add `failOnAccessibilityError: false` (but consider [using a Baseline File](#using-a-baseline-file) instead!)
+
+### Migrating a "Classic" Pipeline definition
+
+1. The options related to specifying which site to scan have moved underneath a new "Hosting Mode" option to make it more clear which ones can be used together.
+    - If you previously specified a "Site Directory", select the `staticSite` "Hosting Mode"
+        - The "Site Directory", "Localhost Port" and "Scan URL Relative Path" task inputs now appear only when `staticSite` is selected
+    - If you previously specified a "Website URL", select the `dynamicSite` "Hosting Mode"
+        - The "Website URL" option now appears only when `dynamicSite` is selected
+    - If you previously specified *both* as "Site Directory" and a "Website URL", you had a misconfiguration - these options were mutually exclusive, and the "Website URL" options was being silently ignored. Select `staticSite` mode and ignore your old "Website URL" input
+2. Publishing a pipeline artifact containing scan results is now built into the Accessibility Insights task, instead of being a separate step you must add yourself afterwards
+    - If you previously used a separate "Publish" step to upload the `_accessibility-reports` folder, you can delete that "Publish" step
+    - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, uncheck the "Upload Results as Artifact" option to skip the new automatic artifact uploading
+    - See [Report Artifacts](#report-artifacts) for more details, including how to customize the artifact name
+3. The "Fail on Accessibility Error" option is now checked by default; when it is checked, the task will fail if it detects an accessibility failure (unless the failure is a known issue tracked by a [Baseline File](#using-a-baseline-file))
+    - If you would prefer to keep the old behavior, where accessibility issues are not treated as a task failure, you can still uncheck this option (but consider [using a Baseline File](#using-a-baseline-file) instead!)
 
 ## Troubleshooting
 

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -181,35 +181,38 @@ Version 2.x of the extension contains several breaking changes from version 1.x.
 
 ### Migrating a YAML Pipeline definition
 
-1. The task inputs related to specifying a "static" site to scan (`siteDir`, `port`, and `urlRelativePath`) have changed to make it more clear that they are related (and mutually exclusive with `url`).
+1. The `repoServiceConnectionName` input has been removed. If you previously created a Service Connection specfically for this task, you should delete it under your Azure DevOps Project's "Service Connections" settings.
+2. The task inputs related to specifying a "static" site to scan (`siteDir`, `port`, and `urlRelativePath`) have changed to make it more clear that they are related (and mutually exclusive with `url`).
     - If you previously specified a `siteDir`, you should:
         - Rename your existing `siteDir` input to `staticSiteDir`
         - Rename your existing `port` input to `staticSitePort` (if specified)
         - Rename your existing `urlRelativePath` input to `staticSiteUrlRelativePath` (if specified)
     - If you previously specified _both_ `url` and `siteDir`, you had a misconfiguration - these inputs were mutually exclusive, and the `url` input was being silently ignored. Remove the `url` input and follow the instructions above for `siteDir`.
     - If you previously specified just `url` and not `siteDir`, you should leave the original `url` input as-is
-2. Publishing a pipeline artifact containing scan results is now built into the Accessibility Insights task, instead of being a separate step you must add yourself afterwards
+3. Publishing a pipeline artifact containing scan results is now built into the Accessibility Insights task, instead of being a separate step you must add yourself afterwards
     - If you previously used a separate `publish` step to upload the `_accessibility-reports` folder, you can delete that `publish` step
     - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, specify `uploadResultsAsArtifact: false` to skip the new automatic artifact uploading
     - See [Report Artifacts](#report-artifacts) for more details, including how to customize the artifact name
-3. By default, the task now fails if it detects an accessibility failure (unless the failure is a known issue tracked by a [Baseline File](#using-a-baseline-file))
+4. By default, the task now fails if it detects an accessibility failure (unless the failure is a known issue tracked by a [Baseline File](#using-a-baseline-file))
     - If you previously specified `failOnAccessibilityError: true`, you can remove it (this is now the default behavior)
     - If you would prefer to keep the old behavior, where accessibility issues are not treated as a task failure, you can add `failOnAccessibilityError: false` (but consider [using a Baseline File](#using-a-baseline-file) instead!)
 
 ### Migrating a "Classic" Pipeline definition
 
-1. The options related to specifying which site to scan have moved underneath a new "Hosting Mode" option to make it more clear which ones can be used together.
+1. The "Azure Repos Connection" option has been removed. If you previously created a Service Connection specfically for this task, you should delete it under your Azure DevOps Project's "Service Connections" settings.
+2. The options related to specifying which site to scan have moved underneath a new "Hosting Mode" option to make it more clear which ones can be used together.
     - If you previously specified a "Site Directory", select the `staticSite` "Hosting Mode"
         - The "Site Directory", "Localhost Port" and "Scan URL Relative Path" task inputs now appear only when `staticSite` is selected
     - If you previously specified a "Website URL", select the `dynamicSite` "Hosting Mode"
         - The "Website URL" option now appears only when `dynamicSite` is selected
     - If you previously specified _both_ as "Site Directory" and a "Website URL", you had a misconfiguration - these options were mutually exclusive, and the "Website URL" options was being silently ignored. Select `staticSite` mode and ignore your old "Website URL" input
-2. Publishing a pipeline artifact containing scan results is now built into the Accessibility Insights task, instead of being a separate step you must add yourself afterwards
+3. Publishing a pipeline artifact containing scan results is now built into the Accessibility Insights task, instead of being a separate step you must add yourself afterwards
     - If you previously used a separate "Publish" step to upload the `_accessibility-reports` folder, you can delete that "Publish" step
     - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, uncheck the "Upload Results as Artifact" option to skip the new automatic artifact uploading
     - See [Report Artifacts](#report-artifacts) for more details, including how to customize the artifact name
-3. The "Fail on Accessibility Error" option is now checked by default; when it is checked, the task will fail if it detects an accessibility failure (unless the failure is a known issue tracked by a [Baseline File](#using-a-baseline-file))
+4. The "Fail on Accessibility Error" option is now checked by default; when it is checked, the task will fail if it detects an accessibility failure (unless the failure is a known issue tracked by a [Baseline File](#using-a-baseline-file))
     - If you would prefer to keep the old behavior, where accessibility issues are not treated as a task failure, you can still uncheck this option (but consider [using a Baseline File](#using-a-baseline-file) instead!)
+5. The "Output Directory" and "Chrome Path" options have moved under a new "Advanced Options" group
 
 ## Troubleshooting
 

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -181,7 +181,9 @@ Version 2.x of the extension contains several breaking changes from version 1.x.
 
 ### Migrating a YAML Pipeline definition
 
-1. The `repoServiceConnectionName` input has been removed. If you previously created a Service Connection specifically for this task, you should delete it under your Azure DevOps Project's "Service Connections" settings.
+1. The Accessibility Insights task no longer requires extra Azure DevOps permissions to work
+    - If you previously specified a `repoServiceConnectionName` input, you should remove it. If this Service Connection was created solely for use with this pipeline, you should delete it in your Azure DevOps Project's "Service Connections" settings.
+    - If you did not previously specify `repoServiceConnectionName`, it likely means that the default Azure DevOps Build Service account for your Azure DevOps project has been granted the `repo:write` permission for this repository. You should audit for this and remove that permission if it is not required by other tasks.
 2. The task inputs related to specifying a "static" site to scan (`siteDir`, `localhostPort`, and `scanUrlRelativePath`) have changed to make it more clear that they are related (and mutually exclusive with `url`).
     - If you previously specified a `siteDir`, you should:
         - Rename your existing `siteDir` input to `staticSiteDir`
@@ -199,7 +201,9 @@ Version 2.x of the extension contains several breaking changes from version 1.x.
 
 ### Migrating a "Classic" Pipeline definition
 
-1. The "Azure Repos Connection" option has been removed. If you previously created a Service Connection specifically for this task, you should delete it under your Azure DevOps Project's "Service Connections" settings.
+1. The Accessibility Insights task no longer requires extra Azure DevOps permissions to work
+    - There is no longer an option for "Azure Repos Connection". If you previously specified a Service Connection using this option, and that Service Connection was created solely for use with this pipeline, you should delete it in your Azure DevOps Project's "Service Connections" settings.
+    - If you did not previously specify an "Azure Repos Connection", it likely means that the default Azure DevOps Build Service account for your Azure DevOps project has been granted the `repo:write` permission for this repository. You should audit for this and remove that permission if it is not required by other tasks.
 2. The options related to specifying which site to scan have moved underneath a new "Hosting Mode" option to make it more clear which ones can be used together.
     - If you previously specified a "Site Directory", select the `staticSite` "Hosting Mode"
         - The "Site Directory", "Localhost Port" and "Scan URL Relative Path" task inputs now appear only when `staticSite` is selected

--- a/pipelines/ado-extension-staging-validation.yaml
+++ b/pipelines/ado-extension-staging-validation.yaml
@@ -37,7 +37,7 @@ steps:
     - script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &
       displayName: 'Start /dev/website-root test server at http://localhost:5858'
 
-    - task: accessibility-insights.staging.task.accessibility-insights@2
+    - task: accessibility-insights.staging.task.accessibility-insights@1
       displayName: '[should succeed] case 1: staticSiteDir, no baseline'
       inputs:
           staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
@@ -49,7 +49,7 @@ steps:
       artifact: 'accessibility-reports-case-1'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@2
+    - task: accessibility-insights.staging.task.accessibility-insights@1
       displayName: '[should succeed] case 2: url, no baseline'
       inputs:
           url: 'http://localhost:5858'
@@ -61,7 +61,7 @@ steps:
       artifact: 'accessibility-reports-case-2'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@2
+    - task: accessibility-insights.staging.task.accessibility-insights@1
       displayName: '[should succeed] case 3: up-to-date baseline'
       inputs:
           url: 'http://localhost:5858'
@@ -74,7 +74,7 @@ steps:
       artifact: 'accessibility-reports-case-3'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@2
+    - task: accessibility-insights.staging.task.accessibility-insights@1
       displayName: '[should fail] case 4: baseline missing failures'
       inputs:
           url: 'http://localhost:5858'
@@ -88,7 +88,7 @@ steps:
       artifact: 'accessibility-reports-case-4'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@2
+    - task: accessibility-insights.staging.task.accessibility-insights@1
       displayName: '[should fail] case 5: baseline with resolved failures'
       inputs:
           url: 'http://localhost:5858'
@@ -102,7 +102,7 @@ steps:
       artifact: 'accessibility-reports-case-5'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@2
+    - task: accessibility-insights.staging.task.accessibility-insights@1
       displayName: '[should fail] case 6: new baseline file'
       inputs:
           staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
@@ -116,7 +116,7 @@ steps:
       artifact: 'accessibility-reports-case-6'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@2
+    - task: accessibility-insights.staging.task.accessibility-insights@1
       displayName: '[should fail] case 7: failOnAccessibilityError'
       inputs:
           url: 'http://localhost:5858'

--- a/pipelines/ado-extension-staging-validation.yaml
+++ b/pipelines/ado-extension-staging-validation.yaml
@@ -37,7 +37,7 @@ steps:
     - script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &
       displayName: 'Start /dev/website-root test server at http://localhost:5858'
 
-    - task: accessibility-insights.staging.task.accessibility-insights@1
+    - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should succeed] case 1: staticSiteDir, no baseline'
       inputs:
           staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
@@ -49,7 +49,7 @@ steps:
       artifact: 'accessibility-reports-case-1'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@1
+    - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should succeed] case 2: url, no baseline'
       inputs:
           url: 'http://localhost:5858'
@@ -61,7 +61,7 @@ steps:
       artifact: 'accessibility-reports-case-2'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@1
+    - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should succeed] case 3: up-to-date baseline'
       inputs:
           url: 'http://localhost:5858'
@@ -74,7 +74,7 @@ steps:
       artifact: 'accessibility-reports-case-3'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@1
+    - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should fail] case 4: baseline missing failures'
       inputs:
           url: 'http://localhost:5858'
@@ -88,7 +88,7 @@ steps:
       artifact: 'accessibility-reports-case-4'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@1
+    - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should fail] case 5: baseline with resolved failures'
       inputs:
           url: 'http://localhost:5858'
@@ -102,7 +102,7 @@ steps:
       artifact: 'accessibility-reports-case-5'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@1
+    - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should fail] case 6: new baseline file'
       inputs:
           staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
@@ -116,7 +116,7 @@ steps:
       artifact: 'accessibility-reports-case-6'
       condition: succeededOrFailed()
 
-    - task: accessibility-insights.staging.task.accessibility-insights@1
+    - task: accessibility-insights.staging.task.accessibility-insights@2
       displayName: '[should fail] case 7: failOnAccessibilityError'
       inputs:
           url: 'http://localhost:5858'


### PR DESCRIPTION
#### Details

This PR adds a `Migrating from version 1 to version 2` section to our ADO usage docs, and a pointer to it and the v1 docs from the top of the usage document.

##### Motivation

Improve usability of new version

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Feature 1893588
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
