### PR TITLE
feat(ado-ext-telemetry): make output artifact naming/grouping more consistent with outputDir

### DIFF
--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -156,7 +156,7 @@ Here is an example of a YAML file that is configured to take advantage of a base
 
 ## Report Artifacts
 
-By default, an HTML report containing detailed results is automatically uploaded as a pipeline artifact named `accessibility-reports`. You can opt out of this automatic artifact upload by setting the `uploadResultAsArtifact` parameter to `false`. You can also specify a custom artifact name by setting the `artifactName` parameter in your YAML file. If not opted out, a link to the artifacts will also appear in both the task log and in the Extensions tab of the pipeline run.
+By default, an HTML report containing detailed results is automatically uploaded as a pipeline artifact named `accessibility-reports`. You can opt out of this automatic artifact upload by setting the `uploadOutputArtifact` parameter to `false`. You can also specify a custom artifact name by setting the `outputArtifactName` parameter in your YAML file. If not opted out, a link to the artifacts will also appear in both the task log and in the Extensions tab of the pipeline run.
 
 To view the report, navigate to Artifacts from the build. Under `accessibility-reports`, or the artifact name manually specified, you'll find the downloadable report labeled `index.html`.
 
@@ -173,7 +173,7 @@ You can choose to block pull requests if the extension finds accessibility issue
 
 ## Running multiple times in a single pipeline
 
-If you want to run the extension multiple times in a single pipeline, you will need to ensure that unique `artifactName` and `outputDir` inputs are specified in your YAML file for each task. Artifact names and the output directory must be unique across all tasks in a pipeline.
+If you want to run the extension multiple times in a single pipeline, you will need to ensure that each task uses a unique `outputArtifactName` and (if specified) `outputDir` input. Artifact names and output directories must be unique across all tasks in a pipeline.
 
 ## Migrating from version 1 to version 2
 
@@ -193,7 +193,7 @@ Version 2.x of the extension contains several breaking changes from version 1.x.
     - If you previously specified just `url` and not `siteDir`, you should leave the original `url` input as-is
 3. Publishing a pipeline artifact containing scan results is now built into the Accessibility Insights task, instead of being a separate step you must add yourself afterwards
     - If you previously used a separate `publish` step to upload the `_accessibility-reports` folder, you can delete that `publish` step
