### PR TITLE
chore: Enable allowJs to support pure ESM with Jest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,11 +45,3 @@ updates:
   - dependency-name: marked-terminal
     versions:
     - ">= 5"
-    # get-port v6+ is pure ESM and requires node >= 12.20
-  - dependency-name: get-port
-    versions:
-    - ">= 6"
-    # serialize-error v9+ is pure ESM and requires node >= 12.20
-  - dependency-name: serialize-error
-    versions:
-    - ">= 9"

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -27,8 +27,9 @@ module.exports = {
     reporters: ['default', ['jest-junit', { outputDirectory: '<rootDir>/test-results/unit', outputName: 'junit.xml' }]],
     setupFilesAfterEnv: ['jest-extended'],
     transform: {
-        '^.+\\.(ts|tsx)$': 'ts-jest',
+        '^.+\\.(jsx?|tsx?)$': 'ts-jest',
     },
+    transformIgnorePatterns: ['/node_modules/(?!(serialize-error|get-port))'], // Transform pure ESM with ts-jest
     testMatch: ['**/*.spec.[tj]s'],
     testPathIgnorePatterns: ['/dist/', '/out/'],
     verbose: true,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -35,7 +35,7 @@
         "axe-core": "4.4.1",
         "express": "^4.18.1",
         "filenamify-url": "^3.0.0",
-        "get-port": "^5.1.1",
+        "get-port": "^6.1.2",
         "inversify": "6.0.1",
         "lodash": "^4.17.21",
         "marked": "^4.0.18",
@@ -43,7 +43,7 @@
         "normalize-path": "^3.0.0",
         "pony-cause": "^2.1.1",
         "reflect-metadata": "^0.1.13",
-        "serialize-error": "^8.0.1",
+        "serialize-error": "^11.0.0",
         "serve-static": "^1.15.0"
     }
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -4,5 +4,6 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "outDir": "dist"
-    }
+    },
+    "include": ["src/**/*"] // With `allowJs: true` in tsconfig.base.json, this setting scopes the files to build the package properly.
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,7 +12,8 @@
         "declaration": true,
         "forceConsistentCasingInFileNames": true,
         "skipLibCheck": true,
-        "esModuleInterop": true
+        "esModuleInterop": true,
+        "allowJs": true
     },
     "awesomeTypescriptLoaderOptions": {
         "usePrecompiledFiles": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5727,6 +5727,11 @@ get-port@^5.1.1:
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
   integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
 
+get-port@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-6.1.2.tgz#c1228abb67ba0e17fb346da33b15187833b9c08a"
+  integrity sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==
+
 get-stdin@*:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-9.0.0.tgz#3983ff82e03d56f1b2ea0d3e60325f39d703a575"
@@ -6039,9 +6044,9 @@ header-generator@^1.1.3:
     ow "^0.23.0"
 
 hosted-git-info@>=3.0.8, hosted-git-info@^2.1.4, hosted-git-info@^3.0.6, hosted-git-info@^4.0.0, hosted-git-info@^4.0.1, hosted-git-info@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-5.0.0.tgz#df7a06678b4ebd722139786303db80fdf302ea56"
-  integrity sha512-rRnjWu0Bxj+nIfUOkz0695C0H6tRrN5iYIzYejb0tDEefe2AekHu/U5Kn9pEie5vsJqpNQU02az7TGSH3qpz4Q==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-5.1.0.tgz#9786123f92ef3627f24abc3f15c20d98ec4a6594"
+  integrity sha512-Ek+QmMEqZF8XrbFdwoDjSbm7rT23pCgEMOJmz6GPk/s4yH//RQfNPArhIxbguNxROq/+5lNBwCDHMhA903Kx1Q==
   dependencies:
     lru-cache "^7.5.1"
 
@@ -9750,7 +9755,14 @@ send@0.18.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-serialize-error@^8.0.1, serialize-error@^8.1.0:
+serialize-error@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-11.0.0.tgz#0129f2b07b19b09bc7a5f2d850ffe9cd2d561582"
+  integrity sha512-YKrURWDqcT3VGX/s/pCwaWtpfJEEaEw5Y4gAnQDku92b/HjVj4r4UhA5QrMVMFotymK2wIWs5xthny5SMFu7Vw==
+  dependencies:
+    type-fest "^2.12.2"
+
+serialize-error@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-8.1.0.tgz#3a069970c712f78634942ddd50fbbc0eaebe2f67"
   integrity sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==
@@ -10757,6 +10769,11 @@ type-fest@^1.0.1, type-fest@^1.2.0, type-fest@^1.2.1, type-fest@^1.2.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
+
+type-fest@^2.12.2:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.18.0.tgz#fdef3a74e0a9e68ebe46054836650fb91ac3881e"
+  integrity sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==
 
 type-fest@^2.3.4:
   version "2.14.0"


### PR DESCRIPTION
#### Details

The shared package has pure ESM dependencies (get-port, serialize-error) which are not out-of-the-box compatible with Jest. This pull request: 

- enables `allowJs` in the tsconfig which will allow ts-jest to transform these modules. 
- sets `include` to the shared tsconfig to prevent extraneous js files from changing the compile file directory.
- removes the dependabot version pins for the dependencies and update them to their latest versions.

##### Motivation

Addresses #1000

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

An alternative approach is to use babel-jest to transform the ESM dependencies. This would require two new dependencies to maintain and making sure regenerator-runtime runs before Jest starts up. One benefit with this solution is that it doesn't modify the tsconfig. [Example branch.](https://github.com/microsoft/accessibility-insights-action/compare/main...katydecorah:accessibility-insights-action:jest-esm-babel?expand=1)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
