### PR TITLE
chore: update ubuntu version to 20.04

### DIFF
--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -7,7 +7,7 @@ trigger: # trigger only affects CI builds
             - main
 
 variables:
-    linuxImage: 'ubuntu-18.04'
+    linuxImage: 'ubuntu-20.04'
     windowsImage: 'windows-2019'
 
 jobs:


### PR DESCRIPTION
#### Details

Update the ubuntu version to 20.04 to move off 18.04. I noticed the following warning:

> ##[warning]The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002

##### Motivation

Keep pipeline environments up to date.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
