### PR TITLE
fix: Fixing one instance of async vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3082,10 +3082,10 @@ async@^1.4.0:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
-async@^2.0.0:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
-  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
+async@^2.0.
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
+  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
   dependencies:
     lodash "^4.17.14"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3082,7 +3082,7 @@ async@^1.4.0:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
-async@^2.0.
+async@^2.0.0:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
   integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==


### PR DESCRIPTION
#### Details

This PR partially addresses [this dependabot alert](https://github.com/microsoft/accessibility-insights-action/security/dependabot/16) about using a vulnerable version of "async." Where possible, it updates the dependencies we have that rely on async and bumps them to use a current, secure version of the package. For the case where this is not possible, we are choosing to resolve this dependabot alert without fixing them, as the amount of work required to make a fix is not logical for the low risk that this vulnerability poses for us.  

This dependency was updated by removing and re-adding the async@^2.0 entry of the lockfile, since our caret version, when refreshed, would bump up to a secure version of async (2.6.4). 

##### Motivation

Keeping dependencies up-to-date.

##### Context

This change leaves a few dependencies on async at lower-than-secure versions. Secure versions of async are specifically 2.6.4, and then 3.2.3 and above. However, there are other dependencies of ours which rely on things which rely on things (and so on)... which rely on async at a vulnerable version.  Namely, tfx-cli at its latest version relies on async ^1.4.0. Additionally, tfx-cli has a dependency on prompt, which relies on async ~0.9.0, and which also has its own dependency on winston 2.x, which uses async ~1.0.0.  

Options considered: 
- Get prompt to use the 3.x version of winston, which relies on an up-to-date version of async.  [This open issue](https://github.com/flatiron/prompt/issues/195) indicates that the prompt repo owner doesn't intend to do that.  That issue and [this other issue](https://github.com/flatiron/prompt/issues/223) suggest that the maintainer is also considering archiving the project generally. Looking into [winston's changelogs](https://github.com/winstonjs/winston/blob/master/CHANGELOG.md) confirm that the work to get prompt to be able to accept a high enough version of winston is significant and not likely something our team wants to take on.
- Get the 2.x version of winston to rely on a safe version of async.  From looking at [async's changelogs](https://github.com/caolan/async/blob/master/CHANGELOG.md), this is also a non-trivial amount of work. 
- Tfx-cli also has [an open issue](https://github.com/microsoft/tfs-cli/issues/407) to upgrade its dependencies, but since there are [other older asks for tfx-cli to update away from vulnerable dependencies](https://github.com/microsoft/tfs-cli/issues/392) that haven't been addressed, and generally the [tfx repo](https://github.com/microsoft/tfs-cli) doesn't see very frequent changes, it is unlikely that someone else will take care of this for us. 
- Investigation into how tfx-cli is used in our repo shows that it is only a dev dependency for us, and that the input is not user-controlled.  Since the dependabot alert is about prototype pollution, this is quite low-risk for us. So, that gives us the option to accept that limited risk and close out the dependabot alert without making any other changes besides the one in this PR; this is the option we are going with. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
