### PR TITLE
Fix: Adding hosting-mode to valid input list

### DIFF
--- a/packages/gh-action/action.yml
+++ b/packages/gh-action/action.yml
@@ -10,11 +10,10 @@ inputs:
         required: true
     static-site-dir:
         description: 'Folder containing website content.'
-        default: ${{ github.workspace }}
-        required: true
+        required: false
     static-site-url-relative-path:
         description: 'Relative path to directory used to construct base scan url. e.g. / on Ubuntu and // on Windows'
-        required: true
+        required: false
         default: '/'
     chrome-path:
         description: 'Path to Chrome executable.'

--- a/packages/gh-action/action.yml
+++ b/packages/gh-action/action.yml
@@ -53,6 +53,9 @@ inputs:
         description: 'Fail the build if there are accessibility issues.'
         required: true
         default: true
+    hosting-mode:
+        description: 'Your site must be served (hosted) before it can be scanned. In _Static Site_ mode, this task will run a localhost web server serving your site directory and scan that. In _Dynamic Site_ mode, you must host your site yourself separately and specify a URL to scan. This can be either a localhost server you run in an earlier pipeline step, or a remote URL (for example, a staging environment).'
+        required: false
 runs:
     using: 'composite'
     steps:
@@ -89,3 +92,4 @@ runs:
               INPUT_STATIC-SITE-PORT: ${{ inputs.static-site-port }}
               INPUT_SCAN-TIMEOUT: ${{ inputs.scan-timeout }}
               INPUT_FAIL-ON-ACCESSIBILITY-ERROR: ${{ inputs.fail-on-accessibility-error }}
+              INPUT_HOSTING-MODE: ${{ inputs.hosting-mode }}

--- a/packages/gh-action/src/task-config/gh-task-config.ts
+++ b/packages/gh-action/src/task-config/gh-task-config.ts
@@ -19,7 +19,7 @@ export class GHTaskConfig extends TaskConfig {
     }
 
     public getReportOutDir(): string {
-        // Relying on action.yml to make this required
+        // Relying on action.yml to provide a default if necessary
         return this.getOptionalPathInput('output-dir');
     }
 
@@ -117,6 +117,8 @@ export class GHTaskConfig extends TaskConfig {
         return normalizePath(this.resolvePath(dirname, normalizePath(path)));
     }
 
+    // We must assume that every input may be optional due to https://github.com/actions/runner/issues/1070,
+    // regardless of whether it was specified as required in action.yml
     private getOptionalPathInput(inputName: string): string | undefined {
         const rawValue = this.actionCoreObj.getInput(inputName);
         return this.getAbsolutePath(rawValue);


### PR DESCRIPTION
#### Details

This PR adds `hosting-mode` to the valid list of inputs for GH Action and removes the default value for `static-site-dir`. It also changes `static-site-dir` and `static-site-url-relative-path` to be optional inputs, as they are not required in `dynamicSite` hosting mode.

Additionally updated the `gh-action-usage.md` to make the examples/suggestions more accurately reflect the new behavior and include a migration guide from v2 to v3, which specifies how to use `hosting-mode`.

##### Motivation
During the last release validation, @lisli1 found an issue where `hosting-mode` was not recognized as a valid input, preventing GH Action from performing an accessibility test on the project.

With the default `static-site-dir`, the GH Action wasn't able to run in `dynamicSite` hosting mode, since it expects `static-site-dir` to not be set when using `dynamicSite`. By removing the default, `static-site-dir` no longer has a value set. This is the same behavior as the ADO extension, which also does not have a default value for `staticSiteDir`.

##### Context
`hosting-mode` was not added to the list of valid inputs on the Action pipeline, causing configuration problems when set.

Considered keeping the existing behavior for `static-site-dir` with the default input and checking for it in `input-validator.ts`, but that would have required adding another method, `getSiteDirDefault` to the shared `task-config.ts`, which may also impact the ADO extension. Decided to keep the changes scoped to the GH Action and make the behavior match what is already in the ADO extension.

This PR exclusively affects GH Action, ADO Extension is not impacted.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
