### PR TITLE
chore: update PR template to encourage information about how GH action & ADO extension were affected

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,3 +18,4 @@
 - [ ] Added relevant unit test for your changes. (`yarn test`)
 - [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
 - [ ] Ran precheckin (`yarn precheckin`)
+- [ ] Described how this PR impacts both the ADO extension and the GitHub action


### PR DESCRIPTION
#### Details

Updating the PR template to encourage more information about how changes affect the ADO extension and/or GitHub action. In recent validation it was a little difficult to tell from the titles alone.

I'm equally happy with other ideas like tags, an explicit text section in this template, or individual checkboxes for impact to GH Action / ADO extension. Some of these might help with automated tooling during validation (for instance, a checkbox for each). Starting with something simple for now.

##### Motivation

Make it easier to understand how a change affects the extension / action since they share a lot of code but the feature-set is different.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [docs] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [docs] Ran precheckin (`yarn precheckin`)
