### PR TITLE
fix: Avoiding the creation of multiple output directories

### DIFF
--- a/packages/ado-extension/src/ado-artifacts-info-provider.ts
+++ b/packages/ado-extension/src/ado-artifacts-info-provider.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ArtifactsInfoProvider } from '@accessibility-insights-action/shared';
+import { ArtifactsInfoProvider, iocTypes } from '@accessibility-insights-action/shared';
 import { inject, injectable } from 'inversify';
 
 import { ADOTaskConfig } from './task-config/ado-task-config';
 
 @injectable()
 export class ADOArtifactsInfoProvider extends ArtifactsInfoProvider {
-    constructor(@inject(ADOTaskConfig) private readonly adoTaskConfig: ADOTaskConfig) {
+    constructor(@inject(iocTypes.TaskConfig) private readonly adoTaskConfig: ADOTaskConfig) {
         super();
     }
     public getArtifactsUrl(): string | undefined {

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -3,7 +3,7 @@
 
 import { ADOTaskConfig } from '../../task-config/ado-task-config';
 import { inject, injectable } from 'inversify';
-import { Logger, ReportConsoleLogConvertor } from '@accessibility-insights-action/shared';
+import { iocTypes, Logger, ReportConsoleLogConvertor } from '@accessibility-insights-action/shared';
 import * as fs from 'fs';
 import * as path from 'path';
 import { ReportMarkdownConvertor } from '@accessibility-insights-action/shared';
@@ -15,7 +15,7 @@ import { BaselineInfo } from '@accessibility-insights-action/shared';
 @injectable()
 export class AdoConsoleCommentCreator extends ProgressReporter {
     constructor(
-        @inject(ADOTaskConfig) private readonly taskConfig: ADOTaskConfig,
+        @inject(iocTypes.TaskConfig) private readonly taskConfig: ADOTaskConfig,
         @inject(ReportMarkdownConvertor) private readonly reportMarkdownConvertor: ReportMarkdownConvertor,
         @inject(ReportConsoleLogConvertor) private readonly reportConsoleLogConvertor: ReportConsoleLogConvertor,
         @inject(Logger) private readonly logger: Logger,

--- a/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
+++ b/packages/ado-extension/src/progress-reporter/enforcement/workflow-enforcer.ts
@@ -3,7 +3,7 @@
 
 import { ADOTaskConfig } from '../../task-config/ado-task-config';
 import { inject, injectable } from 'inversify';
-import { Logger, ProgressReporter } from '@accessibility-insights-action/shared';
+import { iocTypes, Logger, ProgressReporter } from '@accessibility-insights-action/shared';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 import { BaselineEvaluation } from 'accessibility-insights-scan';
 
@@ -11,7 +11,7 @@ import { BaselineEvaluation } from 'accessibility-insights-scan';
 export class WorkflowEnforcer extends ProgressReporter {
     private scanSucceeded = true;
 
-    constructor(@inject(ADOTaskConfig) private readonly adoTaskConfig: ADOTaskConfig, @inject(Logger) private readonly logger: Logger) {
+    constructor(@inject(iocTypes.TaskConfig) private readonly adoTaskConfig: ADOTaskConfig, @inject(Logger) private readonly logger: Logger) {
         super();
     }
 

--- a/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.ts
+++ b/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.ts
@@ -10,7 +10,7 @@ import { BaselineEvaluation } from 'accessibility-insights-scan';
 @injectable()
 export class TelemetrySender extends ProgressReporter {
     constructor(
-        @inject(ADOTaskConfig) private readonly adoTaskConfig: ADOTaskConfig,
+        @inject(iocTypes.TaskConfig) private readonly adoTaskConfig: ADOTaskConfig,
         @inject(iocTypes.TelemetryClient) private readonly telemetryClient: TelemetryClient,
     ) {
         super();


### PR DESCRIPTION
#### Details

The intention of this PR is to avoid creating multiple output directories during pipeline run time.

After the last ADO extension release, we discovered that the reports were not properly created, after some investigation, we found that this was caused by multiple output directories being created due to the creation of multiple instances of the `ADOTaskConfig` class.

##### Motivation

Fix and issue found during ADO extension release validation.

##### Context

Here are some captions from the logs showing the name of the output directory throughout the pipeline run.

In the first instance, we can see from the temp directory suffix that multiple temp dirs were created.
```
Scan report saved successfully as C:\Users\taniamar\AppData\Local\Temp\accessibility-insights-action-xwOzMS/index.html
##[endgroup]
##vso[task.debug]baselineFile=undefined
##vso[task.debug]uploadOutputArtifact=true
##vso[task.debug]System.JobAttempt=undefined
##vso[task.debug]outputArtifactName=accessibility-reports
##vso[OUTPUT DIR: null]
##vso[task.debug]outputDir=undefined
##vso[task.debug]Agent.TempDirectory=C:\Users\taniamar\AppData\Local\Temp
##vso[OUTPUT DIR : C:\Users\taniamar\AppData\Local\Temp\accessibility-insights-action-CDC9H7]
##vso[task.uploadsummary]C:\Users\taniamar\AppData\Local\Temp\accessibility-insights-action-CDC9H7\Accessibility Insights scan summary.md
##vso[OUTPUT DIR: null]
##vso[OUTPUT DIR: C:\Users\taniamar\AppData\Local\Temp\accessibility-insights-action-jP8Jwf]
```

After modifying the classes to make use of iocTypes.TaskConfig instead of ADOTaskConfig, the problem of using multiple classes caused by dependency injection was solved, avoiding the creation of multiple output directories as shown in the following log capture.
```
##vso[OUTPUT DIR: C:\Users\taniamar\AppData\Local\Temp\accessibility-insights-action-yZcyZp]
Scan report saved successfully as C:\Users\taniamar\AppData\Local\Temp\accessibility-insights-action-yZcyZp/index.html
##[endgroup]
##vso[task.debug]baselineFile=undefined
##vso[task.debug]uploadOutputArtifact=true
##vso[task.debug]System.JobAttempt=undefined
##vso[task.debug]outputArtifactName=accessibility-reports
##vso[OUTPUT DIR: C:\Users\taniamar\AppData\Local\Temp\accessibility-insights-action-yZcyZp]
##vso[task.uploadsummary]C:\Users\taniamar\AppData\Local\Temp\accessibility-insights-action-yZcyZp\Accessibility Insights scan summary.md
##vso[artifact.upload artifactname=accessibility-reports]C:\Users\taniamar\AppData\Local\Temp\accessibility-insights-action-yZcyZp
```

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Described how this PR impacts both the ADO extension and the GitHub action