-    - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, specify `uploadResultsAsArtifact: false` to skip the new automatic artifact uploading
+    - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, specify `uploadOutputArtifact: false` to skip the new automatic artifact uploading
     - See [Report Artifacts](#report-artifacts) for more details, including how to customize the artifact name
 4. By default, the task now fails if it detects an accessibility failure (unless the failure is a known issue tracked by a [Baseline File](#using-a-baseline-file))
     - If you previously specified `failOnAccessibilityError: true`, you can remove it (this is now the default behavior)

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -173,7 +173,7 @@ You can choose to block pull requests if the extension finds accessibility issue
 
 ## Running multiple times in a single pipeline
 
-If you want to run the extension multiple times in a single pipeline, you will need to ensure that each task uses a unique `outputArtifactName` and (if specified) `outputDir` input. Artifact names and output directories must be unique across all tasks in a pipeline.
+If you want to run the extension multiple times in a single pipeline, you will need to ensure that each task uses a unique `outputArtifactName` and `outputDir` input. Artifact names and output directories must be unique across all tasks in a pipeline.
 
 ## Migrating from version 1 to version 2
 

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -173,7 +173,7 @@ You can choose to block pull requests if the extension finds accessibility issue
 
 ## Running multiple times in a single pipeline
 
-If you want to run the extension multiple times in a single pipeline, you will need to ensure that each task uses a unique `outputArtifactName` and `outputDir` input. Artifact names and output directories must be unique across all tasks in a pipeline.
+If you want to run multiple Accessibility Insights steps in a single pipeline, you will need to ensure that each step uses a unique `outputArtifactName` and `outputDir`. Artifact names and output directories must be unique across all steps in a pipeline.
 
 ## Migrating from version 1 to version 2
 

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -19,7 +19,7 @@ describe(AdoConsoleCommentCreator, () => {
     let fsMock: IMock<typeof fs>;
     const reportOutDir = 'reportOutDir';
     const fileName = `${reportOutDir}/results.md`;
-    const artifactName = 'accessibility-reports';
+    const outputArtifactName = 'accessibility-reports';
     const reportStub: CombinedReportParameters = {
         results: {
             urlResults: {
@@ -56,13 +56,13 @@ describe(AdoConsoleCommentCreator, () => {
                 .verifiable(Times.once());
 
             adoTaskConfigMock
-                .setup((atcm) => atcm.getUploadResultAsArtifact())
+                .setup((atcm) => atcm.getUploadOutputArtifact())
                 .returns(() => true)
                 .verifiable(Times.once());
 
             loggerMock.setup((lm) => lm.logInfo(`##vso[task.uploadsummary]${fileName}`)).verifiable(Times.once());
             loggerMock
-                .setup((lm) => lm.logInfo(`##vso[artifact.upload artifactname=${artifactName}]${reportOutDir}`))
+                .setup((lm) => lm.logInfo(`##vso[artifact.upload artifactname=${outputArtifactName}]${reportOutDir}`))
                 .verifiable(Times.once());
 
             adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks();
@@ -78,13 +78,13 @@ describe(AdoConsoleCommentCreator, () => {
                 .verifiable(Times.once());
 
             adoTaskConfigMock
-                .setup((atcm) => atcm.getUploadResultAsArtifact())
+                .setup((atcm) => atcm.getUploadOutputArtifact())
                 .returns(() => true)
                 .verifiable(Times.once());
 
             loggerMock.setup((lm) => lm.logInfo(`##vso[task.uploadsummary]${fileName}`)).verifiable(Times.once());
             loggerMock
-                .setup((lm) => lm.logInfo(`##vso[artifact.upload artifactname=${artifactName}-2]${reportOutDir}`))
+                .setup((lm) => lm.logInfo(`##vso[artifact.upload artifactname=${outputArtifactName}-2]${reportOutDir}`))
                 .verifiable(Times.once());
 
             adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks();
@@ -93,11 +93,11 @@ describe(AdoConsoleCommentCreator, () => {
             verifyAllMocks();
         });
 
-        it('skips upload artifact step if uploadResultAsArtifact is false', async () => {
+        it('skips upload artifact step if uploadOutputArtifact is false', async () => {
             adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks();
 
             adoTaskConfigMock
-                .setup((atcm) => atcm.getUploadResultAsArtifact())
+                .setup((atcm) => atcm.getUploadOutputArtifact())
                 .returns(() => false)
                 .verifiable(Times.once());
 
@@ -145,8 +145,8 @@ describe(AdoConsoleCommentCreator, () => {
                 .verifiable(Times.exactly(2));
 
             adoTaskConfigMock
-                .setup((atcm) => atcm.getArtifactName())
-                .returns(() => artifactName)
+                .setup((atcm) => atcm.getOutputArtifactName())
+                .returns(() => outputArtifactName)
                 .verifiable(Times.once());
 
             reportMarkdownConvertorMock

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -31,7 +31,7 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
     public async completeRun(combinedReportResult: CombinedReportParameters, baselineEvaluation?: BaselineEvaluation): Promise<void> {
         const baselineInfo = this.getBaselineInfo(baselineEvaluation);
         this.outputResultsMarkdownToBuildSummary(combinedReportResult, baselineInfo);
-        this.uploadReportArtifacts();
+        this.uploadOutputArtifact();
         this.logResultsToConsole(combinedReportResult, baselineInfo);
 
         return Promise.resolve();
@@ -63,12 +63,12 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
         this.logger.logInfo(`##vso[task.uploadsummary]${fileName}`);
     }
 
-    private uploadReportArtifacts(): void {
-        const uploadResultAsArtifactEnabled: boolean = this.taskConfig.getUploadResultAsArtifact();
-        if (uploadResultAsArtifactEnabled) {
+    private uploadOutputArtifact(): void {
+        const uploadOutputArtifactEnabled: boolean = this.taskConfig.getUploadOutputArtifact();
+        if (uploadOutputArtifactEnabled) {
             const outputDirectory = this.taskConfig.getReportOutDir();
             const jobAttemptBuildVariable = this.taskConfig.getVariable('System.JobAttempt');
-            const artifactName = this.taskConfig.getArtifactName();
+            const artifactName = this.taskConfig.getOutputArtifactName();
 
             let artifactNameSuffix = '';
             let jobAttemptNumber = 1;

--- a/packages/ado-extension/src/task-config/ado-task-config.spec.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.spec.ts
@@ -56,8 +56,8 @@ describe(ADOTaskConfig, () => {
         ${'baselineFile'}              | ${'./baselineFile'} | ${getPlatformAgnosticPath(__dirname + '/baselineFile')} | ${() => taskConfig.getBaselineFile()}
         ${'failOnAccessibilityError'}  | ${true}             | ${true}                                                 | ${() => taskConfig.getFailOnAccessibilityError()}
         ${'singleWorker'}              | ${true}             | ${true}                                                 | ${() => taskConfig.getSingleWorker()}
-        ${'artifactName'}              | ${'artifact-name'}  | ${'artifact-name'}                                      | ${() => taskConfig.getArtifactName()}
-        ${'uploadResultAsArtifact'}    | ${true}             | ${true}                                                 | ${() => taskConfig.getUploadResultAsArtifact()}
+        ${'outputArtifactName'}        | ${'artifact-name'}  | ${'artifact-name'}                                      | ${() => taskConfig.getOutputArtifactName()}
+        ${'uploadOutputArtifact'}      | ${true}             | ${true}                                                 | ${() => taskConfig.getUploadOutputArtifact()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -127,13 +127,13 @@ export class ADOTaskConfig extends TaskConfig {
         return this.processObj.env.SYSTEM_TEAMPROJECT ?? undefined;
     }
 
-    public getArtifactName(): string {
+    public getOutputArtifactName(): string {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return this.adoTaskObj.getInput('artifactName')!;
+        return this.adoTaskObj.getInput('outputArtifactName')!;
     }
 
-    public getUploadResultAsArtifact(): boolean {
-        return this.adoTaskObj.getBoolInput('uploadResultAsArtifact');
+    public getUploadOutputArtifact(): boolean {
+        return this.adoTaskObj.getBoolInput('uploadOutputArtifact');
     }
 
     // This allows us to pull in predefined Azure Pipelines variables listed here:

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -15,21 +15,17 @@
     "instanceNameFormat": "Run accessibility testing",
     "groups": [
         {
+            "displayName": "Output Options",
+            "isExpanded": true,
+            "name": "outputOptions"
+        },
+        {
             "displayName": "Advanced Options",
             "isExpanded": false,
             "name": "advancedOptions"
         }
     ],
     "inputs": [
-        {
-            "name": "outputDir",
-            "type": "string",
-            "label": "Output Directory",
-            "required": true,
-            "defaultValue": "_accessibility-reports",
-            "helpMarkDown": "Folder containing the scan report.",
-            "groupName": "advancedOptions"
-        },
         {
             "name": "hostingMode",
             "type": "pickList",
@@ -72,14 +68,6 @@
             "required": true,
             "helpMarkDown": "The hosted URL to scan/crawl for accessibility issues.",
             "visibleRule": "hostingMode = dynamicSite"
-        },
-        {
-            "name": "chromePath",
-            "type": "string",
-            "label": "Chrome Path",
-            "required": false,
-            "helpMarkDown": "Path to Chrome executable.",
-            "groupName": "advancedOptions"
         },
         {
             "name": "maxUrls",
@@ -136,27 +124,45 @@
         {
             "name": "singleWorker",
             "type": "boolean",
-            "label": "Uses a single crawler worker.",
+            "label": "Uses a single crawler worker",
             "required": true,
             "defaultValue": true,
             "helpMarkDown": "To get deterministic scanning results, either specify the singleWorker parameter or ensure that the value specified for the maxUrls parameter is larger than the total number of urls in the web site being scanned."
         },
         {
-            "name": "uploadResultAsArtifact",
-            "type": "boolean",
-            "label": "Upload result as artifact",
-            "defaultValue": true,
-            "required": true,
-            "helpMarkDown": "Automatically upload the result as an artifact to the build. Set to false if you need to upload the artifact manually in a separate task or publish step."
+            "name": "outputDir",
+            "type": "string",
+            "label": "Output Directory",
+            "required": false,
+            "helpMarkDown": "Directory to write scan output to. Its contents will be uploaded as a pipeline artifact unless uploadOutputArtifact is set to false. Defaults to a generated temporary directory.",
+            "groupName": "outputOptions"
         },
         {
-            "name": "artifactName",
+            "name": "uploadOutputArtifact",
+            "type": "boolean",
+            "label": "Upload Output Artifact",
+            "defaultValue": true,
+            "required": true,
+            "helpMarkDown": "Automatically upload the result as an artifact to the build. Set to false if you need to upload the artifact manually in a separate task or publish step.",
+            "groupName": "outputOptions"
+        },
+        {
+            "name": "outputArtifactName",
             "type": "string",
-            "label": "Artifact Name",
+            "label": "Output Artifact Name",
             "required": false,
             "defaultValue": "accessibility-reports",
-            "helpMarkDown": "Name of the report artifact to be uploaded to the build. Ignored if uploadResultAsArtifact is false.",
-            "visibleRule": "uploadResultAsArtifact = true"
+            "helpMarkDown": "Name of the report artifact to be uploaded to the build. Ignored if uploadOutputArtifact is false.",
+            "visibleRule": "uploadOutputArtifact = true",
+            "groupName": "outputOptions"
+        },
+        {
+            "name": "chromePath",
+            "type": "string",
+            "label": "Chrome Path",
+            "required": false,
+            "helpMarkDown": "Path to Chrome executable. By default, the task downloads a version of Chrome that is tested to work with this task.",
+            "groupName": "advancedOptions"
         }
     ],
     "execution": {

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -133,8 +133,9 @@
             "name": "outputDir",
             "type": "string",
             "label": "Output Directory",
-            "required": false,
-            "helpMarkDown": "Directory to write scan output to. Its contents will be uploaded as a pipeline artifact unless uploadOutputArtifact is set to false. Defaults to a generated temporary directory.",
+            "required": true,
+            "defaultValue": "_accessibility-reports",
+            "helpMarkDown": "Directory to write scan output to. Its contents will be uploaded as a pipeline artifact unless uploadOutputArtifact is set to false.",
             "groupName": "outputOptions"
         },
         {

--- a/packages/shared/src/console-output/__snapshots__/result-console-log-builder.spec.ts.snap
+++ b/packages/shared/src/console-output/__snapshots__/result-console-log-builder.spec.ts.snap
@@ -43,7 +43,7 @@ You can review the log to troubleshoot the issue. Fix it and re-run the pipeline
 "
 `;
 
-exports[`ResultConsoleLogBuilder uploadResultAsArtifact is false skips artifact link line when artifactsUrl returns undefined 1`] = `
+exports[`ResultConsoleLogBuilder uploadOutputArtifact is false skips artifact link line when artifactsUrl returns undefined 1`] = `
 "
 Accessibility Insights
 

--- a/packages/shared/src/console-output/result-console-log-builder.spec.ts
+++ b/packages/shared/src/console-output/result-console-log-builder.spec.ts
@@ -278,7 +278,7 @@ describe(ResultConsoleLogBuilder, () => {
         });
     });
 
-    describe('uploadResultAsArtifact is false', () => {
+    describe('uploadOutputArtifact is false', () => {
         const baselineFileName = 'baseline file';
         it('skips artifact link line when artifactsUrl returns undefined', () => {
             artifactsInfoProviderMock

--- a/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
+++ b/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
@@ -40,7 +40,7 @@ You can review the log to troubleshoot the issue. Fix it and re-run the workflow
 "
 `;
 
-exports[`ResultMarkdownBuilder uploadResultAsArtifact is false skips artifact link line when artifactsUrl returns undefined 1`] = `
+exports[`ResultMarkdownBuilder uploadOutputArtifact is false skips artifact link line when artifactsUrl returns undefined 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **:white_check_mark: No failures detected**

--- a/packages/shared/src/mark-down/result-markdown-builder.spec.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.spec.ts
@@ -278,7 +278,7 @@ describe(ResultMarkdownBuilder, () => {
         });
     });
 
-    describe('uploadResultAsArtifact is false', () => {
+    describe('uploadOutputArtifact is false', () => {
         const baselineFileName = 'baseline file';
         it('skips artifact link line when artifactsUrl returns undefined', () => {
             artifactsInfoProviderMock


### PR DESCRIPTION
#### Details

Per discussion with @karanbirsingh, this PR adjusts the naming and grouping of the new inputs for automatic artifact uploading to be more consistent with the existing `outputDir` input. Previously, `outputDir` was hidden under "Advanced options" and the artifact upload inputs were named `artifactName` and `uploadResultsAsArtifact`. This PR:

* Groups the three related inputs together under a new `Output options` grouping, which appears expanded by default
* Renames `uploadResultsAsArtifact` to `uploadOutputArtifact`, to make it more apparent that it is working with the same output that `outputDir` is
* Renames `artifactName` to `outputArtifactName`, for consistency with `uploadOutputArtifact`

It adjusts all usage/tests/docs accordingly.

##### Motivation

Feature work

##### Context

Separated this out from a separate (upcoming) PR that will adjust the default `outputDir` behavior to send results to a temp directory by default

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1940706
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
