### PR TITLE
feat(ado-ext-telemetry: clean up labels and help text for hosting modes in classic pipelines

### DIFF
--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -210,7 +210,7 @@ Version 2.x of the extension contains several breaking changes from version 1.x.
     - If you did not previously specify an "Azure Repos Connection", it likely means that the default Azure DevOps Build Service account for your Azure DevOps project has been granted the `repo:write` permission for this repository. You should audit for this and remove that permission if it is not required by other tasks.
 2. The options related to specifying which site to scan have moved underneath a new "Hosting Mode" option to make it more clear which ones can be used together.
     - If you previously specified a "Site Directory", select the "Static Site" Hosting Mode
-        - The "Static Site Directory", "Static Site Localhost Port" and "Static Site URL Relative Path" task inputs now appear only when "Static Site" is selected
+        - The "Static Site Directory", "Static Site Port" and "Static Site URL Relative Path" task inputs now appear only when "Static Site" is selected
     - If you previously specified a "Website URL", select the "Dynamic Site" "Hosting Mode"
         - The "Dynamic Site URL" option now appears only when "Dynamic Site" is selected
     - If you previously specified _both_ as "Site Directory" and a "Website URL", you had a misconfiguration - these options were mutually exclusive, and the "Website URL" option was being silently ignored. Select "Static Site" Hosting Mode and ignore your old "Website URL" input

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -209,18 +209,18 @@ Version 2.x of the extension contains several breaking changes from version 1.x.
     - There is no longer an option for "Azure Repos Connection". If you previously specified a Service Connection using this option, and that Service Connection was created solely for use with this pipeline, you should delete it in your Azure DevOps Project's "Service Connections" settings.
     - If you did not previously specify an "Azure Repos Connection", it likely means that the default Azure DevOps Build Service account for your Azure DevOps project has been granted the `repo:write` permission for this repository. You should audit for this and remove that permission if it is not required by other tasks.
 2. The options related to specifying which site to scan have moved underneath a new "Hosting Mode" option to make it more clear which ones can be used together.
-    - If you previously specified a "Site Directory", select the `staticSite` "Hosting Mode"
-        - The "Site Directory", "Localhost Port" and "Scan URL Relative Path" task inputs now appear only when `staticSite` is selected
-    - If you previously specified a "Website URL", select the `dynamicSite` "Hosting Mode"
-        - The "Website URL" option now appears only when `dynamicSite` is selected
-    - If you previously specified _both_ as "Site Directory" and a "Website URL", you had a misconfiguration - these options were mutually exclusive, and the "Website URL" option was being silently ignored. Select `staticSite` mode and ignore your old "Website URL" input
+    - If you previously specified a "Site Directory", select the "Static Site" Hosting Mode
+        - The "Static Site Directory", "Static Site Localhost Port" and "Static Site URL Relative Path" task inputs now appear only when "Static Site" is selected
+    - If you previously specified a "Website URL", select the "Dynamic Site" "Hosting Mode"
+        - The "Dynamic Site URL" option now appears only when "Dynamic Site" is selected
+    - If you previously specified _both_ as "Site Directory" and a "Website URL", you had a misconfiguration - these options were mutually exclusive, and the "Website URL" option was being silently ignored. Select "Static Site" Hosting Mode and ignore your old "Website URL" input
 3. Publishing a pipeline artifact containing scan results is now built into the Accessibility Insights task, instead of being a separate step you must add yourself afterwards
     - If you previously used a separate "Publish" step to upload the `_accessibility-reports` folder, you can delete that "Publish" step
     - If your pipeline is running in OneBranch, or any other environment where individual tasks cannot publish artifacts directly, uncheck the "Upload Output Artifact" option to skip the new automatic artifact uploading. You can specify an "Output Directory" to control where the output artifact contents get written to on the build agent
     - See [Report Artifacts](#report-artifacts) for more details, including how to customize the artifact name
 4. The "Fail on Accessibility Error" option is now checked by default; when it is checked, the task will fail if it detects an accessibility failure (unless the failure is a known issue tracked by a [Baseline File](#using-a-baseline-file))
     - If you would prefer to keep the old behavior, where accessibility issues are not treated as a task failure, you can still uncheck this option (but consider [using a Baseline File](#using-a-baseline-file) instead!)
-5. The "Output Directory" and "Chrome Path" options have moved under a new "Advanced Options" group
+5. The "Chrome Path" option has moved under a new "Advanced Options" group
 
 ## Troubleshooting
 

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -57,7 +57,7 @@
         {
             "name": "staticSitePort",
             "type": "int",
-            "label": "Static Site Localhost Port",
+            "label": "Static Site Port",
             "required": false,
             "helpMarkDown": "The preferred local website TCP port to use when scanning local website content.",
             "visibleRule": "hostingMode = staticSite"

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -32,14 +32,15 @@
             "label": "Hosting Mode",
             "required": true,
             "options": {
-                "staticSite": "We host your site",
-                "dynamicSite": "Host your own site"
-            }
+                "staticSite": "Static Site (this task runs a localhost webserver for your site)",
+                "dynamicSite": "Dynamic Site (you host your site separately)"
+            },
+            "helpMarkDown": "Your site must be served (hosted) before it can be scanned. In _Static Site_ mode, this task will run a localhost webserver serving your site directory and scan that. In _Dynamic Site_ mode, you must host your site yourself separately and specify a URL to scan. This can be either a localhost server you run in an earlier pipeline step, or a remote URL (for example, a staging environment)."
         },
         {
             "name": "staticSiteDir",
             "type": "string",
-            "label": "Site Directory",
+            "label": "Static Site Directory",
             "required": true,
             "helpMarkDown": "Folder containing website content.",
             "visibleRule": "hostingMode = staticSite"
@@ -47,7 +48,7 @@
         {
             "name": "staticSiteUrlRelativePath",
             "type": "string",
-            "label": "Scan URL Relative Path",
+            "label": "Static Site URL Relative Path",
             "required": false,
             "defaultValue": "/",
             "helpMarkDown": "Relative path to directory used to construct base scan url. e.g. / on Ubuntu and // on Windows.",
@@ -56,7 +57,7 @@
         {
             "name": "staticSitePort",
             "type": "int",
-            "label": "Localhost Port",
+            "label": "Static Site Localhost Port",
             "required": false,
             "helpMarkDown": "The preferred local website TCP port to use when scanning local website content.",
             "visibleRule": "hostingMode = staticSite"
@@ -64,7 +65,7 @@
         {
             "name": "url",
             "type": "string",
-            "label": "Website URL",
+            "label": "Dynamic Site URL",
             "required": true,
             "helpMarkDown": "The hosted URL to scan/crawl for accessibility issues.",
             "visibleRule": "hostingMode = dynamicSite"
@@ -101,7 +102,7 @@
         {
             "name": "scanTimeout",
             "type": "int",
-            "label": "Scan Timeout",
+            "label": "Scan Timeout (milliseconds)",
             "defaultValue": "90000",
             "required": false,
             "helpMarkDown": "The maximum timeout in milliseconds for the scan (excluding dependency setup)."


### PR DESCRIPTION
#### Details

This PR updates the labels and help text around hosting mode inputs for Classic Pipelines to be consistent with the docs/naming/error test used by YAML pipelines.

ADO-only change, no GHA impact.

##### Motivation

Want to preempt confusion from some error message/usage docs talking about "static vs dynamic" hosting mode, when the actual option labels don't use those terms.

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
