### PR TITLE
feat(ado-ext-telemetry): re-add chromePath to advanced options group

### DIFF
--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -13,7 +13,13 @@
         "Patch": 0
     },
     "instanceNameFormat": "Run accessibility testing",
-    "groups": [{ "displayName": "Advanced Options", "isExpanded": false, "name": "advancedOptions" }],
+    "groups": [
+        {
+            "displayName": "Advanced Options",
+            "isExpanded": false,
+            "name": "advancedOptions"
+        }
+    ],
     "inputs": [
         {
             "name": "outputDir",
@@ -72,7 +78,8 @@
             "type": "string",
             "label": "Chrome Path",
             "required": false,
-            "helpMarkDown": "Path to Chrome executable."
+            "helpMarkDown": "Path to Chrome executable.",
+            "groupName": "advancedOptions"
         },
         {
             "name": "maxUrls",


### PR DESCRIPTION
#### Details

PR #1092 added `outputDir` and `chromePath` to a new "Advanced Options" group. PR #1122 accidentally reverted the group from `chromePath` - this PR un-reverts it and moves `chromePath` back to "Advanced Options".

##### Motivation

Match feature spec

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
