### PR TITLE
fix: staticSiteUrlRelativePath validation issue

### DIFF
--- a/packages/shared/src/input-validator.spec.ts
+++ b/packages/shared/src/input-validator.spec.ts
@@ -109,7 +109,7 @@ describe(InputValidator, () => {
         it('input configuration fail if static inputs are set in dynamicSite mode', () => {
             setUpHostingMode('dynamicSite');
             setupGetStaticSiteDir('site-dir');
-            setupGetStaticSiteUrlRelativePath(defaultStaticSiteUrlRelativePath);
+            setupGetStaticSiteUrlRelativePath('non-default-static-site-url-relative-path');
             setupGetStaticSitePort(100);
             setupGetUrl('url');
             setupInputName('staticSiteDir', 'StaticSiteDir');
@@ -117,7 +117,7 @@ describe(InputValidator, () => {
             setupInputName('staticSitePort', 'StaticSitePort');
             setupInputName('hosting-mode', 'HostingMode');
 
-            const errorMessage = `A configuration error has occurred, staticSiteDir, staticSitePort must not be set when hosting-mode is set to dynamic\nTo fix this error make sure staticSiteDir, staticSitePort has not been set in the input section of your YAML file`;
+            const errorMessage = `A configuration error has occurred, staticSiteDir, staticSiteUrlRelativePath, staticSitePort must not be set when hosting-mode is set to dynamic\nTo fix this error make sure staticSiteDir, staticSiteUrlRelativePath, staticSitePort has not been set in the input section of your YAML file`;
             setupLoggerWithErrorMessage(errorMessage);
 
             const usageLink = 'https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md';

--- a/packages/shared/src/input-validator.spec.ts
+++ b/packages/shared/src/input-validator.spec.ts
@@ -11,6 +11,7 @@ describe(InputValidator, () => {
     let taskConfigMock: IMock<TaskConfig>;
     let loggerMock: IMock<Logger>;
     let inputValidator: InputValidator;
+    const defaultStaticSiteUrlRelativePath = '/';
 
     beforeEach(() => {
         taskConfigMock = Mock.ofType<TaskConfig>(undefined, MockBehavior.Strict);
@@ -28,7 +29,7 @@ describe(InputValidator, () => {
         it('input configuration fail if siteDir and url are set at the same time', () => {
             setUpHostingMode(undefined);
             setupGetStaticSiteDir('site-dir');
-            setupGetStaticSiteUrlRelativePath(undefined);
+            setupGetStaticSiteUrlRelativePath(defaultStaticSiteUrlRelativePath);
             setupGetStaticSitePort(undefined);
             setupGetUrl('url');
             setupInputName('staticSiteDir', 'StaticSiteDir');
@@ -48,7 +49,7 @@ describe(InputValidator, () => {
         it('input configuration fail if siteDir and url are not set', () => {
             setUpHostingMode(undefined);
             setupGetStaticSiteDir(undefined);
-            setupGetStaticSiteUrlRelativePath(undefined);
+            setupGetStaticSiteUrlRelativePath(defaultStaticSiteUrlRelativePath);
             setupGetStaticSitePort(undefined);
             setupGetUrl(undefined);
             setupInputName('staticSiteDir', 'StaticSiteDir');
@@ -68,7 +69,7 @@ describe(InputValidator, () => {
         it('input configuration fail if siteDir is not set in staticSite mode', () => {
             setUpHostingMode('staticSite');
             setupGetStaticSiteDir(undefined);
-            setupGetStaticSiteUrlRelativePath(undefined);
+            setupGetStaticSiteUrlRelativePath(defaultStaticSiteUrlRelativePath);
             setupGetStaticSitePort(undefined);
             setupGetUrl(undefined);
             setupInputName('staticSiteDir', 'StaticSiteDir');
@@ -88,7 +89,7 @@ describe(InputValidator, () => {
         it('input configuration fail if url is set in staticSite mode', () => {
             setUpHostingMode('staticSite');
             setupGetStaticSiteDir('site-dir');
-            setupGetStaticSiteUrlRelativePath(undefined);
+            setupGetStaticSiteUrlRelativePath(defaultStaticSiteUrlRelativePath);
             setupGetStaticSitePort(undefined);
             setupGetUrl('url');
             setupInputName('url', 'Url');
@@ -108,7 +109,7 @@ describe(InputValidator, () => {
         it('input configuration fail if static inputs are set in dynamicSite mode', () => {
             setUpHostingMode('dynamicSite');
             setupGetStaticSiteDir('site-dir');
-            setupGetStaticSiteUrlRelativePath('ure-relative-path');
+            setupGetStaticSiteUrlRelativePath(defaultStaticSiteUrlRelativePath);
             setupGetStaticSitePort(100);
             setupGetUrl('url');
             setupInputName('staticSiteDir', 'StaticSiteDir');
@@ -116,7 +117,7 @@ describe(InputValidator, () => {
             setupInputName('staticSitePort', 'StaticSitePort');
             setupInputName('hosting-mode', 'HostingMode');
 
-            const errorMessage = `A configuration error has occurred, staticSiteDir, staticSiteUrlRelativePath, staticSitePort must not be set when hosting-mode is set to dynamic\nTo fix this error make sure staticSiteDir, staticSiteUrlRelativePath, staticSitePort has not been set in the input section of your YAML file`;
+            const errorMessage = `A configuration error has occurred, staticSiteDir, staticSitePort must not be set when hosting-mode is set to dynamic\nTo fix this error make sure staticSiteDir, staticSitePort has not been set in the input section of your YAML file`;
             setupLoggerWithErrorMessage(errorMessage);
 
             const usageLink = 'https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md';
@@ -127,10 +128,23 @@ describe(InputValidator, () => {
             expect(inputValidator.validate()).toBe(false);
         });
 
+        test('input configuration succeeds if staticSiteUrlRelativePath equal to defaultValue in dynamicSite mode', () => {
+            setUpHostingMode('dynamicSite');
+            setupInputName(defaultStaticSiteUrlRelativePath, 'StaticSiteUrlRelativePath');
+            setupInputName('hosting-mode', 'HostingMode');
+            setupGetStaticSiteDir(undefined);
+            setupGetStaticSiteUrlRelativePath(defaultStaticSiteUrlRelativePath);
+            setupGetStaticSitePort(undefined);
+            setupGetUrl('url');
+
+            inputValidator = buildInputValidatorWithMocks();
+            expect(inputValidator.validate()).toBe(true);
+        });
+
         it('input configuration succeeded if correct static configuration', () => {
             setUpHostingMode('staticSite');
             setupGetStaticSiteDir('site-dir');
-            setupGetStaticSiteUrlRelativePath(undefined);
+            setupGetStaticSiteUrlRelativePath(defaultStaticSiteUrlRelativePath);
             setupGetStaticSitePort(undefined);
             setupGetUrl(undefined);
 
@@ -144,7 +158,7 @@ describe(InputValidator, () => {
         it('input configuration succeeded if correct dynamic configuration', () => {
             setUpHostingMode('dynamicSite');
             setupGetStaticSiteDir(undefined);
-            setupGetStaticSiteUrlRelativePath(undefined);
+            setupGetStaticSiteUrlRelativePath(defaultStaticSiteUrlRelativePath);
             setupGetStaticSitePort(undefined);
             setupGetUrl('url');
             setupInputName('hosting-mode', 'HostingMode');
@@ -159,7 +173,7 @@ describe(InputValidator, () => {
         it('input configuration succeeded if correct configuration with no hosting mode', () => {
             setUpHostingMode(undefined);
             setupGetStaticSiteDir(undefined);
-            setupGetStaticSiteUrlRelativePath(undefined);
+            setupGetStaticSiteUrlRelativePath(defaultStaticSiteUrlRelativePath);
             setupGetStaticSitePort(undefined);
             setupGetUrl('url');
 

--- a/packages/shared/src/input-validator.ts
+++ b/packages/shared/src/input-validator.ts
@@ -103,14 +103,19 @@ export class InputValidator {
         if (hostingMode === 'dynamicSite') {
             const siteDir = this.taskConfig.getStaticSiteDir();
             const urlRelativePath = this.taskConfig.getStaticSiteUrlRelativePath();
+            const urlRelativePathDefault = '/';
             const sitePort = this.taskConfig.getStaticSitePort();
             const hostingModeName = this.taskConfig.getInputName('HostingMode');
-            if (siteDir !== undefined || urlRelativePath !== undefined || sitePort !== undefined) {
+            if (
+                siteDir !== undefined ||
+                (urlRelativePath !== undefined && urlRelativePath !== urlRelativePathDefault) ||
+                sitePort !== undefined
+            ) {
                 const failedInputs = [];
                 if (siteDir !== undefined) {
                     failedInputs.push(this.taskConfig.getInputName('StaticSiteDir'));
                 }
-                if (urlRelativePath !== undefined) {
+                if (urlRelativePath !== undefined && urlRelativePath !== urlRelativePathDefault) {
                     failedInputs.push(this.taskConfig.getInputName('StaticSiteUrlRelativePath'));
                 }
                 if (sitePort !== undefined) {


### PR DESCRIPTION
#### Details

This fixes an issue with input validation that was causing the following error when `staticSiteUrlRelativePath` is not set in `dynamicSite` hosting mode:

`##[error]A configuration error has occurred, staticSiteUrlRelativePath must not be set when hostingMode is set to dynamic`

This is due to the fact that in `task.json` we have a `defaultValue` set for that input. The validator picks up the default value and assumes that the user has supplied an input.

To fix this, we have allowed the default value of `/` to be an acceptable input in the input validator. That way if there is an invalid input that we know was added by the end user it will still throw the error. This leaves the existing default value in place so as not to break existing static site setups that do not specify the input and consume the default value.

This impact should be the same for both the ADO extension and the Github action, as they both pick up the relevant variable and default value.

##### Motivation

fix validation issues

##### Context

We considered removing the validation for that input altogether, but decided to simply allow for the default of `/` to be accepted by the validator. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
