### PR TITLE
docs: update ADO usage docs to use v2 instead of v1 of the task

### DIFF
--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -52,7 +52,7 @@ pool:
 steps:
     # Insert any jobs here required to build your website files
 
-    - task: accessibility-insights.prod.task.accessibility-insights@1
+    - task: accessibility-insights.prod.task.accessibility-insights@2
       displayName: Scan for accessibility issues
       inputs:
           # Provide either staticSiteDir or url
@@ -65,7 +65,7 @@ steps:
 Provide the website URL. The URL should already be hosted - something like `http://localhost:12345/` or `https://example.com`.
 
 ```yml
-- task: accessibility-insights.prod.task.accessibility-insights@1
+- task: accessibility-insights.prod.task.accessibility-insights@2
   displayName: Scan for accessibility issues
   inputs:
       url: 'http://localhost:12345/'
@@ -78,7 +78,7 @@ The `url` parameter takes priority over `staticSiteDir`. If `url` is provided, s
 Provide the location of your built HTML files using `staticSiteDir` and (optionally) `staticSiteUrlRelativePath`. The action will serve the site for you using `express`.
 
 ```yml
-- task: accessibility-insights.prod.task.accessibility-insights@1
+- task: accessibility-insights.prod.task.accessibility-insights@2
   displayName: Scan for accessibility issues
   inputs:
       staticSiteDir: '$(System.DefaultWorkingDirectory)/website/root/'
@@ -106,7 +106,7 @@ For `discoveryPatterns`, `inputFile`, and `inputUrls`, note that these options e
 Examples:
 
 ```yml
-- task: accessibility-insights.prod.task.accessibility-insights@1
+- task: accessibility-insights.prod.task.accessibility-insights@2
   displayName: Scan for accessibility issues (with url)
   inputs:
       url: 'http://localhost:12345/'
@@ -114,7 +114,7 @@ Examples:
 ```
 
 ```yml
-- task: accessibility-insights.prod.task.accessibility-insights@1
+- task: accessibility-insights.prod.task.accessibility-insights@2
   displayName: Scan for accessibility issues (with staticSiteDir)
   inputs:
       staticSiteDir: '$(System.DefaultWorkingDirectory)/website/root/'
@@ -147,7 +147,7 @@ When the scanning tool fails, it creates a new baseline file--reflecting the cur
 Here is an example of a YAML file that is configured to take advantage of a baseline, assuming just one environment:
 
 ```yml
-- task: accessibility-insights.prod.task.accessibility-insights@1
+- task: accessibility-insights.prod.task.accessibility-insights@2
   displayName: Scan for accessibility issues
   inputs:
       url: 'http://localhost:12345/'


### PR DESCRIPTION
#### Details

The code examples in the ADO usage docs were updated to use v2-style parameters, but we missed updating them to actually use version 2 instead of version 1 of the task. This corrects the examples.

No GHA impact.

##### Motivation

Make usage docs match actual intended usage

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
