### PR TITLE
docs: add information about test deployments to GitHub actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 node_modules/
 dist/
+dist-test-deployment/
 drop/
 test-results/
 out/

--- a/dev/README.md
+++ b/dev/README.md
@@ -29,7 +29,7 @@ To make a change, you can follow these steps:
 
 # Deploy GitHub Action to your own test repo
 
-You can follow the instructions [here](../packages/gh-action/deploy-scripts/deploy-to-github-test.md).
+You can follow the [instructions to deploy to GitHub](../packages/gh-action/deploy-scripts/deploy-to-github-test.md).
 
 # Run GitHub Actions locally
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -27,6 +27,10 @@ To make a change, you can follow these steps:
 -   push your changes to GitHub
 -   create a pull request. If your branch is on the main repo, the PR build should run your implementation against the test files in `website-root`.
 
+# Deploy GitHub Action to your own test repo
+
+You can follow the instructions [here](../packages/gh-action/deploy-scripts/deploy-to-github-test.md).
+
 # Run GitHub Actions locally
 
 ## Prerequisites (Windows)

--- a/packages/gh-action/deploy-scripts/deploy-to-github-test.md
+++ b/packages/gh-action/deploy-scripts/deploy-to-github-test.md
@@ -7,7 +7,7 @@ Licensed under the MIT License.
 
 Sometimes you might want to test your local GitHub action changes in the remote runner.
 
-You can do so by running the following commands in your terminal (e.g. PowerShell).
+You can do so by running the following commands in PowerShell (tested on a Windows machine with PS 5.1). Other environments might require small tweaks to the commands below.
 
 Prerequisites:
 

