### PR TITLE
fix(ado-ext-telemetry): fix failOnAccessibilityError interaction with baseline files

### DIFF
--- a/packages/ado-extension/src/progress-reporter/enforcement/__snapshots__/workflow-enforcer.spec.ts.snap
+++ b/packages/ado-extension/src/progress-reporter/enforcement/__snapshots__/workflow-enforcer.spec.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WorkflowEnforcer completeRun with baseline and failOnAccessibilityError=false fails with pinned error log if baseline needs to be updated 1`] = `
+Array [
+  "[info] ##vso[task.logissue type=error;sourcepath=/some/file] The baseline file does not match scan results.",
+]
+`;
+
+exports[`WorkflowEnforcer completeRun with baseline and failOnAccessibilityError=true fails with pinned error log if baseline needs to be updated 1`] = `
+Array [
+  "[info] ##vso[task.logissue type=error;sourcepath=/some/file] The baseline file does not match scan results.",
+]
+`;
+
+exports[`WorkflowEnforcer completeRun without baseline fails with pinned error log if accessibility error occurs and failOnAccessibilityError=true 1`] = `
+Array [
+  "[error] Accessibility error(s) were found",
+  "[info] To prevent accessibility errors from failing your build, you can:
+* Use a baseline file to avoid failing for known issues, or
+* Set the failOnAccessibilityError task input to false to avoid failing for all issues",
+]
+`;

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.spec.ts
@@ -112,14 +112,10 @@ describe(WorkflowEnforcer, () => {
     });
 
     const setupFailOnAccessibilityErrorInput = (fail: boolean) => {
-        adoTaskConfigMock
-            .setup((o) => o.getFailOnAccessibilityError())
-            .returns(() => fail);
+        adoTaskConfigMock.setup((o) => o.getFailOnAccessibilityError()).returns(() => fail);
     };
 
     const setupBaselineFileInput = (baselineFile: undefined | string) => {
-        adoTaskConfigMock
-            .setup((o) => o.getBaselineFile())
-            .returns(() => baselineFile);
+        adoTaskConfigMock.setup((o) => o.getBaselineFile()).returns(() => baselineFile);
     };
 });

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.spec.ts
@@ -2,135 +2,124 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import { Mock, Times, IMock, MockBehavior } from 'typemoq';
+import { Mock, IMock, MockBehavior } from 'typemoq';
 import { ADOTaskConfig } from '../../task-config/ado-task-config';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 
 import { BaselineEvaluation, BaselineFileContent } from 'accessibility-insights-scan';
 import { WorkflowEnforcer } from './workflow-enforcer';
-import { Logger } from '@accessibility-insights-action/shared';
+import { RecordingTestLogger } from '@accessibility-insights-action/shared';
 
 describe(WorkflowEnforcer, () => {
     let adoTaskConfigMock: IMock<ADOTaskConfig>;
-    let loggerMock: IMock<Logger>;
-    let workflowEnforcer: WorkflowEnforcer;
+    let logger: RecordingTestLogger;
+    let testSubject: WorkflowEnforcer;
+
+    const reportWithErrors = {
+        results: {
+            urlResults: {
+                failedUrls: 1,
+            },
+        },
+    } as unknown as CombinedReportParameters;
+    const reportWithoutErrors = {
+        results: {
+            urlResults: {
+                failedUrls: 0,
+            },
+        },
+    } as unknown as CombinedReportParameters;
+    const emptyBaselineEvaluation = {} as BaselineEvaluation;
+    const baselineEvaluationWithSuggestedUpdate = {
+        suggestedBaselineUpdate: {} as BaselineFileContent,
+    } as BaselineEvaluation;
+    const baselineEvaluationWithoutSuggestedUpdate = {
+        suggestedBaselineUpdate: null,
+    } as BaselineEvaluation;
 
     beforeEach(() => {
         adoTaskConfigMock = Mock.ofType<ADOTaskConfig>(undefined, MockBehavior.Strict);
-        loggerMock = Mock.ofType<Logger>(undefined, MockBehavior.Strict);
-    });
-
-    describe('constructor', () => {
-        it('initializes', () => {
-            workflowEnforcer = buildWorkflowEnforcerWithMocks();
-
-            verifyAllMocks();
-        });
+        logger = new RecordingTestLogger();
+        testSubject = new WorkflowEnforcer(adoTaskConfigMock.object, logger);
     });
 
     describe('completeRun', () => {
-        it('logs correct error if accessibility error occurred', async () => {
-            const reportStub = {
-                results: {
-                    urlResults: {
-                        failedUrls: 1,
-                    },
+        describe('without baseline', () => {
+            beforeEach(() => {
+                setupBaselineFileInput(undefined);
+            });
+
+            it('fails with pinned error log if accessibility error occurs and failOnAccessibilityError=true', async () => {
+                setupFailOnAccessibilityErrorInput(true);
+
+                await testSubject.completeRun(reportWithErrors, emptyBaselineEvaluation);
+
+                expect(logger.recordedLogs()).toMatchSnapshot();
+                await expect(testSubject.didScanSucceed()).resolves.toBe(false);
+            });
+
+            it.each`
+                accessibilityErrorExists | failOnAccessibilityError
+                ${true}                  | ${false}
+                ${false}                 | ${false}
+                ${false}                 | ${true}
+            `(
+                'succeeds silently when accessibilityErrorExists=$accessibilityErrorExists and failOnAccessibilityError=$failOnAccessibilityError',
+                async ({ accessibilityErrorExists, failOnAccessibilityError }) => {
+                    setupFailOnAccessibilityErrorInput(failOnAccessibilityError);
+
+                    const report = accessibilityErrorExists ? reportWithErrors : reportWithoutErrors;
+                    await testSubject.completeRun(report, emptyBaselineEvaluation);
+
+                    expect(logger.recordedLogs()).toStrictEqual([]);
+                    await expect(testSubject.didScanSucceed()).resolves.toBe(true);
                 },
-            } as unknown as CombinedReportParameters;
-            const baselineEvaluationStub = {} as BaselineEvaluation;
-
-            setupFailOnAccessibilityError(true);
-            setupLoggerWithErrorMessage('An accessibility error was found and you specified the "failOnAccessibilityError" flag.');
-
-            const workflowEnforcer = buildWorkflowEnforcerWithMocks();
-
-            await workflowEnforcer.completeRun(reportStub, baselineEvaluationStub);
-
-            verifyAllMocks();
+            );
         });
 
-        it('logs correct error if baseline needs to be updated', async () => {
-            const reportStub = {} as CombinedReportParameters;
-            const baselineEvaluationStub = {
-                suggestedBaselineUpdate: {} as BaselineFileContent,
-            } as BaselineEvaluation;
+        // All baseline behavior should be independent of failOnAccessibilityError
+        describe.each([true, false])('with baseline and failOnAccessibilityError=%p', (failOnAccessibilityError) => {
+            beforeEach(() => {
+                setupBaselineFileInput('/some/file');
+                setupFailOnAccessibilityErrorInput(failOnAccessibilityError);
+            });
 
-            setupFailOnAccessibilityError(false);
-            setupBaselineFileParameterExists();
-            loggerMock
-                .setup((o) =>
-                    o.logInfo(`##vso[task.logissue type=error;sourcepath=baseline-file] The baseline file does not match scan results.`),
-                )
-                .verifiable(Times.once());
+            it('fails with pinned error log if baseline needs to be updated', async () => {
+                await testSubject.completeRun(reportWithErrors, baselineEvaluationWithSuggestedUpdate);
 
-            const workflowEnforcer = buildWorkflowEnforcerWithMocks();
+                expect(logger.recordedLogs()).toMatchSnapshot();
+                await expect(testSubject.didScanSucceed()).resolves.toBe(false);
+            });
 
