### PR TITLE
chore: Update notice task in build.yaml

### DIFF
--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -119,7 +119,7 @@ jobs:
             inputs:
                 ignoreDirectories: 'drop,dist,extension,node_modules'
 
-          - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
+          - task: notice@0
             displayName: 'generate NOTICE.html file'
             inputs:
                 outputfile: '$(System.DefaultWorkingDirectory)/NOTICE.html'


### PR DESCRIPTION
#### Details

When running the build pipeline on another pull request, I kept receiving errors from the notice task (I reran several times):

> ##[error]failed to call notice file generator API
> ##[error]Generation failed. Please see https://aka.ms/noticedebugging for more information.

I used this PR to test using `notice@0` as the task and it built happily (perhaps we were using an earlier version of the notice task?). I compared the result of the notice task with previous builds, and they appear identical.

Link to passing build: https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=37108&view=logs&j=2fc8553a-ee64-55e8-f1a5-e49773d59327&t=01317d73-dbeb-57db-220f-419f852ef1a3

##### Motivation

Prevent errors in build pipeline.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
- [n/a] Described how this PR impacts both the ADO extension and the GitHub action