--- a/packages/gh-action/deploy-scripts/deploy-to-github-test.md
+++ b/packages/gh-action/deploy-scripts/deploy-to-github-test.md
@@ -1,0 +1,49 @@
+# Deploying to GitHub
+
+Sometimes you might want to test your local GitHub action changes in the remote runner.
+
+You can do so by running the following commands in your terminal (e.g. PowerShell).
+
+Prerequisites:
+
+-   install the [GitHub CLI](https://cli.github.com/) once & ensure you're logged into the right account
+
+## How the script works
+
+This script populates a new folder called `dist-test-deployment` that contains a built version of the action. It then pushes this folder to a new **public GitHub repository** inside your account. The repo includes a GitHub workflow file that self-tests the action, so upon repo creation you can immediately see the action running.
+
+## When you're ready to deploy
+
+Run these commands from `packages/gh-action` after running `yarn build`.
+
+```
+rm -r -Force dist-test-deployment
+
+mkdir dist-test-deployment\dev\
+mkdir dist-test-deployment\.github\workflows
+
+cp -r dist dist-test-deployment
+cp action.yml dist-test-deployment
+cp deploy-scripts\validation.yml dist-test-deployment\.github\workflows\
+cp -r ..\..\dev\website-root dist-test-deployment\dev\website-root
+
+git -C dist-test-deployment init -b main
+git -C dist-test-deployment add .
+git -C dist-test-deployment commit -m "adding all files"
+
+gh repo create accessibility-insights-action-test-deployment --source=dist-test-deployment --public --push
+```
+
+## To update the remote repo
+
+I usually just delete & recreate the repo, but if you prefer to keep it long-running, you can try:
+
+-   rerun `yarn build`
+-   replace `dist` contents inside `dist-test-deployment`
+-   commit & push the changes in `dist-test-deployment`
+
+## To delete the remote repo
+
+You can delete the created repo manually, or run this GH command (`--confirm` skips the prompt, so adjust as needed).
+
+`gh repo delete accessibility-insights-action-test-deployment --confirm`

--- a/packages/gh-action/deploy-scripts/deploy-to-github-test.md
+++ b/packages/gh-action/deploy-scripts/deploy-to-github-test.md
@@ -11,8 +11,8 @@ You can do so by running the following commands in PowerShell (tested on a Windo
 
 Prerequisites:
 
-- install the [GitHub CLI](https://cli.github.com/) once & ensure you're logged into the right account
-- git version >= 2.28.0 required for "-b" option in "git init"
+-   install the [GitHub CLI](https://cli.github.com/) once & ensure you're logged into the right account
+-   git version >= 2.28.0 required for "-b" option in "git init"
 
 ## How the script works
 

--- a/packages/gh-action/deploy-scripts/deploy-to-github-test.md
+++ b/packages/gh-action/deploy-scripts/deploy-to-github-test.md
@@ -1,3 +1,8 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+
 # Deploying to GitHub
 
 Sometimes you might want to test your local GitHub action changes in the remote runner.

--- a/packages/gh-action/deploy-scripts/deploy-to-github-test.md
+++ b/packages/gh-action/deploy-scripts/deploy-to-github-test.md
@@ -15,7 +15,7 @@ Prerequisites:
 
 ## How the script works
 
-This script populates a new folder called `dist-test-deployment` that contains a built version of the action. It then pushes this folder to a new **public GitHub repository** inside your account. The repo includes a GitHub workflow file that self-tests the action, so upon repo creation you can immediately see the action running.
+This script populates a new folder called `dist-test-deployment` that contains a built version of the action. It then pushes this folder to a new **private GitHub repository** inside your account. The repo includes a GitHub workflow file that self-tests the action, so upon repo creation you can immediately see the action running.
 
 ## When you're ready to deploy
 
@@ -36,7 +36,7 @@ git -C dist-test-deployment init -b main
 git -C dist-test-deployment add .
 git -C dist-test-deployment commit -m "adding all files"
 
-gh repo create accessibility-insights-action-test-deployment --source=dist-test-deployment --public --push
+gh repo create accessibility-insights-action-test-deployment --source=dist-test-deployment --private --push
 ```
 
 ## To update the remote repo

--- a/packages/gh-action/deploy-scripts/deploy-to-github-test.md
+++ b/packages/gh-action/deploy-scripts/deploy-to-github-test.md
@@ -11,7 +11,8 @@ You can do so by running the following commands in PowerShell (tested on a Windo
 
 Prerequisites:
 
--   install the [GitHub CLI](https://cli.github.com/) once & ensure you're logged into the right account
+- install the [GitHub CLI](https://cli.github.com/) once & ensure you're logged into the right account
+- git version >= 2.28.0 required for "-b" option in "git init"
 
 ## How the script works
 

--- a/packages/gh-action/deploy-scripts/validation.yml
+++ b/packages/gh-action/deploy-scripts/validation.yml
@@ -1,0 +1,17 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+on: [push]
+
+jobs:
+    action_run:
+        runs-on: ubuntu-latest
+        name: Run test deployment of action
+        steps:
+            - uses: actions/checkout@v3
+            - name: Scan local website for accessibility issues
+              uses: ./
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  static-site-dir: ${{ github.workspace }}/dev/website-root
+                  static-site-port: 53800

--- a/packages/gh-action/package.json
+++ b/packages/gh-action/package.json
@@ -8,7 +8,7 @@
         "build": "webpack --config ./webpack.config.js && node prepare-package-dir.js",
         "watch:build": "webpack --config ./webpack.config.js --watch",
         "cbuild": "npm-run-all --serial clean build",
-        "clean": "rimraf dist test-results accessibility-insights-action/dist",
+        "clean": "rimraf dist dist-test-deployment test-results accessibility-insights-action/dist",
         "lint:check": "eslint -c ../../.eslintrc.js \"src/**/*.{js,ts}\"",
         "lint:fix": "eslint -c ../../.eslintrc.js \"src/**/*.{js,ts}\" --quiet --fix",
         "test": "jest",


### PR DESCRIPTION
#### Details

There are a few different ways to test updates to the GitHub action. One way is to deploy the built action remotely. I am adding some information to the docs so that it's in one place. It would be nice to operationalize this into our yarn scripts, but I'm not sure I'll be able to get to that immediately - so hoping that this provides some initial info.

As an example, running the listed commands produces this repo: https://github.com/karanbirsingh/accessibility-insights-action-test-deployment which has its own action.yml. So there is no second 'client' repository required - when the repo is pushed, it immediately begins self-testing its action.

The script is inside a Markdown file which can feel like an odd choice - I didn't put it into a PowerShell script. This is because of a few reasons:
- I am on a Windows machine and have not tested whether these work appropriately in other terminal/OS environments
- Since the commands are not encapsulated with error or retry logic, it didn't feel as 'ready' to put into a yarn command (especially with creating/deleting repos)
- I can easily imagine someone customizing which commands make sense for their workflow

In the "default case" you can copy-paste the full list into PowerShell after a `yarn build` and it results in a repo like the one I shared above.

##### Motivation

Share an approach that can be used to deploy and test the GH action remotely

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Described how this PR impacts both the ADO extension and the GitHub action: This PR only impacts the GH action.
