### PR TITLE
feat(ado-auth-part-2): Add telemetry for authentication events

### DIFF
--- a/packages/shared/src/scanner/scanner.spec.ts
+++ b/packages/shared/src/scanner/scanner.spec.ts
@@ -194,6 +194,22 @@ describe(Scanner, () => {
             verifyMocks();
         });
 
+        it('emits the expected pattern of telemetry when service account name is provided', async () => {
+            scanArguments.serviceAccountName = 'name';
+            setupMocksForSuccessfulScan();
+            setupWaitForPromiseToReturnOriginalPromise();
+
+            inputValidatorMock.setup((m) => m.validate()).returns(() => true);
+
+            telemetryClientMock.setup((m) => m.trackEvent({ name: 'ScanStart' }));
+            telemetryClientMock.setup((m) => m.trackEvent({ name: 'AuthUsed' }));
+            telemetryClientMock.setup((m) => m.flush());
+
+            await scanner.scan();
+
+            verifyMocks();
+        });
+
         function setupMocksForSuccessfulScan(baselineEvaluation?: BaselineEvaluation): void {
             taskConfigMock
                 .setup((m) => m.getScanTimeout())

--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -82,7 +82,7 @@ export class Scanner {
 
             this.telemetryClient.trackEvent({ name: 'ScanStart' });
 
-            if (scanArguments.serviceAccountName != undefined) {
+            if (scanArguments.serviceAccountName !== undefined) {
                 this.telemetryClient.trackEvent({ name: 'AuthUsed' });
             }
 

--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -82,6 +82,10 @@ export class Scanner {
 
             this.telemetryClient.trackEvent({ name: 'ScanStart' });
 
+            if (scanArguments.serviceAccountName != undefined) {
+                this.telemetryClient.trackEvent({ name: 'AuthUsed' });
+            }
+
             this.logger.logStartGroup(`Scanning URL ${scanArguments.url}`);
             this.logger.logDebug(`Starting accessibility scanning of URL ${scanArguments.url}`);
             this.logger.logDebug(`Chrome app executable: ${scanArguments.chromePath ?? 'system default'}`);

--- a/packages/shared/src/telemetry/telemetry-event.ts
+++ b/packages/shared/src/telemetry/telemetry-event.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export type TelemetryEventName = 'ScanStart' | 'ScanCompleted';
+export type TelemetryEventName = 'ScanStart' | 'ScanCompleted' | 'AuthUsed';
 
 export type TelemetryEvent = {
     name: TelemetryEventName;


### PR DESCRIPTION
#### Details

This PR adds a new `AuthUsed` event that tracks information about when authentication was attempted. This event is fired when a non-null value for `serviceAccountName` is found within the `scannArguments`

##### Motivation

Feature work

##### Context

This new event works as a flag and only provides information about whether an authentication attempt was made, and affects exclusively ADO Extension internal runs.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #[1970879](https://dev.azure.com/mseng/1ES/_workitems/edit/1970879/)
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
