### PR TITLE
fix: clarify hosting mode is only for classic pipelines in task.json

### DIFF
--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -35,7 +35,7 @@
                 "staticSite": "Static Site (this task runs a localhost webserver for your site)",
                 "dynamicSite": "Dynamic Site (you host your site separately)"
             },
-            "helpMarkDown": "Your site must be served (hosted) before it can be scanned. In _Static Site_ mode, this task will run a localhost webserver serving your site directory and scan that. In _Dynamic Site_ mode, you must host your site yourself separately and specify a URL to scan. This can be either a localhost server you run in an earlier pipeline step, or a remote URL (for example, a staging environment)."
+            "helpMarkDown": "Note: not required in YAML configuration, only on classic pipelines UI. Your site must be served (hosted) before it can be scanned. In _Static Site_ mode, this task will run a localhost webserver serving your site directory and scan that. In _Dynamic Site_ mode, you must host your site yourself separately and specify a URL to scan. This can be either a localhost server you run in an earlier pipeline step, or a remote URL (for example, a staging environment)."
         },
         {
             "name": "staticSiteDir",


### PR DESCRIPTION
#### Details

This adds a note to the `helpMarkDown` in the `task.json` file for the ado extension clarifying that the `hostingMode` input is not required in YAML pipelines. 

##### Motivation

There have been several people that have gotten confused by the `hostingMode` input because it says `required:true`, but it is dynamically set in YAML pipelines.

##### Context

This does not impact the GH Action in any way

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
