### PR TITLE
fix: Remove --updateBaseline info from debug logs

### DIFF
--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
@@ -48,4 +48,13 @@ describe(adoStdoutTransformer, () => {
         const output = adoStdoutTransformer(input);
         expect(output).toBe(expectedOutput);
     });
+
+    it('CLI option is removed from logs', () => {
+        const input =
+            'To update the baseline with these changes, either rerun with --updateBaseline or copy the updated baseline file to /path/to/test.baseline';
+
+        const output = adoStdoutTransformer(input);
+
+        expect(output).toBe('##[debug]To update the baseline with these changes, copy the updated baseline file to /path/to/test.baseline');
+    });
 });

--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.spec.ts
@@ -48,13 +48,4 @@ describe(adoStdoutTransformer, () => {
         const output = adoStdoutTransformer(input);
         expect(output).toBe(expectedOutput);
     });
-
-    it('CLI option is removed from logs', () => {
-        const input =
-            'To update the baseline with these changes, either rerun with --updateBaseline or copy the updated baseline file to /path/to/test.baseline';
-
-        const output = adoStdoutTransformer(input);
-
-        expect(output).toBe('##[debug]To update the baseline with these changes, copy the updated baseline file to /path/to/test.baseline');
-    });
 });

--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.ts
@@ -6,6 +6,7 @@ const debugPrefix = '##[debug]';
 type RegexTransformation = {
     regex: RegExp;
     method: (rawData: string, regex?: RegExp) => string;
+    prependDebugPrefix?: boolean;
 };
 
 const regexTransformations: RegexTransformation[] = [
@@ -58,14 +59,19 @@ const regexTransformations: RegexTransformation[] = [
         regex: new RegExp('^\u001B\\[32mINFO\u001b\\[39m '), // Includes escape characters used for color formatting)
         method: replaceFirstMatchWithDebugPrefix,
     },
+    {
+        regex: new RegExp('either rerun with --updateBaseline or '),
+        method: removeFirstMatch,
+        prependDebugPrefix: true,
+    },
 ];
 
 export const adoStdoutTransformer = (rawData: string): string | null => {
-    for (const startSubstitution of regexTransformations) {
-        const newData = regexTransformation(rawData, startSubstitution.regex, startSubstitution.method);
+    for (const transformation of regexTransformations) {
+        const newData = regexTransformation(rawData, transformation.regex, transformation.method);
 
         if (newData) {
-            return newData;
+            return transformation.prependDebugPrefix ? prependDebugPrefix(newData) : newData;
         }
     }
 
@@ -86,27 +92,27 @@ function useUnmodifiedString(input: string): string {
 }
 
 function removeFirstMatch(input: string, regex: RegExp): string {
-    return `${input.replace(regex, '$`')}`;
+    return `${input.replace(regex, '')}`;
 }
 
 function replaceFirstMatchWithDebugPrefix(input: string, regex: RegExp): string {
-    return `${debugPrefix}${input.replace(regex, '$`')}`;
+    return `${debugPrefix}${input.replace(regex, '')}`;
 }
 
 function replaceFirstMatchWithWarningPrefix(input: string, regex: RegExp): string {
-    return `##[warning]${input.replace(regex, '$`')}`;
+    return `##[warning]${input.replace(regex, '')}`;
 }
 
 function replaceFirstMatchWithErrorPrefix(input: string, regex: RegExp): string {
-    return `##[error]${input.replace(regex, '$`')}`;
+    return `##[error]${input.replace(regex, '')}`;
 }
 
 function replaceFirstMatchWithGroupPrefix(input: string, regex: RegExp): string {
-    return `##[group]${input.replace(regex, '$`')}`;
+    return `##[group]${input.replace(regex, '')}`;
 }
 
 function replaceFirstMatchWithEndgroupPrefix(input: string, regex: RegExp): string {
-    return `##[endgroup]${input.replace(regex, '$`')}`;
+    return `##[endgroup]${input.replace(regex, '')}`;
 }
 
 function prependDebugPrefix(input: string): string {

--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { stdoutPreprocessor } from '@accessibility-insights-action/shared';
+
 const debugPrefix = '##[debug]';
 
 type RegexTransformation = {
@@ -60,16 +62,17 @@ const regexTransformations: RegexTransformation[] = [
     },
 ];
 
-export const adoStdoutTransformer = (rawData: string): string | null => {
+export const adoStdoutTransformer = (rawData: string, preprocessor: (data: string) => string = stdoutPreprocessor): string | null => {
+    const data = preprocessor(rawData);
     for (const startSubstitution of regexTransformations) {
-        const newData = regexTransformation(rawData, startSubstitution.regex, startSubstitution.method);
+        const newData = regexTransformation(data, startSubstitution.regex, startSubstitution.method);
 
         if (newData) {
             return newData;
         }
     }
 
-    return prependDebugPrefix(rawData);
+    return prependDebugPrefix(data);
 };
 
 const regexTransformation = (input: string, regex: RegExp, modifier: (input: string, regex?: RegExp) => string): string | null => {

--- a/packages/ado-extension/src/output-hooks/ado-stdout-transformer.ts
+++ b/packages/ado-extension/src/output-hooks/ado-stdout-transformer.ts
@@ -6,7 +6,6 @@ const debugPrefix = '##[debug]';
 type RegexTransformation = {
     regex: RegExp;
     method: (rawData: string, regex?: RegExp) => string;
-    prependDebugPrefix?: boolean;
 };
 
 const regexTransformations: RegexTransformation[] = [
@@ -59,19 +58,14 @@ const regexTransformations: RegexTransformation[] = [
         regex: new RegExp('^\u001B\\[32mINFO\u001b\\[39m '), // Includes escape characters used for color formatting)
         method: replaceFirstMatchWithDebugPrefix,
     },
-    {
-        regex: new RegExp('either rerun with --updateBaseline or '),
-        method: removeFirstMatch,
-        prependDebugPrefix: true,
-    },
 ];
 
 export const adoStdoutTransformer = (rawData: string): string | null => {
-    for (const transformation of regexTransformations) {
-        const newData = regexTransformation(rawData, transformation.regex, transformation.method);
+    for (const startSubstitution of regexTransformations) {
+        const newData = regexTransformation(rawData, startSubstitution.regex, startSubstitution.method);
 
         if (newData) {
-            return transformation.prependDebugPrefix ? prependDebugPrefix(newData) : newData;
+            return newData;
         }
     }
 
@@ -92,27 +86,27 @@ function useUnmodifiedString(input: string): string {
 }
 
 function removeFirstMatch(input: string, regex: RegExp): string {
-    return `${input.replace(regex, '')}`;
+    return `${input.replace(regex, '$`')}`;
 }
 
 function replaceFirstMatchWithDebugPrefix(input: string, regex: RegExp): string {
-    return `${debugPrefix}${input.replace(regex, '')}`;
+    return `${debugPrefix}${input.replace(regex, '$`')}`;
 }
 
 function replaceFirstMatchWithWarningPrefix(input: string, regex: RegExp): string {
-    return `##[warning]${input.replace(regex, '')}`;
+    return `##[warning]${input.replace(regex, '$`')}`;
 }
 
 function replaceFirstMatchWithErrorPrefix(input: string, regex: RegExp): string {
-    return `##[error]${input.replace(regex, '')}`;
+    return `##[error]${input.replace(regex, '$`')}`;
 }
 
 function replaceFirstMatchWithGroupPrefix(input: string, regex: RegExp): string {
-    return `##[group]${input.replace(regex, '')}`;
+    return `##[group]${input.replace(regex, '$`')}`;
 }
 
 function replaceFirstMatchWithEndgroupPrefix(input: string, regex: RegExp): string {
-    return `##[endgroup]${input.replace(regex, '')}`;
+    return `##[endgroup]${input.replace(regex, '$`')}`;
 }
 
 function prependDebugPrefix(input: string): string {

--- a/packages/gh-action/src/output-hooks/gh-stdout-transformer.ts
+++ b/packages/gh-action/src/output-hooks/gh-stdout-transformer.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { stdoutPreprocessor } from '@accessibility-insights-action/shared';
+
 const debugPrefix = '::debug::';
 
 type RegexTransformation = {
@@ -56,16 +58,17 @@ const regexTransformations: RegexTransformation[] = [
     },
 ];
 
-export const ghStdoutTransformer = (rawData: string): string | null => {
+export const ghStdoutTransformer = (rawData: string, preprocessor: (data: string) => string = stdoutPreprocessor): string | null => {
+    const data = preprocessor(rawData);
     for (const startSubstitution of regexTransformations) {
-        const newData = regexTransformation(rawData, startSubstitution.regex, startSubstitution.method);
+        const newData = regexTransformation(data, startSubstitution.regex, startSubstitution.method);
 
         if (newData) {
             return newData;
         }
     }
 
-    return prependDebugPrefix(rawData);
+    return prependDebugPrefix(data);
 };
 
 const regexTransformation = (input: string, regex: RegExp, modifier: (input: string, regex?: RegExp) => string): string | null => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,6 +18,7 @@ export { ArtifactsInfoProvider } from './artifacts-info-provider';
 export { hookStdout } from './output-hooks/hook-stdout';
 export { hookStderr } from './output-hooks/hook-stderr';
 export { StreamTransformer } from './output-hooks/stream-transformer';
+export { stdoutPreprocessor } from './output-hooks/stdout-preprocessor';
 export { ExitCode } from './exit-code';
 export { TelemetryClient } from './telemetry/telemetry-client';
 export { TelemetryEvent } from './telemetry/telemetry-event';

--- a/packages/shared/src/output-hooks/stdout-preprocessor.spec.ts
+++ b/packages/shared/src/output-hooks/stdout-preprocessor.spec.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { stdoutPreprocessor } from './stdout-preprocessor';
+
+describe(stdoutPreprocessor, () => {
+    it('Leaves logs as-is if they contain nothing that should be filtered', () => {
+        const input = 'Just your average log message';
+
+        const output = stdoutPreprocessor(input);
+
+        expect(output).toBe(input);
+    });
+
+    it('removes info about --updateBaseline from output', () => {
+        const input =
+            'To update the baseline with these changes, either rerun with --updateBaseline or copy the updated baseline file to /path/to/test.baseline';
+
+        const output = stdoutPreprocessor(input);
+
+        expect(output).toBe('To update the baseline with these changes, copy the updated baseline file to /path/to/test.baseline');
+    });
+});

--- a/packages/shared/src/output-hooks/stdout-preprocessor.ts
+++ b/packages/shared/src/output-hooks/stdout-preprocessor.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export const stdoutPreprocessor = (rawData: string): string => {
+    return rawData.replace('either rerun with --updateBaseline or ', '');
+};


### PR DESCRIPTION
#### Details

Currently, running the ADO extension with baselining outputs
```
To update the baseline with these changes, either rerun with --updateBaseline or copy the updated baseline file to /home/vsts/work/1/s/test.baseline
```
This PR filters out the part of the message that references --updateBaseline, so we only print
```
To update the baseline with these changes, copy the updated baseline file to /home/vsts/work/1/s/test.baseline
```
This fix affects the ADO extension, and will take effect in the Github action if baselining is enabled in the future.

##### Motivation

Fixes #944 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes #944
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