-            await workflowEnforcer.completeRun(reportStub, baselineEvaluationStub);
+            it('succeeds silently if baseline does not need update', async () => {
+                await testSubject.completeRun(reportWithErrors, baselineEvaluationWithoutSuggestedUpdate);
 
-            verifyAllMocks();
-        });
-
-        it('succeeds in happy path (baseline enabled)', async () => {
-            const reportStub = {} as CombinedReportParameters;
-            const baselineEvaluationStub = {} as BaselineEvaluation;
-
-            setupFailOnAccessibilityError(false);
-            setupBaselineFileParameterExists();
-
-            const workflowEnforcer = buildWorkflowEnforcerWithMocks();
-
-            await workflowEnforcer.completeRun(reportStub, baselineEvaluationStub);
-
-            verifyAllMocks();
-        });
-
-        it('succeeds in happy path (baselineEvaluation not provided)', async () => {
-            const reportStub = {} as CombinedReportParameters;
-
-            setupFailOnAccessibilityError(false);
-
-            workflowEnforcer = buildWorkflowEnforcerWithMocks();
-
-            await workflowEnforcer.completeRun(reportStub);
-
-            verifyAllMocks();
+                expect(logger.recordedLogs()).toStrictEqual([]);
+                await expect(testSubject.didScanSucceed()).resolves.toBe(true);
+            });
         });
     });
 
     describe('didScanSucceed', () => {
         it('returns true by default', async () => {
-            const workflowEnforcer = buildWorkflowEnforcerWithMocks();
-            await expect(workflowEnforcer.didScanSucceed()).resolves.toBe(true);
+            await expect(testSubject.didScanSucceed()).resolves.toBe(true);
         });
 
         it('returns false after failRun() is called', async () => {
-            const workflowEnforcer = buildWorkflowEnforcerWithMocks();
-            await workflowEnforcer.failRun();
-            await expect(workflowEnforcer.didScanSucceed()).resolves.toBe(false);
+            await testSubject.failRun();
+            await expect(testSubject.didScanSucceed()).resolves.toBe(false);
         });
     });
 
