### PR TITLE
feat(ado-auth-part-2): Upgrade ADO Extension to use Node16

### DIFF
--- a/packages/ado-extension/package.json
+++ b/packages/ado-extension/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@accessibility-insights-action/shared": "^1.0.0",
         "applicationinsights": "^2.3.4",
-        "azure-pipelines-task-lib": "^3.3.1",
+        "azure-pipelines-task-lib": "^4.0.0-preview",
         "reflect-metadata": "^0.1.13"
     }
 }

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -109,7 +109,7 @@ describe(AdoConsoleCommentCreator, () => {
                 await testSubject.completeRun(reportStub);
 
                 expect(logger.recordedLogs()).toContain(
-                    `[info] ##vso[artifact.upload artifactname=${expectedArtifactName}]${defaultReportOutDir}`,
+                    `[info] ##vso[artifact.upload artifactname=${expectedArtifactName}]${defaultReportOutDir}/index.html`,
                 );
                 verifyAllMocks();
             },

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -6,6 +6,7 @@ import { Mock, Times, IMock, MockBehavior } from 'typemoq';
 import { AdoConsoleCommentCreator } from './ado-console-comment-creator';
 import { ADOTaskConfig } from '../../task-config/ado-task-config';
 import { CombinedReportParameters } from 'accessibility-insights-report';
+import { BaselineEvaluation } from 'accessibility-insights-scan';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -34,6 +35,7 @@ describe(AdoConsoleCommentCreator, () => {
     const baselineInfoStub = {};
     const reportMarkdownStub = '#ReportMarkdownStub';
     const reportConsoleLogStub = 'Report Console Log Stub';
+    const baselineFilenameStub = 'baselineFilenameStub.baseline';
 
     beforeEach(() => {
         adoTaskConfigMock = Mock.ofType<ADOTaskConfig>();
@@ -41,7 +43,8 @@ describe(AdoConsoleCommentCreator, () => {
         reportMarkdownConvertorMock = Mock.ofType<ReportMarkdownConvertor>(undefined, MockBehavior.Strict);
         reportConsoleLogConvertorMock = Mock.ofType<ReportConsoleLogConvertor>(undefined, MockBehavior.Strict);
         fsMock = Mock.ofType<typeof fs>();
-        pathStub = { join: (...paths) => paths.join('/') } as typeof path;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        pathStub = { join: (...paths) => paths.join('/'), basename: (filepath) => baselineFilenameStub } as typeof path;
 
         reportMarkdownConvertorMock
             .setup((o) => o.convert(reportStub, undefined, baselineInfoStub))
@@ -133,6 +136,63 @@ describe(AdoConsoleCommentCreator, () => {
                 await testSubject.completeRun(reportStub);
 
                 expect(logger.recordedLogs()).not.toContain(/##vso\[artifact.upload/);
+                verifyAllMocks();
+            },
+        );
+
+        it.each`
+            baselineFileExists
+            ${true}
+            ${false}
+        `(
+            'should conditionally upload baseline artifact when filename set: baselineFileExists=$baselineFileExists',
+            async ({ baselineFileExists }) => {
+                setupTaskConfig({
+                    uploadOutputArtifact: true,
+                    outputArtifactName: 'accessibility-reports',
+                    jobAttempt: 1,
+                    baselineFile: baselineFilenameStub,
+                });
+
+                const baselineEvaluationStub = {
+                    suggestedBaselineUpdate: null,
+                    newViolationsByRule: {},
+                    fixedViolationsByRule: {},
+                    totalNewViolations: 1,
+                    totalFixedViolations: 1,
+                } as BaselineEvaluation;
+
+                const baselineInfoWithEvalStub = { baselineFileName: baselineFilenameStub, baselineEvaluation: baselineEvaluationStub };
+
+                reportMarkdownConvertorMock
+                    .setup((o) => o.convert(reportStub, undefined, baselineInfoWithEvalStub))
+                    .returns(() => reportMarkdownStub)
+                    .verifiable(Times.atMostOnce());
+
+                reportConsoleLogConvertorMock
+                    .setup((o) => o.convert(reportStub, undefined, baselineInfoWithEvalStub))
+                    .returns(() => reportConsoleLogStub)
+                    .verifiable(Times.atMostOnce());
+
+                const expectedBaselineOutputFilePath = `${defaultReportOutDir}/${baselineFilenameStub}`;
+
+                fsMock
+                    // eslint-disable-next-line security/detect-non-literal-fs-filename
+                    .setup((fsm) => fsm.existsSync(`${expectedBaselineOutputFilePath}`))
+                    .returns(() => baselineFileExists as boolean)
+                    .verifiable(Times.once());
+
+                await testSubject.completeRun(reportStub, baselineEvaluationStub);
+                if (baselineFileExists) {
+                    expect(logger.recordedLogs()).toContain(
+                        `[info] ##vso[artifact.upload artifactname=accessibility-reports]${expectedBaselineOutputFilePath}`,
+                    );
+                } else {
+                    expect(logger.recordedLogs()).not.toContain(
+                        `[info] ##vso[artifact.upload artifactname=accessibility-reports]${expectedBaselineOutputFilePath}`,
+                    );
+                }
+
                 verifyAllMocks();
             },
         );

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -112,7 +112,7 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
             this.logger.logInfo(`##vso[artifact.upload artifactname=${artifactName}]${reportFilePath}`);
 
             // eslint-disable-next-line security/detect-non-literal-fs-filename
-            if (baselineFilePath !== undefined && fs.existsSync(baselineFilePath)) {
+            if (baselineFilePath !== undefined && this.fileSystemObj.existsSync(baselineFilePath)) {
                 this.logger.logInfo(`##vso[artifact.upload artifactname=${artifactName}]${baselineFilePath}`);
             }
         }

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -102,8 +102,12 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
     private uploadOutputArtifact(artifactName: string | null): void {
         if (artifactName != null) {
             const outputDirectory = this.taskConfig.getReportOutDir();
-            const baselineFilePath = this.taskConfig.getBaselineFile();
+            const baselineInputFilePath = this.taskConfig.getBaselineFile();
+
             const reportFilePath = this.pathObj.join(outputDirectory, 'index.html');
+            const baselineFilePath = baselineInputFilePath
+                ? this.pathObj.join(outputDirectory, this.pathObj.basename(baselineInputFilePath))
+                : undefined;
 
             this.logger.logInfo(`##vso[artifact.upload artifactname=${artifactName}]${reportFilePath}`);
 

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -102,7 +102,7 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
     private uploadOutputArtifact(artifactName: string | null): void {
         if (artifactName != null) {
             const outputDirectory = this.taskConfig.getReportOutDir();
-            this.logger.logInfo(`##vso[artifact.upload artifactname=${artifactName}]${outputDirectory}`);
+            this.logger.logInfo(`##vso[artifact.upload artifactname=${artifactName}]${outputDirectory}/index.html`);
         }
     }
 

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -102,7 +102,15 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
     private uploadOutputArtifact(artifactName: string | null): void {
         if (artifactName != null) {
             const outputDirectory = this.taskConfig.getReportOutDir();
-            this.logger.logInfo(`##vso[artifact.upload artifactname=${artifactName}]${outputDirectory}/index.html`);
+            const baselineFilePath = this.taskConfig.getBaselineFile();
+            const reportFilePath = this.pathObj.join(outputDirectory, 'index.html');
+
+            this.logger.logInfo(`##vso[artifact.upload artifactname=${artifactName}]${reportFilePath}`);
+
+            // eslint-disable-next-line security/detect-non-literal-fs-filename
+            if (baselineFilePath !== undefined && fs.existsSync(baselineFilePath)) {
+                this.logger.logInfo(`##vso[artifact.upload artifactname=${artifactName}]${baselineFilePath}`);
+            }
         }
     }
 

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -191,8 +191,9 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "index.js"
         }
-    }
+    },
+    "minimumAgentVersion": "2.206.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3380,10 +3380,10 @@ azure-devops-node-api@^10.2.2:
     tunnel "0.0.6"
     typed-rest-client "^1.8.4"
 
-azure-pipelines-task-lib@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.3.1.tgz#e8e226db104af22dd6d603fdb8c6a2ba995b8a83"
-  integrity sha512-56ZAr4MHIoa24VNVuwPL4iUQ5MKaigPoYXkBG8E8fiVmh8yZdatUo25meNoQwg77vDY22F63Q44UzXoMWmy7ag==
+azure-pipelines-task-lib@^4.0.0-preview:
+  version "4.0.0-preview"
+  resolved "https://registry.yarnpkg.com/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.0.0-preview.tgz#36d494f7f1d7900c9d928da78bd92e86b642ac1d"
+  integrity sha512-BK+VOo42Bec72Wic6Vsm2MaAJezNyF05OYAQS5FuZJM5Z972lZqYpujtSc4BFKUhC3HO+F/Yf4xhAV2tZCzN9Q==
   dependencies:
     minimatch "3.0.5"
     mockery "^1.7.0"


### PR DESCRIPTION
#### Details

This makes the necessary changes to upgrade our extension to use Node16. We reduced artifact uploads to just the report and baseline if applicable due to an issue with the Node16 handler on ADO.

I followed the guide for upgrading that the build task team pointed me to, found here: https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/migrateNode16.md


##### Motivation

Feature work

##### Context

The `azure-pipelines-task-lib` library still has the `-preview` tag. The build task team has done this intentionally to limit the number of pipelines that run on Node16 until they're able to scale up the number of available agents on Node16. The library is stable.

Several approaches were attempted with the artifact upload. I landed on manually uploading the report via logging commands, and checking for the baseline and uploading it in the same way if available. I've tested this in all three available OS environments (Windows, Mac, Ubuntu) and it is working as expected in all three.

This has no impact on the GH Action.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran prechecking (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
