### PR TITLE
feat(ado-auth-part-2): update usage docs to use v3

### DIFF
--- a/docs/ado-extension-overview.md
+++ b/docs/ado-extension-overview.md
@@ -5,8 +5,6 @@ Licensed under the MIT License.
 
 # Accessibility Insights for Azure DevOps
 
-_This extension is in beta and preview mode._
-
 Accessibility Insights for Azure DevOps is an extension that enables you to integrate Accessibility Insights' automated checks, powered by [axe-core](https://github.com/dequelabs/axe-core), into your Azure pipeline.
 
 ## Features

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -52,7 +52,7 @@ pool:
 steps:
     # Insert any jobs here required to build your website files
 
-    - task: accessibility-insights.prod.task.accessibility-insights@2
+    - task: accessibility-insights.prod.task.accessibility-insights@3
       displayName: Scan for accessibility issues
       inputs:
           # Provide either staticSiteDir or url
@@ -65,7 +65,7 @@ steps:
 Provide the website URL. The URL should already be hosted - something like `http://localhost:12345/` or `https://example.com`.
 
 ```yml
-- task: accessibility-insights.prod.task.accessibility-insights@2
+- task: accessibility-insights.prod.task.accessibility-insights@3
   displayName: Scan for accessibility issues
   inputs:
       url: 'http://localhost:12345/'
@@ -78,7 +78,7 @@ The `url` parameter takes priority over `staticSiteDir`. If `url` is provided, s
 Provide the location of your built HTML files using `staticSiteDir` and (optionally) `staticSiteUrlRelativePath`. The action will serve the site for you using `express`.
 
 ```yml
-- task: accessibility-insights.prod.task.accessibility-insights@2
+- task: accessibility-insights.prod.task.accessibility-insights@3
   displayName: Scan for accessibility issues
   inputs:
       staticSiteDir: '$(System.DefaultWorkingDirectory)/website/root/'
@@ -147,7 +147,7 @@ When the scanning tool fails, it creates a new baseline file--reflecting the cur
 Here is an example of a YAML file that is configured to take advantage of a baseline, assuming just one environment:
 
 ```yml
-- task: accessibility-insights.prod.task.accessibility-insights@2
+- task: accessibility-insights.prod.task.accessibility-insights@3
   displayName: Scan for accessibility issues
   inputs:
       url: 'http://localhost:12345/'


### PR DESCRIPTION
#### Details

This updates the usage docs to use v3, and removes language about the extension being in beta.

##### Motivation

feature work

##### Context

This does not affect the GH Action

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Described how this PR impacts both the ADO extension and the GitHub action