-    const buildWorkflowEnforcerWithMocks = () => new WorkflowEnforcer(adoTaskConfigMock.object, loggerMock.object);
-
-    const verifyAllMocks = () => {
-        adoTaskConfigMock.verifyAll();
-    };
-
-    const setupFailOnAccessibilityError = (fail: boolean) => {
+    const setupFailOnAccessibilityErrorInput = (fail: boolean) => {
         adoTaskConfigMock
             .setup((o) => o.getFailOnAccessibilityError())
-            .returns(() => fail)
-            .verifiable(Times.atLeastOnce());
+            .returns(() => fail);
     };
 
-    const setupBaselineFileParameterExists = () => {
+    const setupBaselineFileInput = (baselineFile: undefined | string) => {
         adoTaskConfigMock
             .setup((o) => o.getBaselineFile())
-            .returns(() => 'baseline-file')
-            .verifiable(Times.atLeastOnce());
-    };
-
-    const setupLoggerWithErrorMessage = (message: string) => {
-        loggerMock.setup((o) => o.logError(message)).verifiable(Times.once());
+            .returns(() => baselineFile);
     };
 });

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
@@ -47,7 +47,7 @@ export class WorkflowEnforcer extends ProgressReporter {
                     'To prevent accessibility errors from failing your build, you can:',
                     '* Use a baseline file to avoid failing for known issues, or',
                     '* Set the failOnAccessibilityError task input to false to avoid failing for all issues',
-                ].join("\n"),
+                ].join('\n'),
             );
 
             await this.failRun();

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
@@ -6,7 +6,6 @@ import { inject, injectable } from 'inversify';
 import { Logger, ProgressReporter } from '@accessibility-insights-action/shared';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 import { BaselineEvaluation } from 'accessibility-insights-scan';
