### PR TITLE
Update ado-extension-usage.md

### DIFF
--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -99,7 +99,7 @@ The action supports several crawling options defined in [task.json](https://gith
 For instance, you can:
 
 -   use `maxUrls: 1` to exclusively set the extension to only scan the first Url that has been inputted
--   set `maxUrls: # of inputUrls` to scan a set list of URLs for your site
+-   set `maxUrls` to the number of URLs in `inputUrls` to scan a fixed list of URLs for your site
 
 For `discoveryPatterns`, `inputFile`, and `inputUrls`, note that these options expect resolved URLs. If you provide static HTML files via `staticSiteDir`, you should also provide `staticSitePort` so that you can anticipate the base URL of the file server (`http://localhost:staticSitePort/`).
 

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -98,8 +98,8 @@ The action supports several crawling options defined in [task.json](https://gith
 
 For instance, you can:
 
--   use `maxUrls: 1` to turn off crawling
--   include a list of additional URLs to scan (the crawler won't find pages that are unlinked from the base page)
+-   use `maxUrls: 1` to exclusively set the extension to only scan the first Url that has been inputted
+-   set `maxUrls: # of inputUrls` to scan a set list of URLs for your site
 
 For `discoveryPatterns`, `inputFile`, and `inputUrls`, note that these options expect resolved URLs. If you provide static HTML files via `staticSiteDir`, you should also provide `staticSitePort` so that you can anticipate the base URL of the file server (`http://localhost:staticSitePort/`).
 


### PR DESCRIPTION
#### Details

"Modify crawling options" docs update to clarify behavior of 'maxUrls' input

##### Motivation

Wanted to add clarity around scanning a set number of URLs for the extension's crawl behavior

##### Context

Prior to the update, we had noted that if you set 'maxUrls' to 1, it would disable the crawler. This was a bit misleading, so we have updated the language. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] n/a