### PR TITLE
fix(gha): prevent input validator treating unspecified url input as specified

### DIFF
--- a/packages/gh-action/src/task-config/gh-task-config.spec.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.spec.ts
@@ -33,23 +33,31 @@ describe(GHTaskConfig, () => {
         inputOption                 | inputValue           | expectedValue                                            | getInputFunc
         ${'repo-token'}             | ${'token'}           | ${'token'}                                               | ${() => taskConfig.getToken()}
         ${'scan-url-relative-path'} | ${'path'}            | ${'path'}                                                | ${() => taskConfig.getStaticSiteUrlRelativePath()}
+        ${'scan-url-relative-path'} | ${''}                | ${undefined}                                             | ${() => taskConfig.getStaticSiteUrlRelativePath()}
         ${'chrome-path'}            | ${'./chrome-path'}   | ${getPlatformAgnosticPath(__dirname + '/chrome-path')}   | ${() => taskConfig.getChromePath()}
         ${'input-file'}             | ${'./input-file'}    | ${getPlatformAgnosticPath(__dirname + '/input-file')}    | ${() => taskConfig.getInputFile()}
+        ${'input-file'}             | ${''}                | ${undefined}                                             | ${() => taskConfig.getInputFile()}
         ${'output-dir'}             | ${'./output-dir'}    | ${getPlatformAgnosticPath(__dirname + '/output-dir')}    | ${() => taskConfig.getReportOutDir()}
-        ${'site-dir'}               | ${'path'}            | ${'path'}                                                | ${() => taskConfig.getStaticSiteDir()}
+        ${'site-dir'}               | ${'./site-dir'}      | ${getPlatformAgnosticPath(__dirname + '/site-dir')}      | ${() => taskConfig.getStaticSiteDir()}
+        ${'site-dir'}               | ${''}                | ${undefined}                                             | ${() => taskConfig.getStaticSiteDir()}
         ${'url'}                    | ${'url'}             | ${'url'}                                                 | ${() => taskConfig.getUrl()}
+        ${'url'}                    | ${''}                | ${undefined}                                             | ${() => taskConfig.getUrl()}
         ${'discovery-patterns'}     | ${'abc'}             | ${'abc'}                                                 | ${() => taskConfig.getDiscoveryPatterns()}
+        ${'discovery-patterns'}     | ${''}                | ${undefined}                                             | ${() => taskConfig.getDiscoveryPatterns()}
         ${'input-urls'}             | ${'abc'}             | ${'abc'}                                                 | ${() => taskConfig.getInputUrls()}
+        ${'input-urls'}             | ${''}                | ${undefined}                                             | ${() => taskConfig.getInputUrls()}
         ${'max-urls'}               | ${'20'}              | ${20}                                                    | ${() => taskConfig.getMaxUrls()}
         ${'scan-timeout'}           | ${'100000'}          | ${100000}                                                | ${() => taskConfig.getScanTimeout()}
         ${'localhost-port'}         | ${'8080'}            | ${8080}                                                  | ${() => taskConfig.getStaticSitePort()}
+        ${'localhost-port'}         | ${''}                | ${undefined}                                             | ${() => taskConfig.getStaticSitePort()}
         ${'baseline-file'}          | ${'./baseline-file'} | ${getPlatformAgnosticPath(__dirname + '/baseline-file')} | ${() => taskConfig.getBaselineFile()}
+        ${'baseline-file'}          | ${''}                | ${undefined}                                             | ${() => taskConfig.getBaselineFile()}
         ${'single-worker'}          | ${'true'}            | ${true}                                                  | ${() => taskConfig.getSingleWorker()}
         ${'single-worker'}          | ${''}                | ${true}                                                  | ${() => taskConfig.getSingleWorker()}
         ${'single-worker'}          | ${'false'}           | ${false}                                                 | ${() => taskConfig.getSingleWorker()}
         ${'hosting-mode'}           | ${'staticSite'}      | ${'staticSite'}                                          | ${() => taskConfig.getHostingMode()}
         ${'hosting-mode'}           | ${'dynamicSite'}     | ${'dynamicSite'}                                         | ${() => taskConfig.getHostingMode()}
-        ${'hosting-mode'}           | ${undefined}         | ${undefined}                                             | ${() => taskConfig.getHostingMode()}
+        ${'hosting-mode'}           | ${''}                | ${undefined}                                             | ${() => taskConfig.getHostingMode()}
     `(
         `input value '$inputValue' returned as '$expectedValue' for '$inputOption' parameter`,
         ({ inputOption, getInputFunc, inputValue, expectedValue }) => {

--- a/packages/gh-action/src/task-config/gh-task-config.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.ts
@@ -19,64 +19,55 @@ export class GHTaskConfig extends TaskConfig {
     }
 
     public getReportOutDir(): string {
-        return this.getAbsolutePath(this.actionCoreObj.getInput('output-dir'));
+        // Relying on action.yml to make this required
+        return this.getOptionalPathInput('output-dir');
     }
 
-    public getStaticSiteDir(): string {
-        return this.actionCoreObj.getInput('site-dir');
+    public getStaticSiteDir(): string | undefined {
+        return this.getOptionalPathInput('site-dir');
     }
 
-    public getStaticSiteUrlRelativePath(): string {
-        return this.actionCoreObj.getInput('scan-url-relative-path');
+    public getStaticSiteUrlRelativePath(): string | undefined {
+        return this.getOptionalStringInput('scan-url-relative-path');
     }
 
     public getToken(): string {
-        return this.actionCoreObj.getInput('repo-token');
+        // Relying on action.yml to make this required
+        return this.getOptionalStringInput('repo-token');
     }
 
-    public getChromePath(): string {
-        let chromePath;
-        chromePath = this.getAbsolutePath(this.actionCoreObj.getInput('chrome-path'));
-
-        if (isEmpty(chromePath)) {
-            chromePath = this.processObj.env.CHROME_BIN;
-        }
-
-        return chromePath;
+    public getChromePath(): string | undefined {
+        return this.getOptionalPathInput('chrome-path') ?? this.processObj.env.CHROME_BIN;
     }
 
-    public getUrl(): string {
-        return this.actionCoreObj.getInput('url');
+    public getUrl(): string | undefined {
+        return this.getOptionalStringInput('url');
     }
 
     public getMaxUrls(): number {
-        return parseInt(this.actionCoreObj.getInput('max-urls'));
+        // Relying on action.yml to provide a default if necessary
+        return this.getOptionalIntInput('max-urls');
     }
 
-    public getDiscoveryPatterns(): string {
-        const value = this.actionCoreObj.getInput('discovery-patterns');
-
-        return isEmpty(value) ? undefined : value;
+    public getDiscoveryPatterns(): string | undefined {
+        return this.getOptionalStringInput('discovery-patterns');
     }
 
-    public getInputFile(): string {
-        return this.getAbsolutePath(this.actionCoreObj.getInput('input-file'));
+    public getInputFile(): string | undefined {
+        return this.getOptionalPathInput('input-file');
     }
 
-    public getInputUrls(): string {
-        const value = this.actionCoreObj.getInput('input-urls');
-
-        return isEmpty(value) ? undefined : value;
+    public getInputUrls(): string | undefined {
+        return this.getOptionalStringInput('input-urls');
     }
 
     public getScanTimeout(): number {
-        return parseInt(this.actionCoreObj.getInput('scan-timeout'));
+        // Relying on action.yml to provide a default if necessary
+        return this.getOptionalIntInput('scan-timeout');
     }
 
-    public getStaticSitePort(): number {
-        const value = this.actionCoreObj.getInput('localhost-port');
-
-        return isEmpty(value) ? undefined : parseInt(value, 10);
+    public getStaticSitePort(): number | undefined {
+        return this.getOptionalIntInput('localhost-port');
     }
 
     public getRunId(): number {
@@ -89,25 +80,11 @@ export class GHTaskConfig extends TaskConfig {
     }
 
     public getBaselineFile(): string | undefined {
-        const value = this.getAbsolutePath(this.actionCoreObj.getInput('baseline-file'));
-
-        return isEmpty(value) ? undefined : value;
+        return this.getOptionalPathInput('baseline-file');
     }
 
     public getHostingMode(): string | undefined {
-        const value = this.actionCoreObj.getInput('hosting-mode');
-
-        return isEmpty(value) ? undefined : value;
-    }
-
-    private getAbsolutePath(path: string): string {
-        if (isEmpty(path)) {
-            return undefined;
-        }
-
-        const dirname = this.processObj.env.GITHUB_WORKSPACE ?? __dirname;
-
-        return normalizePath(this.resolvePath(dirname, normalizePath(path)));
+        return this.getOptionalStringInput('hosting-mode');
     }
 
     public getInputName(key: TaskInputKey): string {
@@ -124,5 +101,30 @@ export class GHTaskConfig extends TaskConfig {
     public getUsageDocsUrl(): string {
         const url = 'https://github.com/microsoft/accessibility-insights-action/blob/main/docs/gh-action-usage.md';
         return url;
+    }
+
+    private getAbsolutePath(path: string | undefined): string | undefined {
+        if (isEmpty(path)) {
+            return undefined;
+        }
+
+        const dirname = this.processObj.env.GITHUB_WORKSPACE ?? __dirname;
+
+        return normalizePath(this.resolvePath(dirname, normalizePath(path)));
+    }
+
+    private getOptionalPathInput(inputName: string): string | undefined {
+        const rawValue = this.actionCoreObj.getInput(inputName);
+        return this.getAbsolutePath(rawValue);
+    }
+
+    private getOptionalStringInput(inputName: string): string | undefined {
+        const rawValue = this.actionCoreObj.getInput(inputName);
+        return isEmpty(rawValue) ? undefined : rawValue;
+    }
+
+    private getOptionalIntInput(inputName: string): number | undefined {
+        const rawValue = this.actionCoreObj.getInput(inputName);
+        return isEmpty(rawValue) ? undefined : parseInt(rawValue, 10);
     }
 }

--- a/packages/shared/src/task-config.ts
+++ b/packages/shared/src/task-config.ts
@@ -9,8 +9,8 @@ export type TaskInputKey = 'HostingMode' | 'StaticSiteDir' | 'StaticSiteUrlRelat
 export abstract class TaskConfig {
     constructor(@inject(iocTypes.Process) protected readonly processObj: typeof process) {}
     abstract getReportOutDir(): string;
-    abstract getStaticSiteDir(): string;
-    abstract getStaticSiteUrlRelativePath(): string;
+    abstract getStaticSiteDir(): string | undefined;
+    abstract getStaticSiteUrlRelativePath(): string | undefined;
     abstract getSingleWorker(): boolean;
     abstract getBaselineFile(): string | undefined;
     abstract getToken(): string | undefined;


### PR DESCRIPTION
#### Details

In main right now, the GitHub action self test workflow (which specifies a `site-dir` and no `url`) fails with a message like this:

```
A configuration error has occurred, only one of the following inputs can be set at a time: url or site-dir
```

This happens because the input validator assumed (based on `TaskConfig` typings) that an unspecified url input would be exposed from `TaskConfig` as `undefined`. However, GitHub Actions' `getInput` return empty string rather than undefined for unspecified inputs, and `GHTaskConfig` is currently inconsistent about whether it normalizes those as `undefined` or not.

This PR updates `GHTaskConfig` to normalize unspecified parameters as `undefined` consistently. It also updates a few stray `TaskConfig` return types that should have indicated that they are optional, but didn't.

Right now, these typings are just informative, not enforced. Ideally, we'd enable strict null checks to enforce these at compile time.

No ADO impact.

##### Motivation

Fix blocking GitHub action bug

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
