### PR TITLE
feat(ado-ext-telemetry): improve Extensions tab summary header

### DIFF
--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -34,7 +34,6 @@ describe(AdoConsoleCommentCreator, () => {
     const baselineInfoStub = {};
     const reportMarkdownStub = '#ReportMarkdownStub';
     const reportConsoleLogStub = 'Report Console Log Stub';
-    
 
     beforeEach(() => {
         adoTaskConfigMock = Mock.ofType<ADOTaskConfig>();
@@ -66,66 +65,77 @@ describe(AdoConsoleCommentCreator, () => {
 
     describe('completeRun', () => {
         it.each`
-            uploadOutputArtifact | outputArtifactName           | jobAttempt | expectedSummaryFilePath
-            ${ false }           | ${ 'accessibility-reports' } | ${1}       | ${ 'reportOutDir/Accessibility Insights scan summary.md' }
-            ${ false }           | ${ 'custom-artifact' }       | ${1}       | ${ 'reportOutDir/Accessibility Insights scan summary.md' }
-            ${ false }           | ${ 'accessibility-reports' } | ${2}       | ${ 'reportOutDir/Accessibility Insights scan summary.md' }
-            ${ true }            | ${ 'accessibility-reports' } | ${1}       | ${ 'reportOutDir/Accessibility Insights scan summary.md' }
-            ${ true }            | ${ 'custom-artifact' }       | ${1}       | ${ 'reportOutDir/Accessibility Insights scan summary (custom-artifact).md' }
-            ${ true }            | ${ 'accessibility-reports' } | ${2}       | ${ 'reportOutDir/Accessibility Insights scan summary (accessibility-reports-2).md' }
-        `('should create and upload a job summary with the expected filename for inputs uploadOutputArtifact=$uploadOutputArtifact, outputArtifactName=$outputArtifactName, jobAttempt=$jobAttempt', async ({
-            uploadOutputArtifact, outputArtifactName, jobAttempt, expectedSummaryFilePath
-        }) => {
-            setupTaskConfig({
-                uploadOutputArtifact, outputArtifactName, jobAttempt
-            });
+            uploadOutputArtifact | outputArtifactName         | jobAttempt | expectedSummaryFilePath
+            ${false}             | ${'accessibility-reports'} | ${1}       | ${'reportOutDir/Accessibility Insights scan summary.md'}
+            ${false}             | ${'custom-artifact'}       | ${1}       | ${'reportOutDir/Accessibility Insights scan summary.md'}
+            ${false}             | ${'accessibility-reports'} | ${2}       | ${'reportOutDir/Accessibility Insights scan summary.md'}
+            ${true}              | ${'accessibility-reports'} | ${1}       | ${'reportOutDir/Accessibility Insights scan summary.md'}
+            ${true}              | ${'custom-artifact'}       | ${1}       | ${'reportOutDir/Accessibility Insights scan summary (custom-artifact).md'}
+            ${true}              | ${'accessibility-reports'} | ${2}       | ${'reportOutDir/Accessibility Insights scan summary (accessibility-reports-2).md'}
+        `(
+            'should create and upload a job summary with the expected filename for inputs uploadOutputArtifact=$uploadOutputArtifact, outputArtifactName=$outputArtifactName, jobAttempt=$jobAttempt',
+            async ({ uploadOutputArtifact, outputArtifactName, jobAttempt, expectedSummaryFilePath }) => {
+                setupTaskConfig({
+                    uploadOutputArtifact,
+                    outputArtifactName,
+                    jobAttempt,
+                });
 
-            // eslint-disable-next-line security/detect-non-literal-fs-filename
-            fsMock.setup((fsm) => fsm.writeFileSync(expectedSummaryFilePath, reportMarkdownStub)).verifiable(Times.once());
+                // eslint-disable-next-line security/detect-non-literal-fs-filename
+                fsMock.setup((fsm) => fsm.writeFileSync(expectedSummaryFilePath, reportMarkdownStub)).verifiable(Times.once());
 
-            await testSubject.completeRun(reportStub);
+                await testSubject.completeRun(reportStub);
 
-            expect(logger.recordedLogs()).toContain(`[info] ##vso[task.uploadsummary]${expectedSummaryFilePath}`);
-            verifyAllMocks();
-        });
-
-        it.each`
-            outputArtifactName           | jobAttempt | expectedArtifactName
-            ${ 'accessibility-reports' } | ${1}       | ${ 'accessibility-reports' }
-            ${ 'custom-artifact' }       | ${1}       | ${ 'custom-artifact' }
-            ${ 'accessibility-reports' } | ${2}       | ${ 'accessibility-reports-2' }
-            ${ 'custom-artifact' }       | ${2}       | ${ 'custom-artifact-2' }
-        `('should upload an artifact with the expected name for inputs uploadOutputArtifact=true, outputArtifactName=$outputArtifactName, jobAttempt=$jobAttempt', async ({
-            outputArtifactName, jobAttempt, expectedArtifactName
-        }) => {
-            setupTaskConfig({
-                uploadOutputArtifact: true, outputArtifactName, jobAttempt
-            });
-
-            await testSubject.completeRun(reportStub);
-
-            expect(logger.recordedLogs()).toContain(`[info] ##vso[artifact.upload artifactname=${expectedArtifactName}]${defaultReportOutDir}`);
-            verifyAllMocks();
-        });
+                expect(logger.recordedLogs()).toContain(`[info] ##vso[task.uploadsummary]${expectedSummaryFilePath}`);
+                verifyAllMocks();
+            },
+        );
 
         it.each`
-            outputArtifactName           | jobAttempt
-            ${ 'accessibility-reports' } | ${1}
-            ${ 'custom-artifact' }       | ${1}
-            ${ 'accessibility-reports' } | ${2}
-            ${ 'custom-artifact' }       | ${2}
-        `('should not upload an artifact inputs uploadOutputArtifact=false, outputArtifactName=$outputArtifactName, jobAttempt=$jobAttempt', async ({
-            outputArtifactName, jobAttempt
-        }) => {
-            setupTaskConfig({
-                uploadOutputArtifact: false, outputArtifactName, jobAttempt
-            });
+            outputArtifactName         | jobAttempt | expectedArtifactName
+            ${'accessibility-reports'} | ${1}       | ${'accessibility-reports'}
+            ${'custom-artifact'}       | ${1}       | ${'custom-artifact'}
+            ${'accessibility-reports'} | ${2}       | ${'accessibility-reports-2'}
+            ${'custom-artifact'}       | ${2}       | ${'custom-artifact-2'}
+        `(
+            'should upload an artifact with the expected name for inputs uploadOutputArtifact=true, outputArtifactName=$outputArtifactName, jobAttempt=$jobAttempt',
+            async ({ outputArtifactName, jobAttempt, expectedArtifactName }) => {
+                setupTaskConfig({
+                    uploadOutputArtifact: true,
+                    outputArtifactName,
+                    jobAttempt,
+                });
 
-            await testSubject.completeRun(reportStub);
+                await testSubject.completeRun(reportStub);
 
-            expect(logger.recordedLogs()).not.toContain( /##vso\[artifact.upload/ );
-            verifyAllMocks();
-        });
+                expect(logger.recordedLogs()).toContain(
+                    `[info] ##vso[artifact.upload artifactname=${expectedArtifactName}]${defaultReportOutDir}`,
+                );
+                verifyAllMocks();
+            },
+        );
+
+        it.each`
+            outputArtifactName         | jobAttempt
+            ${'accessibility-reports'} | ${1}
+            ${'custom-artifact'}       | ${1}
+            ${'accessibility-reports'} | ${2}
+            ${'custom-artifact'}       | ${2}
+        `(
+            'should not upload an artifact inputs uploadOutputArtifact=false, outputArtifactName=$outputArtifactName, jobAttempt=$jobAttempt',
+            async ({ outputArtifactName, jobAttempt }) => {
+                setupTaskConfig({
+                    uploadOutputArtifact: false,
+                    outputArtifactName,
+                    jobAttempt,
+                });
+
+                await testSubject.completeRun(reportStub);
+
+                expect(logger.recordedLogs()).not.toContain(/##vso\[artifact.upload/);
+                verifyAllMocks();
+            },
+        );
     });
 
     describe('failRun', () => {
@@ -154,31 +164,21 @@ describe(AdoConsoleCommentCreator, () => {
     });
 
     function setupTaskConfig(config: {
-        uploadOutputArtifact: boolean,
-        outputArtifactName: string,
-        jobAttempt: number,
-        baselineFile?: string,
-        reportOutDir?: string,
+        uploadOutputArtifact: boolean;
+        outputArtifactName: string;
+        jobAttempt: number;
+        baselineFile?: string;
+        reportOutDir?: string;
     }): void {
-        adoTaskConfigMock
-            .setup((atcm) => atcm.getUploadOutputArtifact())
-            .returns(() => config.uploadOutputArtifact);
+        adoTaskConfigMock.setup((atcm) => atcm.getUploadOutputArtifact()).returns(() => config.uploadOutputArtifact);
 
-        adoTaskConfigMock
-            .setup((atcm) => atcm.getVariable('System.JobAttempt'))
-            .returns(() => `${config.jobAttempt}`);
+        adoTaskConfigMock.setup((atcm) => atcm.getVariable('System.JobAttempt')).returns(() => `${config.jobAttempt}`);
 
-        adoTaskConfigMock
-            .setup((atcm) => atcm.getOutputArtifactName())
-            .returns(() => config.outputArtifactName);
+        adoTaskConfigMock.setup((atcm) => atcm.getOutputArtifactName()).returns(() => config.outputArtifactName);
 
-        adoTaskConfigMock
-            .setup((atcm) => atcm.getBaselineFile())
-            .returns(() => config.baselineFile);
+        adoTaskConfigMock.setup((atcm) => atcm.getBaselineFile()).returns(() => config.baselineFile);
 
-        adoTaskConfigMock
-            .setup((atcm) => atcm.getReportOutDir())
-            .returns(() => config.reportOutDir ?? defaultReportOutDir);
+        adoTaskConfigMock.setup((atcm) => atcm.getReportOutDir()).returns(() => config.reportOutDir ?? defaultReportOutDir);
     }
 
     const verifyAllMocks = () => {

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -7,19 +7,23 @@ import { AdoConsoleCommentCreator } from './ado-console-comment-creator';
 import { ADOTaskConfig } from '../../task-config/ado-task-config';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 import * as fs from 'fs';
+import * as path from 'path';
 
-import { Logger, ReportConsoleLogConvertor, ReportMarkdownConvertor } from '@accessibility-insights-action/shared';
+import { RecordingTestLogger, ReportConsoleLogConvertor, ReportMarkdownConvertor } from '@accessibility-insights-action/shared';
+
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
 describe(AdoConsoleCommentCreator, () => {
     let adoTaskConfigMock: IMock<ADOTaskConfig>;
-    let loggerMock: IMock<Logger>;
+    let logger: RecordingTestLogger;
     let reportMarkdownConvertorMock: IMock<ReportMarkdownConvertor>;
     let reportConsoleLogConvertorMock: IMock<ReportConsoleLogConvertor>;
-    let adoConsoleCommentCreator: AdoConsoleCommentCreator;
+    let testSubject: AdoConsoleCommentCreator;
     let fsMock: IMock<typeof fs>;
-    const reportOutDir = 'reportOutDir';
-    const fileName = `${reportOutDir}/results.md`;
-    const outputArtifactName = 'accessibility-reports';
+    let pathStub: typeof path;
+
+    const defaultReportOutDir = 'reportOutDir';
     const reportStub: CombinedReportParameters = {
         results: {
             urlResults: {
@@ -29,156 +33,156 @@ describe(AdoConsoleCommentCreator, () => {
     } as CombinedReportParameters;
     const baselineInfoStub = {};
     const reportMarkdownStub = '#ReportMarkdownStub';
-
-    const expectedLogOutput = reportMarkdownStub;
+    const reportConsoleLogStub = 'Report Console Log Stub';
+    
 
     beforeEach(() => {
-        adoTaskConfigMock = Mock.ofType<ADOTaskConfig>(undefined, MockBehavior.Strict);
-        loggerMock = Mock.ofType<Logger>(undefined, MockBehavior.Strict);
+        adoTaskConfigMock = Mock.ofType<ADOTaskConfig>();
+        logger = new RecordingTestLogger();
         reportMarkdownConvertorMock = Mock.ofType<ReportMarkdownConvertor>(undefined, MockBehavior.Strict);
         reportConsoleLogConvertorMock = Mock.ofType<ReportConsoleLogConvertor>(undefined, MockBehavior.Strict);
         fsMock = Mock.ofType<typeof fs>();
-    });
+        pathStub = { join: (...paths) => paths.join('/') } as typeof path;
 
-    describe('constructor', () => {
-        it('should initialize', () => {
-            buildAdoConsoleCommentCreatorWithMocks(false);
+        reportMarkdownConvertorMock
+            .setup((o) => o.convert(reportStub, undefined, baselineInfoStub))
+            .returns(() => reportMarkdownStub)
+            .verifiable(Times.atMostOnce());
 
-            verifyAllMocks();
-        });
+        reportConsoleLogConvertorMock
+            .setup((o) => o.convert(reportStub, undefined, baselineInfoStub))
+            .returns(() => reportConsoleLogStub)
+            .verifiable(Times.atMostOnce());
+
+        testSubject = new AdoConsoleCommentCreator(
+            adoTaskConfigMock.object,
+            reportMarkdownConvertorMock.object,
+            reportConsoleLogConvertorMock.object,
+            logger,
+            fsMock.object,
+            pathStub,
+        );
     });
 
     describe('completeRun', () => {
-        it('should output results to the console', async () => {
-            adoTaskConfigMock
-                .setup((atcm) => atcm.getVariable('System.JobAttempt'))
-                .returns(() => '1')
-                .verifiable(Times.once());
+        it.each`
+            uploadOutputArtifact | outputArtifactName           | jobAttempt | expectedSummaryFilePath
+            ${ false }           | ${ 'accessibility-reports' } | ${1}       | ${ 'reportOutDir/Accessibility Insights scan summary.md' }
+            ${ false }           | ${ 'custom-artifact' }       | ${1}       | ${ 'reportOutDir/Accessibility Insights scan summary.md' }
+            ${ false }           | ${ 'accessibility-reports' } | ${2}       | ${ 'reportOutDir/Accessibility Insights scan summary.md' }
+            ${ true }            | ${ 'accessibility-reports' } | ${1}       | ${ 'reportOutDir/Accessibility Insights scan summary.md' }
+            ${ true }            | ${ 'custom-artifact' }       | ${1}       | ${ 'reportOutDir/Accessibility Insights scan summary (custom-artifact).md' }
+            ${ true }            | ${ 'accessibility-reports' } | ${2}       | ${ 'reportOutDir/Accessibility Insights scan summary (accessibility-reports-2).md' }
+        `('should create and upload a job summary with the expected filename for inputs uploadOutputArtifact=$uploadOutputArtifact, outputArtifactName=$outputArtifactName, jobAttempt=$jobAttempt', async ({
+            uploadOutputArtifact, outputArtifactName, jobAttempt, expectedSummaryFilePath
+        }) => {
+            setupTaskConfig({
+                uploadOutputArtifact, outputArtifactName, jobAttempt
+            });
 
-            adoTaskConfigMock
-                .setup((atcm) => atcm.getUploadOutputArtifact())
-                .returns(() => true)
-                .verifiable(Times.once());
+            // eslint-disable-next-line security/detect-non-literal-fs-filename
+            fsMock.setup((fsm) => fsm.writeFileSync(expectedSummaryFilePath, reportMarkdownStub)).verifiable(Times.once());
 
-            loggerMock.setup((lm) => lm.logInfo(`##vso[task.uploadsummary]${fileName}`)).verifiable(Times.once());
-            loggerMock
-                .setup((lm) => lm.logInfo(`##vso[artifact.upload artifactname=${outputArtifactName}]${reportOutDir}`))
-                .verifiable(Times.once());
+            await testSubject.completeRun(reportStub);
 
-            adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks();
-            await adoConsoleCommentCreator.completeRun(reportStub);
-
+            expect(logger.recordedLogs()).toContain(`[info] ##vso[task.uploadsummary]${expectedSummaryFilePath}`);
             verifyAllMocks();
         });
 
-        it('Successfully adds suffix to output name if job attmept > 1', async () => {
-            adoTaskConfigMock
-                .setup((atcm) => atcm.getVariable('System.JobAttempt'))
-                .returns(() => '2')
-                .verifiable(Times.once());
+        it.each`
+            outputArtifactName           | jobAttempt | expectedArtifactName
+            ${ 'accessibility-reports' } | ${1}       | ${ 'accessibility-reports' }
+            ${ 'custom-artifact' }       | ${1}       | ${ 'custom-artifact' }
+            ${ 'accessibility-reports' } | ${2}       | ${ 'accessibility-reports-2' }
+            ${ 'custom-artifact' }       | ${2}       | ${ 'custom-artifact-2' }
+        `('should upload an artifact with the expected name for inputs uploadOutputArtifact=true, outputArtifactName=$outputArtifactName, jobAttempt=$jobAttempt', async ({
+            outputArtifactName, jobAttempt, expectedArtifactName
+        }) => {
+            setupTaskConfig({
+                uploadOutputArtifact: true, outputArtifactName, jobAttempt
+            });
 
-            adoTaskConfigMock
-                .setup((atcm) => atcm.getUploadOutputArtifact())
-                .returns(() => true)
-                .verifiable(Times.once());
+            await testSubject.completeRun(reportStub);
 
-            loggerMock.setup((lm) => lm.logInfo(`##vso[task.uploadsummary]${fileName}`)).verifiable(Times.once());
-            loggerMock
-                .setup((lm) => lm.logInfo(`##vso[artifact.upload artifactname=${outputArtifactName}-2]${reportOutDir}`))
-                .verifiable(Times.once());
-
-            adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks();
-            await adoConsoleCommentCreator.completeRun(reportStub);
-
+            expect(logger.recordedLogs()).toContain(`[info] ##vso[artifact.upload artifactname=${expectedArtifactName}]${defaultReportOutDir}`);
             verifyAllMocks();
         });
 
-        it('skips upload artifact step if uploadOutputArtifact is false', async () => {
-            adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks();
+        it.each`
+            outputArtifactName           | jobAttempt
+            ${ 'accessibility-reports' } | ${1}
+            ${ 'custom-artifact' }       | ${1}
+            ${ 'accessibility-reports' } | ${2}
+            ${ 'custom-artifact' }       | ${2}
+        `('should not upload an artifact inputs uploadOutputArtifact=false, outputArtifactName=$outputArtifactName, jobAttempt=$jobAttempt', async ({
+            outputArtifactName, jobAttempt
+        }) => {
+            setupTaskConfig({
+                uploadOutputArtifact: false, outputArtifactName, jobAttempt
+            });
 
-            adoTaskConfigMock
-                .setup((atcm) => atcm.getUploadOutputArtifact())
-                .returns(() => false)
-                .verifiable(Times.once());
+            await testSubject.completeRun(reportStub);
 
-            loggerMock.setup((lm) => lm.logInfo(`##vso[task.uploadsummary]${fileName}`)).verifiable(Times.never());
-            await adoConsoleCommentCreator.completeRun(reportStub);
+            expect(logger.recordedLogs()).not.toContain( /##vso\[artifact.upload/ );
+            verifyAllMocks();
         });
     });
 
     describe('failRun', () => {
         it('does nothing interesting', async () => {
-            const adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks(false);
+            await testSubject.failRun();
 
-            await adoConsoleCommentCreator.failRun();
-
+            expect(logger.recordedLogs()).toStrictEqual([]);
             verifyAllMocks();
         });
     });
 
     describe('didScanSucceed', () => {
         it('returns true by default', async () => {
-            const adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks();
+            await expect(testSubject.didScanSucceed()).resolves.toBe(true);
 
-            await expect(adoConsoleCommentCreator.didScanSucceed()).resolves.toBe(true);
+            verifyAllMocks();
         });
 
         it('returns true after failRun() is called', async () => {
-            const adoConsoleCommentCreator = buildAdoConsoleCommentCreatorWithMocks(false);
+            await testSubject.failRun();
 
-            await adoConsoleCommentCreator.failRun();
+            await expect(testSubject.didScanSucceed()).resolves.toBe(true);
 
-            await expect(adoConsoleCommentCreator.didScanSucceed()).resolves.toBe(true);
+            verifyAllMocks();
         });
     });
 
-    const buildAdoConsoleCommentCreatorWithMocks = (setupSharedMocks = true): AdoConsoleCommentCreator => {
-        if (setupSharedMocks) {
-            adoTaskConfigMock
-                .setup((atcm) => atcm.getBaselineFile())
-                .returns(() => undefined)
-                .verifiable(Times.once());
+    function setupTaskConfig(config: {
+        uploadOutputArtifact: boolean,
+        outputArtifactName: string,
+        jobAttempt: number,
+        baselineFile?: string,
+        reportOutDir?: string,
+    }): void {
+        adoTaskConfigMock
+            .setup((atcm) => atcm.getUploadOutputArtifact())
+            .returns(() => config.uploadOutputArtifact);
 
-            adoTaskConfigMock
-                .setup((atcm) => atcm.getReportOutDir())
-                .returns(() => reportOutDir)
-                .verifiable(Times.exactly(2));
+        adoTaskConfigMock
+            .setup((atcm) => atcm.getVariable('System.JobAttempt'))
+            .returns(() => `${config.jobAttempt}`);
 
-            adoTaskConfigMock
-                .setup((atcm) => atcm.getOutputArtifactName())
-                .returns(() => outputArtifactName)
-                .verifiable(Times.once());
+        adoTaskConfigMock
+            .setup((atcm) => atcm.getOutputArtifactName())
+            .returns(() => config.outputArtifactName);
 
-            reportMarkdownConvertorMock
-                .setup((o) => o.convert(reportStub, undefined, baselineInfoStub))
-                .returns(() => expectedLogOutput)
-                .verifiable(Times.once());
+        adoTaskConfigMock
+            .setup((atcm) => atcm.getBaselineFile())
+            .returns(() => config.baselineFile);
 
-            reportConsoleLogConvertorMock
-                .setup((o) => o.convert(reportStub, undefined, baselineInfoStub))
-                .returns(() => expectedLogOutput)
-                .verifiable(Times.once());
-
-            loggerMock.setup((lm) => lm.logInfo(expectedLogOutput)).verifiable(Times.once());
-            loggerMock.setup((lm) => lm.logInfo(`##vso[task.uploadsummary]${fileName}`)).verifiable(Times.once());
-
-            // eslint-disable-next-line security/detect-non-literal-fs-filename
-            fsMock.setup((fsm) => fsm.writeFileSync(fileName, expectedLogOutput)).verifiable();
-        }
-
-        return new AdoConsoleCommentCreator(
-            adoTaskConfigMock.object,
-            reportMarkdownConvertorMock.object,
-            reportConsoleLogConvertorMock.object,
-            loggerMock.object,
-            adoTaskConfigMock.object,
-            fsMock.object,
-        );
-    };
+        adoTaskConfigMock
+            .setup((atcm) => atcm.getReportOutDir())
+            .returns(() => config.reportOutDir ?? defaultReportOutDir);
+    }
 
     const verifyAllMocks = () => {
         adoTaskConfigMock.verifyAll();
-        loggerMock.verifyAll();
         reportMarkdownConvertorMock.verifyAll();
         reportConsoleLogConvertorMock.verifyAll();
         fsMock.verifyAll();

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -54,7 +54,11 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
         return { baselineFileName, baselineEvaluation };
     }
 
-    private outputResultsMarkdownToBuildSummary(artifactName: string | null, combinedReportResult: CombinedReportParameters, baselineInfo?: BaselineInfo): void {
+    private outputResultsMarkdownToBuildSummary(
+        artifactName: string | null,
+        combinedReportResult: CombinedReportParameters,
+        baselineInfo?: BaselineInfo,
+    ): void {
         const reportMarkdown = this.reportMarkdownConvertor.convert(combinedReportResult, undefined, baselineInfo);
         const outDirectory = this.taskConfig.getReportOutDir();
 


### PR DESCRIPTION
#### Details

The new "job summary in the ADO Extensions tab" feature uses a section header based on the filename of the markdown file we upload as the summary. Before this PR, we always used `results.md` as the filename, so we always got a section header of `results`, which didn't look quite right.

This PR updates the filename to use the following format:

* `Accessibility Insights scan summary` if the `uploadOutputArtifact` is false
* `Accessibility Insights scan summary` if we are uploading to an artifact with the default name ("accessibility-reports")
* `Accessibility Insights scan summary (artifact-name)` if we are uploading to an artifact with a non-default name (either because a user specified `outputArtifactName` themselves or because this is a rerun of a job and we've used something like `accessibility-reports-2` because of that)

ADO only change, no impact on GHA

##### Motivation

Avoid the off-looking `results` header in the new summary UI

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1893588
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
