### PR TITLE
chore: remove obsolete Dependabot README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Licensed under the MIT License.
 
 [![Actions Status](https://github.com/microsoft/accessibility-insights-action/workflows/Build/badge.svg)](https://github.com/microsoft/accessibility-insights-action/actions)
 [![codecov](https://codecov.io/gh/microsoft/accessibility-insights-action/branch/main/graph/badge.svg)](https://codecov.io/gh/microsoft/accessibility-insights-action)
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=microsoft/accessibility-insights-action)](https://dependabot.com)
 
 _This action is still in early development & we don't recommend its usage in public production projects yet._
 


### PR DESCRIPTION
#### Details

Dependabot's README badges broke when the old non-GitHub Dependabot migrated to GitHub. This PR removes the broken badge.

##### Motivation

Fixes broken link/image at top of README

##### Context

There isn't currently a replacement for the badge feature in the native GitHub Dependabot. https://github.com/dependabot/dependabot-core/issues/1912 tracks the request to add it, but hasn't seen activity in some time.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] Described how this PR impacts both the ADO extension and the GitHub action
