### PR TITLE
chore: run validation scenarios in canary and prod as well as staging

### DIFF
--- a/pipelines/ado-extension-canary-validation.yaml
+++ b/pipelines/ado-extension-canary-validation.yaml
@@ -21,6 +21,9 @@ resources:
               stages:
                   - package_publish_canary
 
+pool:
+    vmImage: ubuntu-latest
+
 extends:
     template: ado-extension-validation-template.yaml
     parameters:

--- a/pipelines/ado-extension-canary-validation.yaml
+++ b/pipelines/ado-extension-canary-validation.yaml
@@ -22,6 +22,6 @@ resources:
                   - package_publish_canary
 
 extends:
-    template: ado-extension-validation-template.yml
+    template: ado-extension-validation-template.yaml
     parameters:
         taskUnderTest: accessibility-insights.canary.task.accessibility-insights@2

--- a/pipelines/ado-extension-canary-validation.yaml
+++ b/pipelines/ado-extension-canary-validation.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+trigger: none
+
+pr:
+    branches:
+        include:
+            - main
+    paths:
+        include:
+            - dev
+            - pipelines/ado-extension-canary-validation.yaml
+            - pipelines/ado-extension-validation-template.yaml
+
+resources:
+    pipelines:
+        - pipeline: prod-release
+          source: accessibility-insights-ado-extension-release-canary
+          trigger:
+              stages:
+                  - package_publish_canary
+
+extends:
+    template: ado-extension-validation-template.yml
+    parameters:
+        taskUnderTest: accessibility-insights.canary.task.accessibility-insights@2

--- a/pipelines/ado-extension-prod-validation.yaml
+++ b/pipelines/ado-extension-prod-validation.yaml
@@ -22,6 +22,6 @@ resources:
                   - package_publish_prod
 
 extends:
-    template: ado-extension-validation-template.yml
+    template: ado-extension-validation-template.yaml
     parameters:
         taskUnderTest: accessibility-insights.prod.task.accessibility-insights@2

--- a/pipelines/ado-extension-prod-validation.yaml
+++ b/pipelines/ado-extension-prod-validation.yaml
@@ -6,7 +6,7 @@
 # PR/CI scenarios as triggered from an ADO repo; see the release validation OneNote
 # template for details.
 
-# A CI build will be automatically kicked off when the "publish to staging" stage
+# A CI build will be automatically kicked off when the "publish to production" stage
 # of prod-release is run. A PR build which triggers this pipeline can be run be
 # creating a PR which touches any file under the "/dev" folder.
 
@@ -19,7 +19,7 @@ pr:
     paths:
         include:
             - dev
-            - pipelines/ado-extension-staging-validation.yaml
+            - pipelines/ado-extension-prod-validation.yaml
             - pipelines/ado-extension-validation-template.yaml
 
 resources:
@@ -28,9 +28,9 @@ resources:
           source: accessibility-insights-ado-extension-release-production
           trigger:
               stages:
-                  - package_publish_staging
+                  - package_publish_prod
 
 extends:
     template: ado-extension-validation-template.yml
     parameters:
-        taskUnderTest: accessibility-insights.staging.task.accessibility-insights@2
+        taskUnderTest: accessibility-insights.prod.task.accessibility-insights@2

--- a/pipelines/ado-extension-prod-validation.yaml
+++ b/pipelines/ado-extension-prod-validation.yaml
@@ -1,15 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# This pipeline covers the staging scenarios for the ADO extension as triggered for
-# a PR/CI build of a GitHub repo. Note that release validation *also* requires covering
-# PR/CI scenarios as triggered from an ADO repo; see the release validation OneNote
-# template for details.
-
-# A CI build will be automatically kicked off when the "publish to production" stage
-# of prod-release is run. A PR build which triggers this pipeline can be run be
-# creating a PR which touches any file under the "/dev" folder.
-
 trigger: none
 
 pr:

--- a/pipelines/ado-extension-prod-validation.yaml
+++ b/pipelines/ado-extension-prod-validation.yaml
@@ -21,6 +21,9 @@ resources:
               stages:
                   - package_publish_prod
 
+pool:
+    vmImage: ubuntu-latest
+
 extends:
     template: ado-extension-validation-template.yaml
     parameters:

--- a/pipelines/ado-extension-staging-validation.yaml
+++ b/pipelines/ado-extension-staging-validation.yaml
@@ -21,6 +21,9 @@ resources:
               stages:
                   - package_publish_staging
 
+pool:
+    vmImage: ubuntu-latest
+
 extends:
     template: ado-extension-validation-template.yaml
     parameters:

--- a/pipelines/ado-extension-staging-validation.yaml
+++ b/pipelines/ado-extension-staging-validation.yaml
@@ -22,6 +22,6 @@ resources:
                   - package_publish_staging
 
 extends:
-    template: ado-extension-validation-template.yml
+    template: ado-extension-validation-template.yaml
     parameters:
         taskUnderTest: accessibility-insights.staging.task.accessibility-insights@2

