### PR TITLE
fix: Update emojis to use unicode for ADO

### DIFF
--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -47,7 +47,7 @@ describe(AdoConsoleCommentCreator, () => {
         pathStub = { join: (...paths) => paths.join('/'), basename: (filepath) => baselineFilenameStub } as typeof path;
 
         reportMarkdownConvertorMock
-            .setup((o) => o.convert(reportStub, false, undefined, baselineInfoStub))
+            .setup((o) => o.convert(reportStub, 'ADO', undefined, baselineInfoStub))
             .returns(() => reportMarkdownStub)
             .verifiable(Times.atMostOnce());
 
@@ -165,7 +165,7 @@ describe(AdoConsoleCommentCreator, () => {
                 const baselineInfoWithEvalStub = { baselineFileName: baselineFilenameStub, baselineEvaluation: baselineEvaluationStub };
 
                 reportMarkdownConvertorMock
-                    .setup((o) => o.convert(reportStub, false, undefined, baselineInfoWithEvalStub))
+                    .setup((o) => o.convert(reportStub, 'ADO', undefined, baselineInfoWithEvalStub))
                     .returns(() => reportMarkdownStub)
                     .verifiable(Times.atMostOnce());
 

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -47,7 +47,7 @@ describe(AdoConsoleCommentCreator, () => {
         pathStub = { join: (...paths) => paths.join('/'), basename: (filepath) => baselineFilenameStub } as typeof path;
 
         reportMarkdownConvertorMock
-            .setup((o) => o.convert(reportStub, undefined, baselineInfoStub))
+            .setup((o) => o.convert(reportStub, false, undefined, baselineInfoStub))
             .returns(() => reportMarkdownStub)
             .verifiable(Times.atMostOnce());
 
@@ -165,7 +165,7 @@ describe(AdoConsoleCommentCreator, () => {
                 const baselineInfoWithEvalStub = { baselineFileName: baselineFilenameStub, baselineEvaluation: baselineEvaluationStub };
 
                 reportMarkdownConvertorMock
-                    .setup((o) => o.convert(reportStub, undefined, baselineInfoWithEvalStub))
+                    .setup((o) => o.convert(reportStub, false, undefined, baselineInfoWithEvalStub))
                     .returns(() => reportMarkdownStub)
                     .verifiable(Times.atMostOnce());
 

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -59,7 +59,7 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
         combinedReportResult: CombinedReportParameters,
         baselineInfo?: BaselineInfo,
     ): void {
-        const reportMarkdown = this.reportMarkdownConvertor.convert(combinedReportResult, undefined, baselineInfo);
+        const reportMarkdown = this.reportMarkdownConvertor.convert(combinedReportResult, false, undefined, baselineInfo);
         const outDirectory = this.taskConfig.getReportOutDir();
 
         const summaryFilePath = this.pathObj.join(outDirectory, this.summaryMarkdownFileName(artifactName));

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -59,7 +59,7 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
         combinedReportResult: CombinedReportParameters,
         baselineInfo?: BaselineInfo,
     ): void {
-        const reportMarkdown = this.reportMarkdownConvertor.convert(combinedReportResult, false, undefined, baselineInfo);
+        const reportMarkdown = this.reportMarkdownConvertor.convert(combinedReportResult, 'ADO', undefined, baselineInfo);
         const outDirectory = this.taskConfig.getReportOutDir();
 
         const summaryFilePath = this.pathObj.join(outDirectory, this.summaryMarkdownFileName(artifactName));

--- a/packages/gh-action/src/job-summary/job-summary-creator.spec.ts
+++ b/packages/gh-action/src/job-summary/job-summary-creator.spec.ts
@@ -48,7 +48,7 @@ describe(JobSummaryCreator, () => {
     describe('completeRun', () => {
         it('converts to markdown and writes the job summary', async () => {
             reportMarkdownConvertorMock
-                .setup((a) => a.convert(combinedReportResult, true))
+                .setup((a) => a.convert(combinedReportResult, 'github'))
                 .returns(() => markdownContent)
                 .verifiable();
             taskConfigMock

--- a/packages/gh-action/src/job-summary/job-summary-creator.spec.ts
+++ b/packages/gh-action/src/job-summary/job-summary-creator.spec.ts
@@ -48,7 +48,7 @@ describe(JobSummaryCreator, () => {
     describe('completeRun', () => {
         it('converts to markdown and writes the job summary', async () => {
             reportMarkdownConvertorMock
-                .setup((a) => a.convert(combinedReportResult))
+                .setup((a) => a.convert(combinedReportResult, true))
                 .returns(() => markdownContent)
                 .verifiable();
             taskConfigMock

--- a/packages/gh-action/src/job-summary/job-summary-creator.ts
+++ b/packages/gh-action/src/job-summary/job-summary-creator.ts
@@ -24,7 +24,7 @@ export class JobSummaryCreator extends ProgressReporter {
     }
 
     public async completeRun(combinedReportResult: CombinedReportParameters): Promise<void> {
-        const reportMarkdown = this.reportMarkdownConvertor.convert(combinedReportResult, true);
+        const reportMarkdown = this.reportMarkdownConvertor.convert(combinedReportResult, 'github');
         return await this.taskConfig.writeJobSummary(reportMarkdown);
     }
 

--- a/packages/gh-action/src/job-summary/job-summary-creator.ts
+++ b/packages/gh-action/src/job-summary/job-summary-creator.ts
@@ -24,7 +24,7 @@ export class JobSummaryCreator extends ProgressReporter {
     }
 
     public async completeRun(combinedReportResult: CombinedReportParameters): Promise<void> {
-        const reportMarkdown = this.reportMarkdownConvertor.convert(combinedReportResult);
+        const reportMarkdown = this.reportMarkdownConvertor.convert(combinedReportResult, true);
         return await this.taskConfig.writeJobSummary(reportMarkdown);
     }
 

--- a/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
+++ b/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
@@ -43,10 +43,10 @@ You can review the log to troubleshoot the issue. Fix it and re-run the workflow
 exports[`ResultMarkdownBuilder uploadOutputArtifact is false skips artifact link line when artifactsUrl returns undefined 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
-**:white_check_mark: No failures detected**
+**✓ No failures detected**
 No failures were detected by automatic scanning.
 
-**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+**→ Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 ---
 #### Scan summary
@@ -60,10 +60,10 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 exports[`ResultMarkdownBuilder with baseline builds content when baseline failures and scanned failures are the same (no new failures) 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
-**:white_check_mark: No new failures**
+**✓ No new failures**
 No failures were detected by automatic scanning except those which exist in the baseline.
 
-**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+**→ Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **6 failure instances in baseline**
 (not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file))
@@ -148,10 +148,10 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and no additional failures 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
-**:white_check_mark: No new failures**
+**✓ No new failures**
 No failures were detected by automatic scanning except those which exist in the baseline.
 
-**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+**→ Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **1 failure instances in baseline**
 (not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file))
@@ -212,10 +212,10 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 exports[`ResultMarkdownBuilder with baseline builds content when there are no baseline failures and no new failures 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
-**:white_check_mark: No failures detected**
+**✓ No failures detected**
 No failures were detected by automatic scanning.
 
-**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+**→ Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 
 
@@ -233,10 +233,10 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and baseline failures are undefined 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
-**:white_check_mark: No failures detected**
+**✓ No failures detected**
 No failures were detected by automatic scanning.
 
-**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+**→ Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **Baseline not configured**
 A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
@@ -255,10 +255,10 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and no baseline detected 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
-**:white_check_mark: No failures detected**
+**✓ No failures detected**
 No failures were detected by automatic scanning.
 
-**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+**→ Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **Baseline not detected**
 To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.

--- a/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
+++ b/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ResultMarkdownBuilder builds content with failures 1`] = `
+exports[`ResultMarkdownBuilder builds content with failures, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 * **URLs**: 5 URL(s) failed, 1 URL(s) passed, and 7 were not scannable
 * **Rules**: 2 check(s) failed, 1 check(s) passed, and 2 were not applicable
@@ -13,7 +13,20 @@ exports[`ResultMarkdownBuilder builds content with failures 1`] = `
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder builds content with no failures 1`] = `
+exports[`ResultMarkdownBuilder builds content with failures, executionEnv: github 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
+* **URLs**: 5 URL(s) failed, 1 URL(s) passed, and 7 were not scannable
+* **Rules**: 2 check(s) failed, 1 check(s) passed, and 2 were not applicable
+* Download the **Accessibility Insights artifact** to view the detailed results of these checks
+#### Failed instances
+* **3 × rule id**:  rule description
+* **1 × rule id 2**:  rule description 2
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
+exports[`ResultMarkdownBuilder builds content with no failures, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights: All applicable checks passed
 * **URLs**: 1 URL(s) passed, and 7 were not scannable
 * **Rules**: 1 check(s) passed, and 2 were not applicable
@@ -22,7 +35,26 @@ exports[`ResultMarkdownBuilder builds content with no failures 1`] = `
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder builds content with title 1`] = `
+exports[`ResultMarkdownBuilder builds content with no failures, executionEnv: github 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights: All applicable checks passed
+* **URLs**: 1 URL(s) passed, and 7 were not scannable
+* **Rules**: 1 check(s) passed, and 2 were not applicable
+* Download the **Accessibility Insights artifact** to view the detailed results of these checks
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
+exports[`ResultMarkdownBuilder builds content with title, executionEnv: ADO 1`] = `
+"### some title
+### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights: All applicable checks passed
+* **URLs**: 1 URL(s) passed, and 7 were not scannable
+* **Rules**: 1 check(s) passed, and 2 were not applicable
+* Download the **Accessibility Insights artifact** to view the detailed results of these checks
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
+exports[`ResultMarkdownBuilder builds content with title, executionEnv: github 1`] = `
 "### some title
 ### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights: All applicable checks passed
 * **URLs**: 1 URL(s) passed, and 7 were not scannable
@@ -40,7 +72,7 @@ You can review the log to troubleshoot the issue. Fix it and re-run the workflow
 "
 `;
 
-exports[`ResultMarkdownBuilder uploadOutputArtifact is false skips artifact link line when artifactsUrl returns undefined 1`] = `
+exports[`ResultMarkdownBuilder uploadOutputArtifact is false skips artifact link line when artifactsUrl returns undefined, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **✓ No failures detected**
@@ -57,7 +89,24 @@ No failures were detected by automatic scanning.
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when baseline failures and scanned failures are the same (no new failures) 1`] = `
+exports[`ResultMarkdownBuilder uploadOutputArtifact is false skips artifact link line when artifactsUrl returns undefined, executionEnv: github 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
+
+**:white_check_mark: No failures detected**
+No failures were detected by automatic scanning.
+
+**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+
+---
+#### Scan summary
+**URLs**: 0 with failures, 1 passed, 7 not scannable
+**Rules**: 0 with failures, 1 passed, 2 not applicable
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
+exports[`ResultMarkdownBuilder with baseline builds content when baseline failures and scanned failures are the same (no new failures, executionEnv: ADO) 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **✓ No new failures**
@@ -79,7 +128,29 @@ See all failures and scan details by downloading the report from [run artifacts]
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when some baseline failures have been fixed and some new ones have been introduced 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when baseline failures and scanned failures are the same (no new failures, executionEnv: github) 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
+
+**:white_check_mark: No new failures**
+No failures were detected by automatic scanning except those which exist in the baseline.
+
+**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+
+**6 failure instances in baseline**
+(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file))
+
+See all failures and scan details by downloading the report from [run artifacts](artifacts-url)
+
+---
+#### Scan summary
+**URLs**: 5 with failures, 1 passed, 7 not scannable
+**Rules**: 2 with failures, 1 passed, 2 not applicable
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
+exports[`ResultMarkdownBuilder with baseline builds content when some baseline failures have been fixed and some new ones have been introduced, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 **3 failure instances from baseline no longer exist:**
 * (2) **rule id**
@@ -102,7 +173,30 @@ See all failures and scan details by downloading the report from [run artifacts]
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when some baseline failures have been fixed and some still occur 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when some baseline failures have been fixed and some new ones have been introduced, executionEnv: github 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
+**3 failure instances from baseline no longer exist:**
+* (2) **rule id**
+* (1) **rule id 2**
+
+**1 failure instances not in baseline**
+* (1) **rule id**:  rule description
+
+**9 failure instances in baseline**
+(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
+
+See all failures and scan details by downloading the report from [run artifacts](artifacts-url)
+
+---
+#### Scan summary
+**URLs**: 5 with failures, 1 passed, 7 not scannable
+**Rules**: 2 with failures, 1 passed, 2 not applicable
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
+exports[`ResultMarkdownBuilder with baseline builds content when some baseline failures have been fixed and some still occur, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 **3 failure instances from baseline no longer exist:**
 * (2) **rule id**
@@ -124,7 +218,29 @@ See all failures and scan details by downloading the report from [run artifacts]
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and new failures 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when some baseline failures have been fixed and some still occur, executionEnv: github 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
+**3 failure instances from baseline no longer exist:**
+* (2) **rule id**
+* (1) **rule id 2**
+
+**0 failure instances not in baseline**
+
+**9 failure instances in baseline**
+(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
+
+See all failures and scan details by downloading the report from [run artifacts](artifacts-url)
+
+---
+#### Scan summary
+**URLs**: 5 with failures, 1 passed, 7 not scannable
+**Rules**: 2 with failures, 1 passed, 2 not applicable
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
+exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and new failures, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **4 failure instances not in baseline**
@@ -145,7 +261,28 @@ See all failures and scan details by downloading the report from [run artifacts]
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and no additional failures 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and new failures, executionEnv: github 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
+
+**4 failure instances not in baseline**
+* (3) **rule id**:  rule description
+* (1) **rule id 2**:  rule description 2
+
+**2 failure instances in baseline**
+(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
+
+See all failures and scan details by downloading the report from [run artifacts](artifacts-url)
+
+---
+#### Scan summary
+**URLs**: 5 with failures, 1 passed, 7 not scannable
+**Rules**: 2 with failures, 1 passed, 2 not applicable
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
+exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and no additional failures, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **✓ No new failures**
@@ -167,7 +304,29 @@ See all failures and scan details by downloading the report from [run artifacts]
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are new failures and no baseline detected 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and no additional failures, executionEnv: github 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
+
+**:white_check_mark: No new failures**
+No failures were detected by automatic scanning except those which exist in the baseline.
+
+**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+
+**1 failure instances in baseline**
+(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file))
+
+See all failures and scan details by downloading the report from [run artifacts](artifacts-url)
+
+---
+#### Scan summary
+**URLs**: 0 with failures, 1 passed, 7 not scannable
+**Rules**: 0 with failures, 1 passed, 2 not applicable
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
+exports[`ResultMarkdownBuilder with baseline builds content when there are new failures and no baseline detected, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **6 failure instances**
@@ -188,7 +347,7 @@ See all failures and scan details by downloading the report from [run artifacts]
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are new failures and no baseline failures 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when there are new failures and no baseline detected, executionEnv: github 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **6 failure instances**
@@ -209,7 +368,49 @@ See all failures and scan details by downloading the report from [run artifacts]
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are no baseline failures and no new failures 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when there are new failures and no baseline failures, executionEnv: ADO 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
+
+**6 failure instances**
+* (5) **rule id**:  rule description
+* (1) **rule id 2**:  rule description 2
+
+**Baseline not detected**
+To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+
+See all failures and scan details by downloading the report from [run artifacts](artifacts-url)
+
+---
+#### Scan summary
+**URLs**: 5 with failures, 1 passed, 7 not scannable
+**Rules**: 2 with failures, 1 passed, 2 not applicable
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
+exports[`ResultMarkdownBuilder with baseline builds content when there are new failures and no baseline failures, executionEnv: github 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
+
+**6 failure instances**
+* (5) **rule id**:  rule description
+* (1) **rule id 2**:  rule description 2
+
+**Baseline not detected**
+To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+
+See all failures and scan details by downloading the report from [run artifacts](artifacts-url)
+
+---
+#### Scan summary
+**URLs**: 5 with failures, 1 passed, 7 not scannable
+**Rules**: 2 with failures, 1 passed, 2 not applicable
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
+exports[`ResultMarkdownBuilder with baseline builds content when there are no baseline failures and no new failures, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **✓ No failures detected**
@@ -230,7 +431,28 @@ See scan details by downloading the report from [run artifacts](artifacts-url)
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and baseline failures are undefined 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when there are no baseline failures and no new failures, executionEnv: github 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
+
+**:white_check_mark: No failures detected**
+No failures were detected by automatic scanning.
+
+**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+
+
+
+See scan details by downloading the report from [run artifacts](artifacts-url)
+
+---
+#### Scan summary
+**URLs**: 0 with failures, 1 passed, 7 not scannable
+**Rules**: 0 with failures, 1 passed, 2 not applicable
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
+exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and baseline failures are undefined, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **✓ No failures detected**
@@ -252,7 +474,29 @@ See scan details by downloading the report from [run artifacts](artifacts-url)
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and no baseline detected 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and baseline failures are undefined, executionEnv: github 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
+
+**:white_check_mark: No failures detected**
+No failures were detected by automatic scanning.
+
+**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+
+**Baseline not configured**
+A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+
+See scan details by downloading the report from [run artifacts](artifacts-url)
+
+---
+#### Scan summary
+**URLs**: 0 with failures, 1 passed, 7 not scannable
+**Rules**: 0 with failures, 1 passed, 2 not applicable
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
+exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and no baseline detected, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **✓ No failures detected**
@@ -274,7 +518,50 @@ See scan details by downloading the report from [run artifacts](artifacts-url)
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there is no baseline configured 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and no baseline detected, executionEnv: github 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
+
+**:white_check_mark: No failures detected**
+No failures were detected by automatic scanning.
+
+**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+
+**Baseline not detected**
+To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+
+See scan details by downloading the report from [run artifacts](artifacts-url)
+
+---
+#### Scan summary
+**URLs**: 0 with failures, 1 passed, 7 not scannable
+**Rules**: 0 with failures, 1 passed, 2 not applicable
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
+exports[`ResultMarkdownBuilder with baseline builds content when there is no baseline configured, executionEnv: ADO 1`] = `
+"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
+
+**6 failure instances**
+* (5) **rule id**:  rule description
+* (1) **rule id 2**:  rule description 2
+
+**Baseline not configured**
+A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+
+See all failures and scan details by downloading the report from [run artifacts](artifacts-url)
+
+---
+#### Scan summary
+**URLs**: 5 with failures, 1 passed, 7 not scannable
+**Rules**: 2 with failures, 1 passed, 2 not applicable
+
+---
+This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
+`;
+
+exports[`ResultMarkdownBuilder with baseline builds content when there is no baseline configured, executionEnv: github 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **6 failure instances**

--- a/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
+++ b/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
@@ -75,10 +75,10 @@ You can review the log to troubleshoot the issue. Fix it and re-run the workflow
 exports[`ResultMarkdownBuilder uploadOutputArtifact is false skips artifact link line when artifactsUrl returns undefined, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
-**✓ No failures detected**
+**✅ No failures detected**
 No failures were detected by automatic scanning.
 
-**→ Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+**👉 Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 ---
 #### Scan summary
@@ -109,10 +109,10 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 exports[`ResultMarkdownBuilder with baseline builds content when baseline failures and scanned failures are the same (no new failures, executionEnv: ADO) 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
-**✓ No new failures**
+**✅ No new failures**
 No failures were detected by automatic scanning except those which exist in the baseline.
 
-**→ Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+**👉 Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **6 failure instances in baseline**
 (not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file))
@@ -285,10 +285,10 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and no additional failures, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
-**✓ No new failures**
+**✅ No new failures**
 No failures were detected by automatic scanning except those which exist in the baseline.
 
-**→ Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+**👉 Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **1 failure instances in baseline**
 (not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file))
@@ -413,10 +413,10 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 exports[`ResultMarkdownBuilder with baseline builds content when there are no baseline failures and no new failures, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
-**✓ No failures detected**
+**✅ No failures detected**
 No failures were detected by automatic scanning.
 
-**→ Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+**👉 Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 
 
@@ -455,10 +455,10 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and baseline failures are undefined, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
-**✓ No failures detected**
+**✅ No failures detected**
 No failures were detected by automatic scanning.
 
-**→ Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+**👉 Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **Baseline not configured**
 A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
@@ -499,10 +499,10 @@ This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/relea
 exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and no baseline detected, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
-**✓ No failures detected**
+**✅ No failures detected**
 No failures were detected by automatic scanning.
 
-**→ Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
+**👉 Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **Baseline not detected**
 To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.

--- a/packages/shared/src/mark-down/report-markdown-convertor.spec.ts
+++ b/packages/shared/src/mark-down/report-markdown-convertor.spec.ts
@@ -37,16 +37,16 @@ describe(ReportMarkdownConvertor, () => {
 
     describe('convert', () => {
         it('report', () => {
-            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, false, undefined, undefined)).verifiable();
+            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, 'ADO', undefined, undefined)).verifiable();
 
-            reportMarkdownConvertor.convert(combinedReportResult, false);
+            reportMarkdownConvertor.convert(combinedReportResult, 'ADO');
         });
 
         it('report with title', () => {
             const title = 'some title';
-            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, false, title, undefined)).verifiable();
+            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, 'ADO', title, undefined)).verifiable();
 
-            reportMarkdownConvertor.convert(combinedReportResult, false, title);
+            reportMarkdownConvertor.convert(combinedReportResult, 'ADO', title);
         });
 
         it('report with baseline', () => {
@@ -54,9 +54,9 @@ describe(ReportMarkdownConvertor, () => {
                 baselineFileName: 'some filename',
                 baselineEvaluationStub: {} as BaselineEvaluation,
             };
-            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, false, undefined, baselineInfo)).verifiable();
+            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, 'ADO', undefined, baselineInfo)).verifiable();
 
-            reportMarkdownConvertor.convert(combinedReportResult, false, undefined, baselineInfo);
+            reportMarkdownConvertor.convert(combinedReportResult, 'ADO', undefined, baselineInfo);
         });
     });
 

--- a/packages/shared/src/mark-down/report-markdown-convertor.spec.ts
+++ b/packages/shared/src/mark-down/report-markdown-convertor.spec.ts
@@ -37,16 +37,16 @@ describe(ReportMarkdownConvertor, () => {
 
     describe('convert', () => {
         it('report', () => {
-            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, undefined, undefined)).verifiable();
+            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, false, undefined, undefined)).verifiable();
 
-            reportMarkdownConvertor.convert(combinedReportResult);
+            reportMarkdownConvertor.convert(combinedReportResult, false);
         });
 
         it('report with title', () => {
             const title = 'some title';
-            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, title, undefined)).verifiable();
+            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, false, title, undefined)).verifiable();
 
-            reportMarkdownConvertor.convert(combinedReportResult, title);
+            reportMarkdownConvertor.convert(combinedReportResult, false, title);
         });
 
         it('report with baseline', () => {
@@ -54,9 +54,9 @@ describe(ReportMarkdownConvertor, () => {
                 baselineFileName: 'some filename',
                 baselineEvaluationStub: {} as BaselineEvaluation,
             };
-            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, undefined, baselineInfo)).verifiable();
+            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, false, undefined, baselineInfo)).verifiable();
 
-            reportMarkdownConvertor.convert(combinedReportResult, undefined, baselineInfo);
+            reportMarkdownConvertor.convert(combinedReportResult, false, undefined, baselineInfo);
         });
     });
 

--- a/packages/shared/src/mark-down/report-markdown-convertor.spec.ts
+++ b/packages/shared/src/mark-down/report-markdown-convertor.spec.ts
@@ -37,7 +37,7 @@ describe(ReportMarkdownConvertor, () => {
     });
 
     describe('convert', () => {
-        it.each(['ADO', 'github'])(
+        it.each(executionEnvArray)(
             'should convert with baseline and title undefined and execution env %s',
             (executionEnv: ExecutionEnvironment) => {
                 resultMarkdownBuilderMock
@@ -48,7 +48,7 @@ describe(ReportMarkdownConvertor, () => {
             },
         );
 
-        it.each(['ADO', 'github'])(
+        it.each(executionEnvArray)(
             'should convert with baseline and title defined and execution env %s',
             (executionEnv: ExecutionEnvironment) => {
                 const title = 'some title';
@@ -58,7 +58,7 @@ describe(ReportMarkdownConvertor, () => {
             },
         );
 
-        it.each(['ADO', 'github'])('report with baseline, execution env %s', (executionEnv: ExecutionEnvironment) => {
+        it.each(executionEnvArray)('report with baseline, execution env %s', (executionEnv: ExecutionEnvironment) => {
             const baselineInfo = {
                 baselineFileName: 'some filename',
                 baselineEvaluationStub: {} as BaselineEvaluation,

--- a/packages/shared/src/mark-down/report-markdown-convertor.spec.ts
+++ b/packages/shared/src/mark-down/report-markdown-convertor.spec.ts
@@ -4,7 +4,7 @@ import 'reflect-metadata';
 
 import { IMock, Mock } from 'typemoq';
 import { ReportMarkdownConvertor } from './report-markdown-convertor';
-import { ResultMarkdownBuilder } from './result-markdown-builder';
+import { ExecutionEnvironment, ResultMarkdownBuilder } from './result-markdown-builder';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 import { BaselineEvaluation } from 'accessibility-insights-scan';
 
@@ -12,6 +12,7 @@ describe(ReportMarkdownConvertor, () => {
     let resultMarkdownBuilderMock: IMock<ResultMarkdownBuilder>;
     let reportMarkdownConvertor: ReportMarkdownConvertor;
     let combinedReportResult: CombinedReportParameters;
+    const executionEnvArray = ['ADO', 'github'];
 
     beforeEach(() => {
         resultMarkdownBuilderMock = Mock.ofType(ResultMarkdownBuilder);
@@ -36,27 +37,37 @@ describe(ReportMarkdownConvertor, () => {
     });
 
     describe('convert', () => {
-        it('report', () => {
-            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, 'ADO', undefined, undefined)).verifiable();
+        it.each(['ADO', 'github'])(
+            'should convert with baseline and title undefined and execution env %s',
+            (executionEnv: ExecutionEnvironment) => {
+                resultMarkdownBuilderMock
+                    .setup((o) => o.buildContent(combinedReportResult, executionEnv, undefined, undefined))
+                    .verifiable();
 
-            reportMarkdownConvertor.convert(combinedReportResult, 'ADO');
-        });
+                reportMarkdownConvertor.convert(combinedReportResult, executionEnv);
+            },
+        );
 
-        it('report with title', () => {
-            const title = 'some title';
-            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, 'ADO', title, undefined)).verifiable();
+        it.each(['ADO', 'github'])(
+            'should convert with baseline and title defined and execution env %s',
+            (executionEnv: ExecutionEnvironment) => {
+                const title = 'some title';
+                resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, executionEnv, title, undefined)).verifiable();
 
-            reportMarkdownConvertor.convert(combinedReportResult, 'ADO', title);
-        });
+                reportMarkdownConvertor.convert(combinedReportResult, executionEnv, title);
+            },
+        );
 
-        it('report with baseline', () => {
+        it.each(['ADO', 'github'])('report with baseline, execution env %s', (executionEnv: ExecutionEnvironment) => {
             const baselineInfo = {
                 baselineFileName: 'some filename',
                 baselineEvaluationStub: {} as BaselineEvaluation,
             };
-            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, 'ADO', undefined, baselineInfo)).verifiable();
+            resultMarkdownBuilderMock
+                .setup((o) => o.buildContent(combinedReportResult, executionEnv, undefined, baselineInfo))
+                .verifiable();
 
-            reportMarkdownConvertor.convert(combinedReportResult, 'ADO', undefined, baselineInfo);
+            reportMarkdownConvertor.convert(combinedReportResult, executionEnv, undefined, baselineInfo);
         });
     });
 

--- a/packages/shared/src/mark-down/report-markdown-convertor.ts
+++ b/packages/shared/src/mark-down/report-markdown-convertor.ts
@@ -10,8 +10,13 @@ import { BaselineInfo } from '../baseline-info';
 export class ReportMarkdownConvertor {
     constructor(@inject(ResultMarkdownBuilder) private readonly checkResultMarkdownBuilder: ResultMarkdownBuilder) {}
 
-    public convert(combinedReportResult: CombinedReportParameters, title?: string, baselineInfo?: BaselineInfo): string {
-        return this.checkResultMarkdownBuilder.buildContent(combinedReportResult, title, baselineInfo);
+    public convert(
+        combinedReportResult: CombinedReportParameters,
+        useGithubMarkdownEmoji: boolean,
+        title?: string,
+        baselineInfo?: BaselineInfo,
+    ): string {
+        return this.checkResultMarkdownBuilder.buildContent(combinedReportResult, useGithubMarkdownEmoji, title, baselineInfo);
     }
 
     public getErrorMarkdown(): string {

--- a/packages/shared/src/mark-down/report-markdown-convertor.ts
+++ b/packages/shared/src/mark-down/report-markdown-convertor.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import { ResultMarkdownBuilder } from './result-markdown-builder';
+import { ExecutionEnvironment, ResultMarkdownBuilder } from './result-markdown-builder';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 import { BaselineInfo } from '../baseline-info';
 
@@ -12,11 +12,11 @@ export class ReportMarkdownConvertor {
 
     public convert(
         combinedReportResult: CombinedReportParameters,
-        useGithubMarkdownEmoji: boolean,
+        executionEnvironment: ExecutionEnvironment,
         title?: string,
         baselineInfo?: BaselineInfo,
     ): string {
-        return this.checkResultMarkdownBuilder.buildContent(combinedReportResult, useGithubMarkdownEmoji, title, baselineInfo);
+        return this.checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnvironment, title, baselineInfo);
     }
 
     public getErrorMarkdown(): string {

--- a/packages/shared/src/mark-down/result-markdown-builder.spec.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.spec.ts
@@ -28,7 +28,7 @@ describe(ResultMarkdownBuilder, () => {
     it('builds content with failures', () => {
         setCombinedReportResultWithFailures();
 
-        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult);
+        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false);
 
         expect(actualContent).toMatchSnapshot();
     });
@@ -36,7 +36,7 @@ describe(ResultMarkdownBuilder, () => {
     it('builds content with no failures', () => {
         setCombinedReportResultWithNoFailures();
 
-        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult);
+        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false);
 
         expect(actualContent).toMatchSnapshot();
     });
@@ -66,7 +66,7 @@ describe(ResultMarkdownBuilder, () => {
             },
         } as CombinedReportParameters;
 
-        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult);
+        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false);
 
         const snapshotFile = path.join(__dirname, '__custom-snapshots__', 'axe-descriptions.snap.md');
         expect(actualContent).toMatchFile(snapshotFile);
@@ -76,7 +76,7 @@ describe(ResultMarkdownBuilder, () => {
         const title = 'some title';
         setCombinedReportResultWithNoFailures();
 
-        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, title);
+        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, title);
 
         expect(actualContent).toMatchSnapshot();
     });
@@ -104,7 +104,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -121,7 +121,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -141,7 +141,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -161,7 +161,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -178,7 +178,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithNoFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -194,7 +194,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithNoFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -212,7 +212,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -226,7 +226,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithNoFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -240,7 +240,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -255,7 +255,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -271,7 +271,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithNoFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -295,7 +295,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithNoFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();

--- a/packages/shared/src/mark-down/result-markdown-builder.spec.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.spec.ts
@@ -28,7 +28,7 @@ describe(ResultMarkdownBuilder, () => {
     it('builds content with failures', () => {
         setCombinedReportResultWithFailures();
 
-        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false);
+        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, 'ADO');
 
         expect(actualContent).toMatchSnapshot();
     });
@@ -36,7 +36,7 @@ describe(ResultMarkdownBuilder, () => {
     it('builds content with no failures', () => {
         setCombinedReportResultWithNoFailures();
 
-        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false);
+        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, 'ADO');
 
         expect(actualContent).toMatchSnapshot();
     });
@@ -66,7 +66,7 @@ describe(ResultMarkdownBuilder, () => {
             },
         } as CombinedReportParameters;
 
-        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false);
+        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, 'ADO');
 
         const snapshotFile = path.join(__dirname, '__custom-snapshots__', 'axe-descriptions.snap.md');
         expect(actualContent).toMatchFile(snapshotFile);
@@ -76,7 +76,7 @@ describe(ResultMarkdownBuilder, () => {
         const title = 'some title';
         setCombinedReportResultWithNoFailures();
 
-        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, title);
+        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, 'ADO', title);
 
         expect(actualContent).toMatchSnapshot();
     });
@@ -104,7 +104,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, 'ADO', undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -121,7 +121,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, 'ADO', undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -141,7 +141,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, 'ADO', undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -161,7 +161,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, 'ADO', undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -178,7 +178,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithNoFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, 'ADO', undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -194,7 +194,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithNoFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, 'ADO', undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -212,7 +212,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, 'ADO', undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -226,7 +226,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithNoFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, 'ADO', undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -240,7 +240,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, 'ADO', undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -255,7 +255,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, 'ADO', undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -271,7 +271,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithNoFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, 'ADO', undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();
@@ -295,7 +295,7 @@ describe(ResultMarkdownBuilder, () => {
             };
             setCombinedReportResultWithNoFailures();
 
-            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, false, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, 'ADO', undefined, baselineInfo);
 
             expect(actualContent).toMatchSnapshot();
             verifyAllMocks();

--- a/packages/shared/src/mark-down/result-markdown-builder.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.ts
@@ -228,8 +228,8 @@ export class ResultMarkdownBuilder {
     };
 
     private getNoFailuresText = (baselineEvaluation: BaselineEvaluation, executionEnvironment: ExecutionEnvironment): string[] => {
-        const checkMark = executionEnvironment == 'github' ? ':white_check_mark:' : '✓';
-        const pointRight = executionEnvironment == 'github' ? ':point_right:' : '→';
+        const checkMark = executionEnvironment == 'github' ? ':white_check_mark:' : '✅';
+        const pointRight = executionEnvironment == 'github' ? ':point_right:' : '👉';
         let failureDetailsHeading = `${checkMark} No failures detected`;
         let failureDetailsDescription = `No failures were detected by automatic scanning.`;
         if (this.baselineHasFailures(baselineEvaluation)) {

--- a/packages/shared/src/mark-down/result-markdown-builder.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.ts
@@ -25,7 +25,12 @@ export class ResultMarkdownBuilder {
         return this.scanResultDetails(lines.join(''));
     }
 
-    public buildContent(combinedReportResult: CombinedReportParameters, title?: string, baselineInfo?: BaselineInfo): string {
+    public buildContent(
+        combinedReportResult: CombinedReportParameters,
+        githubMarkdownEmoji: boolean,
+        title?: string,
+        baselineInfo?: BaselineInfo,
+    ): string {
         const passedChecks = combinedReportResult.results.resultsByRule.passed.length;
         const inapplicableChecks = combinedReportResult.results.resultsByRule.notApplicable.length;
         const failedChecks = combinedReportResult.results.resultsByRule.failed.length;
@@ -51,7 +56,7 @@ export class ResultMarkdownBuilder {
             lines = [
                 this.headingWithMessage(),
                 this.fixedFailureDetails(baselineInfo),
-                this.failureDetailsBaseline(combinedReportResult, baselineInfo),
+                this.failureDetailsBaseline(combinedReportResult, baselineInfo, githubMarkdownEmoji),
                 sectionSeparator(),
                 this.baselineDetails(baselineInfo),
                 this.downloadArtifactsWithLink(combinedReportResult, baselineInfo.baselineEvaluation),
@@ -199,7 +204,11 @@ export class ResultMarkdownBuilder {
         return lines.join('');
     };
 
-    private failureDetailsBaseline = (combinedReportResult: CombinedReportParameters, baselineInfo: BaselineInfo): string => {
+    private failureDetailsBaseline = (
+        combinedReportResult: CombinedReportParameters,
+        baselineInfo: BaselineInfo,
+        githubMarkdownEmoji: boolean,
+    ): string => {
         let lines = [];
         if (
             this.hasFailures(combinedReportResult, baselineInfo.baselineEvaluation) ||
@@ -210,15 +219,15 @@ export class ResultMarkdownBuilder {
             const failureInstancesHeading = this.getFailureInstancesHeading(failureInstances, baselineInfo.baselineEvaluation);
             lines = [sectionSeparator(), bold(failureInstancesHeading), sectionSeparator(), ...failedRulesList];
         } else {
-            lines = [sectionSeparator(), ...this.getNoFailuresText(baselineInfo.baselineEvaluation)];
+            lines = [sectionSeparator(), ...this.getNoFailuresText(baselineInfo.baselineEvaluation, githubMarkdownEmoji)];
         }
 
         return lines.join('');
     };
 
-    private getNoFailuresText = (baselineEvaluation: BaselineEvaluation): string[] => {
-        const checkMark = ':white_check_mark:';
-        const pointRight = ':point_right:';
+    private getNoFailuresText = (baselineEvaluation: BaselineEvaluation, githubMarkdownEmoji: boolean): string[] => {
+        const checkMark = githubMarkdownEmoji ? ':white_check_mark:' : '✓';
+        const pointRight = githubMarkdownEmoji ? ':point_right:' : '→';
         let failureDetailsHeading = `${checkMark} No failures detected`;
         let failureDetailsDescription = `No failures were detected by automatic scanning.`;
         if (this.baselineHasFailures(baselineEvaluation)) {

--- a/packages/shared/src/mark-down/result-markdown-builder.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.ts
@@ -10,6 +10,8 @@ import { brand } from '../content/strings';
 import { bold, escaped, footerSeparator, heading, link, listItem, productTitle, sectionSeparator } from './markdown-formatter';
 import { iocTypes } from '../ioc/ioc-types';
 
+export type ExecutionEnvironment = 'github' | 'ADO';
+
 @injectable()
 export class ResultMarkdownBuilder {
     constructor(@inject(iocTypes.ArtifactsInfoProvider) private readonly artifactsInfoProvider: ArtifactsInfoProvider) {}
@@ -27,7 +29,7 @@ export class ResultMarkdownBuilder {
 
     public buildContent(
         combinedReportResult: CombinedReportParameters,
-        githubMarkdownEmoji: boolean,
+        executionEnvironment: ExecutionEnvironment,
         title?: string,
         baselineInfo?: BaselineInfo,
     ): string {
@@ -56,7 +58,7 @@ export class ResultMarkdownBuilder {
             lines = [
                 this.headingWithMessage(),
                 this.fixedFailureDetails(baselineInfo),
-                this.failureDetailsBaseline(combinedReportResult, baselineInfo, githubMarkdownEmoji),
+                this.failureDetailsBaseline(combinedReportResult, baselineInfo, executionEnvironment),
                 sectionSeparator(),
                 this.baselineDetails(baselineInfo),
                 this.downloadArtifactsWithLink(combinedReportResult, baselineInfo.baselineEvaluation),
@@ -207,7 +209,7 @@ export class ResultMarkdownBuilder {
     private failureDetailsBaseline = (
         combinedReportResult: CombinedReportParameters,
         baselineInfo: BaselineInfo,
-        githubMarkdownEmoji: boolean,
+        executionEnvironment: ExecutionEnvironment,
     ): string => {
         let lines = [];
         if (
@@ -219,15 +221,15 @@ export class ResultMarkdownBuilder {
             const failureInstancesHeading = this.getFailureInstancesHeading(failureInstances, baselineInfo.baselineEvaluation);
             lines = [sectionSeparator(), bold(failureInstancesHeading), sectionSeparator(), ...failedRulesList];
         } else {
-            lines = [sectionSeparator(), ...this.getNoFailuresText(baselineInfo.baselineEvaluation, githubMarkdownEmoji)];
+            lines = [sectionSeparator(), ...this.getNoFailuresText(baselineInfo.baselineEvaluation, executionEnvironment)];
         }
 
         return lines.join('');
     };
 
-    private getNoFailuresText = (baselineEvaluation: BaselineEvaluation, githubMarkdownEmoji: boolean): string[] => {
-        const checkMark = githubMarkdownEmoji ? ':white_check_mark:' : '✓';
-        const pointRight = githubMarkdownEmoji ? ':point_right:' : '→';
+    private getNoFailuresText = (baselineEvaluation: BaselineEvaluation, executionEnvironment: ExecutionEnvironment): string[] => {
+        const checkMark = executionEnvironment == 'github' ? ':white_check_mark:' : '✓';
+        const pointRight = executionEnvironment == 'github' ? ':point_right:' : '→';
         let failureDetailsHeading = `${checkMark} No failures detected`;
         let failureDetailsDescription = `No failures were detected by automatic scanning.`;
         if (this.baselineHasFailures(baselineEvaluation)) {


### PR DESCRIPTION
#### Details

This changes the emojis included in markdown output to be unicode emojis on ADO.

Here is a test build output using the Unicode emojis in ADO: https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=36820&view=ms.vss-build-web.run-extensions-tab

##### Motivation

addresses issue #1263 

##### Context

I considered just changing to unicode emojis for both Github and ADO, but I decided to introduce a new `executionEnvironment` variable that allows us to output different emojis for ADO and GH. This will allow us to use the markdown emojis on GH once baselining is enabled on the action.

Currently this has no impact on the GH action, but does impact markdown output in the future if baselining is enabled.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes #1263
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