-import { listItem, sectionSeparator } from '@accessibility-insights-action/shared/dist/mark-down/markdown-formatter';
 
 @injectable()
 export class WorkflowEnforcer extends ProgressReporter {
@@ -46,9 +45,9 @@ export class WorkflowEnforcer extends ProgressReporter {
             this.logger.logInfo(
                 [
                     'To prevent accessibility errors from failing your build, you can:',
-                    listItem('Use a baseline file to avoid failing for known issues, or'),
-                    listItem('Set the failOnAccessibilityError task input to false to avoid failing for all issues'),
-                ].join(sectionSeparator()),
+                    '* Use a baseline file to avoid failing for known issues, or',
+                    '* Set the failOnAccessibilityError task input to false to avoid failing for all issues',
+                ].join("\n"),
             );
 
             await this.failRun();

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
@@ -43,11 +43,13 @@ export class WorkflowEnforcer extends ProgressReporter {
     private async failIfAccessibilityErrorExists(combinedReportResult: CombinedReportParameters): Promise<void> {
         if (this.adoTaskConfig.getFailOnAccessibilityError() && combinedReportResult.results.urlResults.failedUrls > 0) {
             this.logger.logError('Accessibility error(s) were found');
-            this.logger.logInfo([
-                'To prevent accessibility errors from failing your build, you can:',
-                listItem('Use a baseline file to avoid failing for known issues, or'),
-                listItem('Set the failOnAccessibilityError task input to false to avoid failing for all issues')
-            ].join(sectionSeparator()));
+            this.logger.logInfo(
+                [
+                    'To prevent accessibility errors from failing your build, you can:',
+                    listItem('Use a baseline file to avoid failing for known issues, or'),
+                    listItem('Set the failOnAccessibilityError task input to false to avoid failing for all issues'),
+                ].join(sectionSeparator()),
+            );
 
             await this.failRun();
         }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@
 
 export { setupSharedIocContainer } from './ioc/setup-ioc-container';
 export { Logger } from './logger/logger';
+export { RecordingTestLogger } from './logger/recording-test-logger';
 export { Scanner } from './scanner/scanner';
 export { iocTypes } from './ioc/ioc-types';
 export { ProgressReporter } from './progress-reporter/progress-reporter';

--- a/packages/shared/src/logger/recording-test-logger.spec.ts
+++ b/packages/shared/src/logger/recording-test-logger.spec.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { LogLevel } from './log-level';
+import { RecordingTestLogger } from './recording-test-logger';
+
+describe(RecordingTestLogger, () => {
+    it('records different log calls in order with readable snapshotting', () => {
+        const testSubject = new RecordingTestLogger();
+        testSubject.log('message 1 (info)', LogLevel.info);
+        testSubject.logDebug('message 2 (debug)');
+        testSubject.logInfo('message 3 (info)');
+        testSubject.logInfo('message 4 (info w/props)', { key: 'val' });
+        testSubject.trackException(new Error('message 5 (exception)'));
+        testSubject.trackExceptionAny('error', 'message 6 (exceptionAny)');
+        testSubject.logWarning('message 7 (warning)');
+        testSubject.logError('message 8 (error)');
+        testSubject.logStartGroup('message 9 (start group)');
+        testSubject.logEndGroup();
+
+        expect(testSubject.recordedLogs()).toMatchInlineSnapshot(`
+            Array [
+              "[info] message 1 (info)",
+              "[debug] message 2 (debug)",
+              "[info] message 3 (info)",
+              Object {
+                "message": "[info] message 4 (info w/props)",
+                "properties": Object {
+                  "key": "val",
+                },
+              },
+              Object {
+                "exception": [Error: message 5 (exception)],
+              },
+              Object {
+                "exception": [ErrorWithCause: message 6 (exceptionAny)],
+              },
+              "[warning] message 7 (warning)",
+              "[error] message 8 (error)",
+              "[group] message 9 (start group)",
+              "[endgroup] ",
+            ]
+        `);
+    });
+});

--- a/packages/shared/src/logger/recording-test-logger.ts
+++ b/packages/shared/src/logger/recording-test-logger.ts
@@ -10,12 +10,15 @@ import * as process from 'process';
 // when a test does expect(recordingLogger.recordedLogs()).toMatchSnapshot()
 // Particularly, "Simple" logs (messages with no properties) will show up in
 // snapshots as simple strings.
-export type LogRecord = string | {
-    message: string,
-    properties?: { [name: string]: string }
-} | {
-    exception: Error,
-};
+export type LogRecord =
+    | string
+    | {
+          message: string;
+          properties?: { [name: string]: string };
+      }
+    | {
+          exception: Error;
+      };
 
 export class RecordingTestLogger extends Logger {
     private client: RecordingLoggerClient;
@@ -34,14 +37,18 @@ export class RecordingTestLogger extends Logger {
 class RecordingLoggerClient implements LoggerClient {
     public logRecords: LogRecord[] = [];
 
-    log(message: string, logLevel: LogLevel, properties?: {
-        [name: string]: string;
-    }): void {
+    log(
+        message: string,
+        logLevel: LogLevel,
+        properties?: {
+            [name: string]: string;
+        },
+    ): void {
         const messageWithLevel = `[${LogLevel[logLevel]}] ${message}`;
         if (properties) {
             this.logRecords.push({
                 message: messageWithLevel,
-                properties
+                properties,
             });
         } else {
             this.logRecords.push(messageWithLevel);
@@ -49,12 +56,12 @@ class RecordingLoggerClient implements LoggerClient {
     }
     trackException(error: Error): void {
         this.logRecords.push({
-            exception: error
+            exception: error,
         });
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await
-    async setup(baseProperties?: { [index: string]: string; }): Promise<void> {
+    async setup(baseProperties?: { [index: string]: string }): Promise<void> {
         throw new Error('Not supported');
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/shared/src/logger/recording-test-logger.ts
+++ b/packages/shared/src/logger/recording-test-logger.ts
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { LoggerClient } from './logger-client';
+import { LogLevel } from './log-level';
+import { Logger } from './logger';
+import { LoggerProperties } from './logger-properties';
+import * as process from 'process';
+
+// We allow this type to be complex in order to produce readable snapshots
+// when a test does expect(recordingLogger.recordedLogs()).toMatchSnapshot()
+// Particularly, "Simple" logs (messages with no properties) will show up in
+// snapshots as simple strings.
+export type LogRecord = string | {
+    message: string,
+    properties?: { [name: string]: string }
+} | {
+    exception: Error,
+};
+
+export class RecordingTestLogger extends Logger {
+    private client: RecordingLoggerClient;
+    constructor(currentProcess: typeof process = process) {
+        const client = new RecordingLoggerClient();
+        super([client], currentProcess);
+        this.client = client;
+        this.initialized = true;
+    }
+
+    public recordedLogs(): LogRecord[] {
+        return [...this.client.logRecords];
+    }
+}
+
+class RecordingLoggerClient implements LoggerClient {
+    public logRecords: LogRecord[] = [];
+
+    log(message: string, logLevel: LogLevel, properties?: {
+        [name: string]: string;
+    }): void {
+        const messageWithLevel = `[${LogLevel[logLevel]}] ${message}`;
+        if (properties) {
+            this.logRecords.push({
+                message: messageWithLevel,
+                properties
+            });
+        } else {
+            this.logRecords.push(messageWithLevel);
+        }
+    }
+    trackException(error: Error): void {
+        this.logRecords.push({
+            exception: error
+        });
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await
+    async setup(baseProperties?: { [index: string]: string; }): Promise<void> {
+        throw new Error('Not supported');
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    setCustomProperties(properties: LoggerProperties): void {
+        throw new Error('Not supported');
+    }
+}


### PR DESCRIPTION
#### Details

The new `failOnAccessibilityError: true` default behavior interacts poorly with baseline files; it causes accessibility errors which are baselined to still fail the build, which defeats the purpose of the baseline file.

This PR updates the workflow enforcer behavior to ignore `failOnAccessibilityError` entirely if a baseline file is specified, instead.

It also improves the error output in the default case (no baseline file, default `failOnAccessibilityError` setting); previously, an accessibility error in that state would produce build log error output like this:

```
##[error]An accessibility error was found and you specified the "failOnAccessibilityError" flag.
```

This is misleading, because the common case is now going to be that the user actually didn't specify `failOnAccessibilityError` themselves at all. The error now instead reads:

```
##[error]Accessibility error(s) were found
To prevent accessibility errors from failing your build, you can:
* Use a baseline file to avoid failing for known issues, or
* Set the failOnAccessibilityError task input to false to avoid failing for all issues
```

I also introduced a new test utility class (`RecordingTestLogger`) to enable the use of snapshots with the workflow enforcer error messages; this is something @ThanyaLeif and I considered adding in #1149 , so it seems like a repeatedly useful concept.

This is an ADO-only change; the workflow enforcer, baseline functionality, and `failOnAccessibilityError` inputs are all ADO-specific.

##### Motivation

Fix issues caught during feature release validation

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1893588
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