--- a/pipelines/ado-extension-staging-validation.yaml
+++ b/pipelines/ado-extension-staging-validation.yaml
@@ -1,15 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# This pipeline covers the staging scenarios for the ADO extension as triggered for
-# a PR/CI build of a GitHub repo. Note that release validation *also* requires covering
-# PR/CI scenarios as triggered from an ADO repo; see the release validation OneNote
-# template for details.
-
-# A CI build will be automatically kicked off when the "publish to staging" stage
-# of prod-release is run. A PR build which triggers this pipeline can be run be
-# creating a PR which touches any file under the "/dev" folder.
-
 trigger: none
 
 pr:

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -1,0 +1,119 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# This template covers the validation scenarios for the ADO extension as triggered for
+# a PR/CI build of a GitHub repo. Note that release validation *also* requires covering
+# PR/CI scenarios as triggered from an ADO repo; see the release validation OneNote
+# template for details.
+
+# These are primarily validated against the staging environment during release validation
+
+parameters:
+    - name: taskUnderTest
+      type: string
+
+pool:
+    vmImage: ubuntu-latest
+
+steps:
+    # reused by all "url" cases
+    - script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &
+      displayName: 'Start /dev/website-root test server at http://localhost:5858'
+
+    - task: ${{ parameters.taskUnderTest }}
+      displayName: '[should fail] case 1: staticSiteDir, no baseline'
+      inputs:
+          staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
+          # intentionally omits artifactName; should go to default accessibility-reports
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - task: ${{ parameters.taskUnderTest }}
+      displayName: '[should succeed] case 2: staticSiteDir, no baseline, failOnAccessibilityError:false'
+      inputs:
+          staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
+          failOnAccessibilityError: false
+          outputArtifactName: accessibility-reports-case-2
+      condition: succeededOrFailed()
+
+    - task: ${{ parameters.taskUnderTest }}
+      displayName: '[should fail] case 3: url, no baseline'
+      inputs:
+          url: 'http://localhost:5858'
+          outputArtifactName: 'accessibility-reports-case-3'
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - task: ${{ parameters.taskUnderTest }}
+      displayName: '[should succeed] case 4: up-to-date baseline'
+      inputs:
+          url: 'http://localhost:5858'
+          outputArtifactName: 'accessibility-reports-case-4'
+          baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/up-to-date-5858.baseline'
+      condition: succeededOrFailed()
+
+    - task: ${{ parameters.taskUnderTest }}
+      displayName: '[should fail] case 5: baseline missing failures'
+      inputs:
+          url: 'http://localhost:5858'
+          outputArtifactName: 'accessibility-reports-case-5'
+          baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/missing-failures-5858.baseline'
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - task: ${{ parameters.taskUnderTest }}
+      displayName: '[should fail] case 6: baseline with resolved failures'
+      inputs:
+          url: 'http://localhost:5858'
+          outputArtifactName: 'accessibility-reports-case-6'
+          baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/with-resolved-failures-5858.baseline'
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - task: ${{ parameters.taskUnderTest }}
+      displayName: '[should fail] case 7: new baseline file'
+      inputs:
+          staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
+          outputArtifactName: 'accessibility-reports-case-7'
+          baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/doesnt-exist.baseline'
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - task: ${{ parameters.taskUnderTest }}
+      displayName: '[should fail] case 8: url, custom artifact upload step'
+      inputs:
+          url: 'http://localhost:5858'
+          uploadOutputArtifact: false
+          outputDir: '_accessibility-reports-case-8'
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - publish: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-8'
+      displayName: 'custom report artifact upload for case 8'
+      artifact: 'accessibility-reports-case-8'
+      condition: succeededOrFailed()
+
+    - task: ${{ parameters.taskUnderTest }}
+      displayName: '[should fail] case 9: invalid inputs (no site specified)'
+      inputs:
+          outputArtifactName: 'accessibility-reports-case-9'
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - task: ${{ parameters.taskUnderTest }}
+      displayName: '[should fail] case 10: invalid inputs (both url and staticSiteDir specified)'
+      inputs:
+          url: 'http://localhost:5858'
+          staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
+          outputArtifactName: 'accessibility-reports-case-10'
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - task: ${{ parameters.taskUnderTest }}
+      displayName: '[should fail] case 11: v1 inputs specified'
+      inputs:
+          repoServiceConnectionName: 'this isnt used anymore'
+          # siteDir instead of staticSiteDir
+          siteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
+      condition: succeededOrFailed()
+      continueOnError: true

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -12,9 +12,6 @@ parameters:
     - name: taskUnderTest
       type: string
 
-pool:
-    vmImage: ubuntu-latest
-
 steps:
     # reused by all "url" cases
     - script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &


### PR DESCRIPTION
#### Details

Today, we have a variety of staging validation scenarios, but we don't actually run them until we kick off a staging release. It would be nice to be able to validate particularly interesting/risky changes against the same scenarios in Canary without kicking off a staging release. This PR runs the same scenarios that we already run for staging releases on canary and prod release as well.

No GHA impact.

##### Motivation

See above

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
