### PR TITLE
Clarify that the scan-timeout is in milliseconds in gh-action-usage.md

### DIFF
--- a/docs/gh-action-usage.md
+++ b/docs/gh-action-usage.md
@@ -168,4 +168,4 @@ Version 3.x of the action contains several breaking changes from version 2.x. To
 -   If the action didn't trigger as you expected, go to the ["on" section](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on) of your yml file. Make sure any listed branch names are correct for your repository.
 -   If the action fails to complete, you can check the build logs for execution errors. Using the template above, these logs will be in the `Scan for accessibility issues` step.
 -   If you can't find an artifact, note that your workflow must include an `actions/upload-artifact` step to add the report folder to your check results. See the "Basic template" above.
--   If the scan takes longer than 90 seconds, you can override the default timeout by providing a value for `scan-timeout`
+-   If the scan takes longer than 90 seconds, you can override the default timeout by providing a value for `scan-timeout` in milliseconds.


### PR DESCRIPTION
#### Details

To avoid confusion since we're talking about the default being 90 seconds just before.

##### Motivation

I wanted to bump the timeout and thought it is in seconds.

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
- [n/a] Described how this PR impacts both the ADO extension and the GitHub action
