### PR TITLE
chore: quote bash variables in ADO extension release script

### DIFF
--- a/pipelines/package-vsix-file.yaml
+++ b/pipelines/package-vsix-file.yaml
@@ -14,13 +14,13 @@ parameters:
 
 steps:
     - bash: |
-          echo publisher ID: $(PublisherID)
-          echo extension ID: $(ExtensionID)
-          echo extension name: $(ExtensionName)
-          echo extensionVersionOverride: $(extensionVersionOverride)
-          echo environment: ${{ parameters.environment }}
-          echo shouldSign: ${{ parameters.shouldSign }}
-          echo appInsightsConnectionString: $(AppInsightsConnectionString)
+          echo publisher ID: "$(PublisherID)"
+          echo extension ID: "$(ExtensionID)"
+          echo extension name: "$(ExtensionName)"
+          echo extensionVersionOverride: "$(extensionVersionOverride)"
+          echo environment: "${{ parameters.environment }}"
+          echo shouldSign: "${{ parameters.shouldSign }}"
+          echo appInsightsConnectionString: "$(AppInsightsConnectionString)"
 
     - task: TfxInstaller@3
       inputs:


### PR DESCRIPTION
#### Details

We have a bash script in our release automation that echos several variables for the ADO extension (name, telemetry instrumentation key, etc). We recently changed the name of the ADO extension to a value that includes parentheses. The bash task fails: `syntax error near unexpected token `('` so this PR adds [surrounding quotes](https://tldp.org/LDP/abs/html/quotingvar.html).

No impact to GH action.

##### Motivation

unblock release pipeline

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Described how this PR impacts both the ADO extension and the GitHub action
