### PR TITLE
feat(ado-ext-telemetry): update outputDir to write to a temp dir by default

### DIFF
--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -197,7 +197,7 @@ Version 2.x of the extension contains several breaking changes from version 1.x.
     - If you previously specified just `url` and not `siteDir`, you should leave the original `url` input as-is
 3. Publishing a pipeline artifact containing scan results is now built into the Accessibility Insights task, instead of being a separate step you must add yourself afterwards
     - If you previously used a separate `publish` step to upload the `_accessibility-reports` folder, you can delete that `publish` step
-    - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, specify `uploadOutputArtifact: false` to skip the new automatic artifact uploading and specify an `outputDir` to control where the output artifact contents get written to on the build agent
+    - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, specify `uploadOutputArtifact: false` to skip the new automatic artifact uploading. You can specify `outputDir` to control where the output artifact contents get written to on the build agent
     - See [Report Artifacts](#report-artifacts) for more details, including how to customize the artifact name
 4. By default, the task now fails if it detects an accessibility failure (unless the failure is a known issue tracked by a [Baseline File](#using-a-baseline-file))
     - If you previously specified `failOnAccessibilityError: true`, you can remove it (this is now the default behavior)
@@ -216,7 +216,7 @@ Version 2.x of the extension contains several breaking changes from version 1.x.
     - If you previously specified _both_ as "Site Directory" and a "Website URL", you had a misconfiguration - these options were mutually exclusive, and the "Website URL" option was being silently ignored. Select `staticSite` mode and ignore your old "Website URL" input
 3. Publishing a pipeline artifact containing scan results is now built into the Accessibility Insights task, instead of being a separate step you must add yourself afterwards
     - If you previously used a separate "Publish" step to upload the `_accessibility-reports` folder, you can delete that "Publish" step
-    - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, uncheck the "Upload Output Artifact" option to skip the new automatic artifact uploading and specify an "Output Directory" to control where the output artifact contents get written to on the build agent
+    - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, uncheck the "Upload Output Artifact" option to skip the new automatic artifact uploading. You can specify an "Output Directory" to control where the output artifact contents get written to on the build agent
     - See [Report Artifacts](#report-artifacts) for more details, including how to customize the artifact name
 4. The "Fail on Accessibility Error" option is now checked by default; when it is checked, the task will fail if it detects an accessibility failure (unless the failure is a known issue tracked by a [Baseline File](#using-a-baseline-file))
     - If you would prefer to keep the old behavior, where accessibility issues are not treated as a task failure, you can still uncheck this option (but consider [using a Baseline File](#using-a-baseline-file) instead!)

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -156,9 +156,11 @@ Here is an example of a YAML file that is configured to take advantage of a base
 
 ## Report Artifacts
 
-By default, an HTML report containing detailed results is automatically uploaded as a pipeline artifact named `accessibility-reports`. You can opt out of this automatic artifact upload by setting the `uploadOutputArtifact` parameter to `false`. You can also specify a custom artifact name by setting the `outputArtifactName` parameter in your YAML file. If not opted out, a link to the artifacts will also appear in both the task log and in the Extensions tab of the pipeline run.
+By default, an HTML report containing detailed results is automatically uploaded as a pipeline artifact named `accessibility-reports`. You can customize this artifact name by setting the `outputArtifactName` parameter in your YAML file. A link to the artifact will appear in both the task log and in the Extensions tab of the pipeline run.
 
 To view the report, navigate to Artifacts from the build. Under `accessibility-reports`, or the artifact name manually specified, you'll find the downloadable report labeled `index.html`.
+
+If you would prefer not to upload an artifact, or if you are in a Pipelines environment where individual tasks are not allowed to upload artifacts (for example, OneBranch), you can opt out of this automatic artifact upload by setting the `uploadOutputArtifact` parameter to `false`. You can set the `outputDir` parameter to control where the output gets written to on the build agent.
 
 ## Summary results
 
@@ -173,7 +175,7 @@ You can choose to block pull requests if the extension finds accessibility issue
 
 ## Running multiple times in a single pipeline
 
-If you want to run multiple Accessibility Insights steps in a single pipeline, you will need to ensure that each step uses a unique `outputArtifactName` and (if specified) `outputDir`. Artifact names and output directories must be unique across all steps in a pipeline.
+If you want to run multiple Accessibility Insights steps in a single pipeline, you will need to ensure that each step uses a unique `outputArtifactName`. Any custom `outputDir` settings must also be unique among all steps in a pipeline.
 
 ## Migrating from version 1 to version 2
 
@@ -193,7 +195,7 @@ Version 2.x of the extension contains several breaking changes from version 1.x.
     - If you previously specified just `url` and not `siteDir`, you should leave the original `url` input as-is
 3. Publishing a pipeline artifact containing scan results is now built into the Accessibility Insights task, instead of being a separate step you must add yourself afterwards
     - If you previously used a separate `publish` step to upload the `_accessibility-reports` folder, you can delete that `publish` step
-    - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, specify `uploadOutputArtifact: false` to skip the new automatic artifact uploading
+    - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, specify `uploadOutputArtifact: false` to skip the new automatic artifact uploading and specify an `outputDir` to control where the output artifact contents get written to on the build agent
     - See [Report Artifacts](#report-artifacts) for more details, including how to customize the artifact name
 4. By default, the task now fails if it detects an accessibility failure (unless the failure is a known issue tracked by a [Baseline File](#using-a-baseline-file))
     - If you previously specified `failOnAccessibilityError: true`, you can remove it (this is now the default behavior)
@@ -212,7 +214,7 @@ Version 2.x of the extension contains several breaking changes from version 1.x.
     - If you previously specified _both_ as "Site Directory" and a "Website URL", you had a misconfiguration - these options were mutually exclusive, and the "Website URL" option was being silently ignored. Select `staticSite` mode and ignore your old "Website URL" input
 3. Publishing a pipeline artifact containing scan results is now built into the Accessibility Insights task, instead of being a separate step you must add yourself afterwards
     - If you previously used a separate "Publish" step to upload the `_accessibility-reports` folder, you can delete that "Publish" step
-    - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, uncheck the "Upload Output Artifact" option to skip the new automatic artifact uploading
+    - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, uncheck the "Upload Output Artifact" option to skip the new automatic artifact uploading and specify an "Output Directory" to control where the output artifact contents get written to on the build agent
     - See [Report Artifacts](#report-artifacts) for more details, including how to customize the artifact name
 4. The "Fail on Accessibility Error" option is now checked by default; when it is checked, the task will fail if it detects an accessibility failure (unless the failure is a known issue tracked by a [Baseline File](#using-a-baseline-file))
     - If you would prefer to keep the old behavior, where accessibility issues are not treated as a task failure, you can still uncheck this option (but consider [using a Baseline File](#using-a-baseline-file) instead!)

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -175,7 +175,9 @@ You can choose to block pull requests if the extension finds accessibility issue
 
 ## Running multiple times in a single pipeline
 
-If you want to run multiple Accessibility Insights steps in a single pipeline, you will need to ensure that each step uses a unique `outputArtifactName`. Any custom `outputDir` settings must also be unique among all steps in a pipeline.
+If you want to run multiple Accessibility Insights steps in a single pipeline, you will need to ensure that each step uses a unique `outputArtifactName`.
+
+Each step also needs a unique output directory on the build agent. The task will generate unique output directories for you by default, but if you override `outputDir`, you will need to ensure that it is also unique among all steps.
 
 ## Migrating from version 1 to version 2
 

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -173,7 +173,7 @@ You can choose to block pull requests if the extension finds accessibility issue
 
 ## Running multiple times in a single pipeline
 
-If you want to run multiple Accessibility Insights steps in a single pipeline, you will need to ensure that each step uses a unique `outputArtifactName` and `outputDir`. Artifact names and output directories must be unique across all steps in a pipeline.
+If you want to run multiple Accessibility Insights steps in a single pipeline, you will need to ensure that each step uses a unique `outputArtifactName` and (if specified) `outputDir`. Artifact names and output directories must be unique across all steps in a pipeline.
 
 ## Migrating from version 1 to version 2
 
@@ -212,7 +212,7 @@ Version 2.x of the extension contains several breaking changes from version 1.x.
     - If you previously specified _both_ as "Site Directory" and a "Website URL", you had a misconfiguration - these options were mutually exclusive, and the "Website URL" option was being silently ignored. Select `staticSite` mode and ignore your old "Website URL" input
 3. Publishing a pipeline artifact containing scan results is now built into the Accessibility Insights task, instead of being a separate step you must add yourself afterwards
     - If you previously used a separate "Publish" step to upload the `_accessibility-reports` folder, you can delete that "Publish" step
-    - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, uncheck the "Upload Results as Artifact" option to skip the new automatic artifact uploading
+    - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, uncheck the "Upload Output Artifact" option to skip the new automatic artifact uploading
     - See [Report Artifacts](#report-artifacts) for more details, including how to customize the artifact name
 4. The "Fail on Accessibility Error" option is now checked by default; when it is checked, the task will fail if it detects an accessibility failure (unless the failure is a known issue tracked by a [Baseline File](#using-a-baseline-file))
     - If you would prefer to keep the old behavior, where accessibility issues are not treated as a task failure, you can still uncheck this option (but consider [using a Baseline File](#using-a-baseline-file) instead!)

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -26,8 +26,7 @@ export class ADOTaskConfig extends TaskConfig {
         if (this.memoizedReportOutDir == null) {
             const customOutputDir = this.getAbsolutePath(this.adoTaskObj.getInput('outputDir'));
 
-            this.memoizedReportOutDir =
-                customOutputDir != null ? customOutputDir : this.tempDirCreator.createTempDirSync(this.getVariable('Agent.TempDirectory'));
+            this.memoizedReportOutDir = customOutputDir ?? this.tempDirCreator.createTempDirSync(this.getVariable('Agent.TempDirectory'));
         }
 
         return this.memoizedReportOutDir;

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -5,7 +5,7 @@ import * as adoTask from 'azure-pipelines-task-lib/task';
 import { inject, injectable } from 'inversify';
 import { isEmpty } from 'lodash';
 import * as process from 'process';
-import { iocTypes, TaskConfig } from '@accessibility-insights-action/shared';
+import { iocTypes, TaskConfig, TempDirCreator } from '@accessibility-insights-action/shared';
 import normalizePath from 'normalize-path';
 import { resolve } from 'path';
 
@@ -13,15 +13,24 @@ import { resolve } from 'path';
 export class ADOTaskConfig extends TaskConfig {
     constructor(
         @inject(iocTypes.Process) protected readonly processObj: typeof process,
+        @inject(TempDirCreator) private readonly tempDirCreator: TempDirCreator,
         private readonly adoTaskObj = adoTask,
         private readonly resolvePath: typeof resolve = resolve,
     ) {
         super(processObj);
     }
 
+    // memoizing this is important to avoid generating multiple temp directories in the defualt case
+    private memoizedReportOutDir: string | null = null;
     public getReportOutDir(): string {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return this.getAbsolutePath(this.adoTaskObj.getInput('outputDir'))!;
+        if (this.memoizedReportOutDir == null) {
+            const customOutputDir = this.getAbsolutePath(this.adoTaskObj.getInput('outputDir'));
+
+            this.memoizedReportOutDir =
+                customOutputDir != null ? customOutputDir : this.tempDirCreator.createTempDirSync(this.getVariable('Agent.TempDirectory'));
+        }
+
+        return this.memoizedReportOutDir;
     }
 
     public getStaticSiteDir(): string {

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -20,7 +20,7 @@ export class ADOTaskConfig extends TaskConfig {
         super(processObj);
     }
 
-    // memoizing this is important to avoid generating multiple temp directories in the defualt case
+    // memoizing this is important to avoid generating multiple temp directories in the default case
     private memoizedReportOutDir: string | null = null;
     public getReportOutDir(): string {
         if (this.memoizedReportOutDir == null) {

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -130,15 +130,6 @@
             "helpMarkDown": "To get deterministic scanning results, either specify the singleWorker parameter or ensure that the value specified for the maxUrls parameter is larger than the total number of urls in the web site being scanned."
         },
         {
-            "name": "outputDir",
-            "type": "string",
-            "label": "Output Directory",
-            "required": true,
-            "defaultValue": "_accessibility-reports",
-            "helpMarkDown": "Directory to write scan output to. Its contents will be uploaded as a pipeline artifact unless uploadOutputArtifact is set to false.",
-            "groupName": "outputOptions"
-        },
-        {
             "name": "uploadOutputArtifact",
             "type": "boolean",
             "label": "Upload Output Artifact",
@@ -155,6 +146,14 @@
             "defaultValue": "accessibility-reports",
             "helpMarkDown": "Name of the report artifact to be uploaded to the build. Ignored if uploadOutputArtifact is false.",
             "visibleRule": "uploadOutputArtifact = true",
+            "groupName": "outputOptions"
+        },
+        {
+            "name": "outputDir",
+            "type": "string",
+            "label": "Output Directory",
+            "required": false,
+            "helpMarkDown": "Directory to write scan output to. Its contents will be uploaded as a pipeline artifact unless uploadOutputArtifact is set to false. If unspecified, output will be written to a generated temporary directory.",
             "groupName": "outputOptions"
         },
         {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -21,3 +21,4 @@ export { ExitCode } from './exit-code';
 export { TelemetryClient } from './telemetry/telemetry-client';
 export { TelemetryEvent } from './telemetry/telemetry-event';
 export { NullTelemetryClient } from './telemetry/null-telemetry-client';
+export { TempDirCreator } from './utils/temp-dir-creator';

--- a/packages/shared/src/utils/temp-dir-creator.spec.ts
+++ b/packages/shared/src/utils/temp-dir-creator.spec.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import type * as fs from 'fs';
+import type * as path from 'path';
+import { IMock, Mock, It } from 'typemoq';
+
+import { TempDirCreator } from './temp-dir-creator';
+
+describe(TempDirCreator, () => {
+    describe('createTempDirSync', () => {
+        const stubPath = { sep: 'SEP' } as typeof path;
+        let mockFs: IMock<typeof fs>;
+        let testSubject: TempDirCreator;
+
+        beforeEach(() => {
+            mockFs = Mock.ofType<typeof fs>();
+            testSubject = new TempDirCreator(mockFs.object, stubPath);
+        });
+
+        it('passes through to the expected fs and path APIs', () => {
+            const baseTempDir = '/base/temp/dir';
+            const expectedmkdtempSyncInput = '/base/temp/dirSEPaccessibility-insights-action-';
+            const mkdtempSyncOutput = 'mkdtempSyncOutput';
+            mockFs.setup((m) => m.mkdtempSync(expectedmkdtempSyncInput)).returns(() => mkdtempSyncOutput);
+
+            const output = testSubject.createTempDirSync(baseTempDir);
+
+            expect(output).toBe(mkdtempSyncOutput);
+            mockFs.verifyAll();
+        });
+
+        it('propagates exceptions from fs.mkdtempSync', () => {
+            const mkdtempSyncError = new Error('from mkdtempSync');
+            mockFs
+                .setup((m) => m.mkdtempSync(It.isAny()))
+                .throws(mkdtempSyncError)
+                .verifiable();
+
+            expect(() => testSubject.createTempDirSync('irrelevant')).toThrowError(mkdtempSyncError);
+
+            mockFs.verifyAll();
+        });
+    });
+});

--- a/packages/shared/src/utils/temp-dir-creator.ts
+++ b/packages/shared/src/utils/temp-dir-creator.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { injectable } from 'inversify';
+
+@injectable()
+export class TempDirCreator {
+    constructor(private readonly fsObj: typeof fs = fs, private readonly pathObj: typeof path = path) {}
+
+    public createTempDirSync(baseTempDir?: string): string {
+        const prefix = `${baseTempDir}${this.pathObj.sep}accessibility-insights-action-`;
+        return this.fsObj.mkdtempSync(prefix);
+    }
+}


### PR DESCRIPTION
#### Details

This PR updates the ADO `outputDir` input to be optional without a default, instead of defaulting to `_accessibility-reports`, and to create a uniquely generated temp directory to use for `outputDir` if none is specified.

This PR intentionally does not update the GitHub Action with the same behavior because we didn't implement the embedded artifact uploading there, and it doesn't make sense to use a temp dir without the automatic artifact uploading. I did put the interesting part of the temp file generation in the `shared` package - I think if we wanted to implement it in the action in the future, it might makes sense to move the current `AdoTaskConfig.getReportOutDir` implementation into the base `TaskConfig` class as a wrapper around private-protected `getRawOutputDir` methods overriden by the subclasses.

##### Motivation

Now that uploading the output as an artifact is default, embedded behavior, the `outputDir` is an implementation detail for most users. We noticed in #1135 that it felt awkward to have to specify an implementation detail just to run the task multiple times from one pipeline, so this PR updates the default behavior to avoid having to do that.

This is technically breaking, since a user could previously have had a publish step that relied on the default _accessibility-reports directory, so it's been documented in the v1 to v2 docs.

##### Context

I think it would be nice for us to detect and give a nice error in the case where `outputDir` is specified explicitly in a way which is not unique among multiple steps in the same pipeline (probably by detecting if it already exists and erroring if so). I've left that out of scope for this PR since I expect it might make sense to fold it into the other input validation stuff @ThanyaLeif is in progress on.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1940706
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
