### PR TITLE
feat(ado-gha-axe-core): Add Job Summary to GH Action

### DIFF
--- a/packages/gh-action/src/ioc/setup-ioc-container.ts
+++ b/packages/gh-action/src/ioc/setup-ioc-container.ts
@@ -10,20 +10,23 @@ import { GitHubIocTypes } from './gh-ioc-types';
 import { CheckRunCreator } from '../check-run/check-run-creator';
 import { GitHubArtifactsInfoProvider } from '../gh-artifacts-info-provider';
 import { ConsoleCommentCreator } from '../console/console-comment-creator';
+import { JobSummaryCreator } from '../job-summary/job-summary-creator';
 
 export function setupIocContainer(container = new inversify.Container({ autoBindInjectable: true })): inversify.Container {
     container = setupSharedIocContainer(container);
     container.bind(GitHubIocTypes.Github).toConstantValue(github);
     container.bind(iocTypes.TaskConfig).to(GHTaskConfig).inSingletonScope();
     container.bind(CheckRunCreator).toSelf().inSingletonScope();
+    container.bind(JobSummaryCreator).toSelf().inSingletonScope();
     container.bind(ConsoleCommentCreator).toSelf().inSingletonScope();
     container
         .bind(iocTypes.ProgressReporters)
         .toDynamicValue((context) => {
             const consoleCommentCreator = context.container.get(ConsoleCommentCreator);
             const checkRunCreator = context.container.get(CheckRunCreator);
+            const jobSummaryCreator = context.container.get(JobSummaryCreator);
 
-            return [checkRunCreator, consoleCommentCreator];
+            return [checkRunCreator, consoleCommentCreator, jobSummaryCreator];
         })
         .inSingletonScope();
 

--- a/packages/gh-action/src/job-summary/job-summary-creator.spec.ts
+++ b/packages/gh-action/src/job-summary/job-summary-creator.spec.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+import { IMock, Mock } from 'typemoq';
+import { Logger, ReportMarkdownConvertor } from '@accessibility-insights-action/shared';
+import { CombinedReportParameters } from 'accessibility-insights-report';
+import { JobSummaryCreator } from './job-summary-creator';
+import { GHTaskConfig } from '../task-config/gh-task-config';
+
+describe(JobSummaryCreator, () => {
+    let testSubject: JobSummaryCreator;
+    let reportMarkdownConvertorMock: IMock<ReportMarkdownConvertor>;
+    let loggerMock: IMock<Logger>;
+    let taskConfigMock: IMock<GHTaskConfig>;
+
+    const markdownContent = 'test markdown content';
+    const combinedReportResult = { serviceName: 'combinedReportResult' } as CombinedReportParameters;
+
+    beforeEach(() => {
+        taskConfigMock = Mock.ofType<GHTaskConfig>();
+        reportMarkdownConvertorMock = Mock.ofType(ReportMarkdownConvertor);
+        loggerMock = Mock.ofType(Logger);
+        testSubject = new JobSummaryCreator(taskConfigMock.object, reportMarkdownConvertorMock.object, loggerMock.object);
+    });
+
+    afterEach(() => {
+        reportMarkdownConvertorMock.verifyAll();
+        loggerMock.verifyAll();
+    });
+
+    describe('start', () => {
+        it('does nothing', async () => {
+            await expect(testSubject.start()).resolves.toBeUndefined();
+        });
+    });
+
+    describe('didScanSucceed', () => {
+        it('returns true by default', async () => {
+            await expect(testSubject.didScanSucceed()).resolves.toBe(true);
+        });
+
+        it('returns false after failRun() is called', async () => {
+            await testSubject.failRun();
+            await expect(testSubject.didScanSucceed()).resolves.toBe(false);
+        });
+    });
+
+    describe('completeRun', () => {
+        it('converts to markdown and writes the job summary', async () => {
+            reportMarkdownConvertorMock
+                .setup((a) => a.convert(combinedReportResult))
+                .returns(() => markdownContent)
+                .verifiable();
+            taskConfigMock
+                .setup((a) => a.writeJobSummary(markdownContent))
+                .returns(() => Promise.resolve())
+                .verifiable();
+            await testSubject.completeRun(combinedReportResult);
+        });
+    });
+});

--- a/packages/gh-action/src/job-summary/job-summary-creator.ts
+++ b/packages/gh-action/src/job-summary/job-summary-creator.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { inject, injectable } from 'inversify';
+import { iocTypes, Logger, ProgressReporter, ReportMarkdownConvertor } from '@accessibility-insights-action/shared';
+import { CombinedReportParameters } from 'accessibility-insights-report';
+import { GHTaskConfig } from '../task-config/gh-task-config';
+
+@injectable()
+export class JobSummaryCreator extends ProgressReporter {
+    private scanSucceeded = true;
+
+    constructor(
+        @inject(iocTypes.TaskConfig) private readonly taskConfig: GHTaskConfig,
+        @inject(ReportMarkdownConvertor) private readonly reportMarkdownConvertor: ReportMarkdownConvertor,
+        @inject(Logger) private readonly logger: Logger,
+    ) {
+        super();
+    }
+
+    public start(): Promise<void> {
+        this.logger.logDebug('job summary creator started');
+        return Promise.resolve();
+    }
+
+    public async completeRun(combinedReportResult: CombinedReportParameters): Promise<void> {
+        const reportMarkdown = this.reportMarkdownConvertor.convert(combinedReportResult);
+        return await this.taskConfig.writeJobSummary(reportMarkdown);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public async failRun(): Promise<void> {
+        this.scanSucceeded = false;
+    }
+
+    public didScanSucceed(): Promise<boolean> {
+        return Promise.resolve(this.scanSucceeded);
+    }
+}

--- a/packages/gh-action/src/task-config/gh-task-config.spec.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.spec.ts
@@ -12,14 +12,14 @@ describe(GHTaskConfig, () => {
     let processStub: any;
     let actionCoreMock: IMock<typeof actionCore>;
     let taskConfig: GHTaskConfig;
-    let markdownSummaryMock: IMock<typeof actionCore.markdownSummary>;
+    let markdownSummaryMock: IMock<typeof actionCore.summary>;
 
     beforeEach(() => {
         processStub = {
             env: {},
         } as any;
         actionCoreMock = Mock.ofType<typeof actionCore>();
-        markdownSummaryMock = Mock.ofType<typeof actionCore.markdownSummary>();
+        markdownSummaryMock = Mock.ofType<typeof actionCore.summary>();
         taskConfig = new GHTaskConfig(processStub, actionCoreMock.object);
     });
 
@@ -139,7 +139,7 @@ describe(GHTaskConfig, () => {
             .verifiable();
         markdownSummaryMock.setup((o) => o.write()).verifiable();
 
-        actionCoreMock.setup((o) => o.markdownSummary).returns(() => markdownSummaryMock.object);
+        actionCoreMock.setup((o) => o.summary).returns(() => markdownSummaryMock.object);
 
         await taskConfig.writeJobSummary(markdownStub);
     });

--- a/packages/gh-action/src/task-config/gh-task-config.spec.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.spec.ts
@@ -12,17 +12,20 @@ describe(GHTaskConfig, () => {
     let processStub: any;
     let actionCoreMock: IMock<typeof actionCore>;
     let taskConfig: GHTaskConfig;
+    let markdownSummaryMock: IMock<typeof actionCore.markdownSummary>;
 
     beforeEach(() => {
         processStub = {
             env: {},
         } as any;
         actionCoreMock = Mock.ofType<typeof actionCore>();
+        markdownSummaryMock = Mock.ofType<typeof actionCore.markdownSummary>();
         taskConfig = new GHTaskConfig(processStub, actionCoreMock.object);
     });
 
     afterEach(() => {
         actionCoreMock.verifyAll();
+        markdownSummaryMock.verifyAll();
     });
 
     function getPlatformAgnosticPath(inputPath: string): string {
@@ -125,5 +128,19 @@ describe(GHTaskConfig, () => {
         const actualRunId = taskConfig.getRunId();
 
         expect(actualRunId).toBe(runId);
+    });
+
+    it('should write job summary', async () => {
+        const markdownStub = 'markdownStub';
+
+        markdownSummaryMock
+            .setup((o) => o.addRaw(markdownStub))
+            .returns(() => markdownSummaryMock.object)
+            .verifiable();
+        markdownSummaryMock.setup((o) => o.write()).verifiable();
+
+        actionCoreMock.setup((o) => o.markdownSummary).returns(() => markdownSummaryMock.object);
+
+        await taskConfig.writeJobSummary(markdownStub);
     });
 });

--- a/packages/gh-action/src/task-config/gh-task-config.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.ts
@@ -99,7 +99,7 @@ export class GHTaskConfig extends TaskConfig {
     }
 
     public async writeJobSummary(jobSummaryMarkdown: string): Promise<void> {
-        await this.actionCoreObj.markdownSummary.addRaw(jobSummaryMarkdown).write();
+        await this.actionCoreObj.summary.addRaw(jobSummaryMarkdown).write();
     }
 
     public getUsageDocsUrl(): string {

--- a/packages/gh-action/src/task-config/gh-task-config.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.ts
@@ -98,6 +98,10 @@ export class GHTaskConfig extends TaskConfig {
         return keyToName[key];
     }
 
+    public async writeJobSummary(jobSummaryMarkdown: string): Promise<void> {
+        await this.actionCoreObj.markdownSummary.addRaw(jobSummaryMarkdown).write();
+    }
+
     public getUsageDocsUrl(): string {
         const url = 'https://github.com/microsoft/accessibility-insights-action/blob/main/docs/gh-action-usage.md';
         return url;


### PR DESCRIPTION
#### Details

This PR adds the new Job Summary functionality to the Github Action

Here is a link to a test action run that uses the job summary, you can find it under "build summary" at the bottom of the summary tab:
https://github.com/brocktaylor7/accessibility-insights-action-test/actions/runs/2471620857

![image](https://user-images.githubusercontent.com/13286385/173119536-2504d9b8-0a77-47ab-a42a-cf313b8b68e8.png)


##### Motivation

Feature work.

##### Context

I spent some time looking into whether we could directly link the artifact within the job summary. Because the artifact upload happens in a subsequent step in the Github Action, the artifact doesn't yet exist when the job summary is being created and thus can't be linked.

There will be a separate PR that removes the check run and token. We may also need to look into whether we need to fail the build in that step when accessibility issues are found, as I believe the current place that the build fails is within the check run step.

This PR has no impact on the ADO Extension.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
