### PR TITLE
fix: Surface error messages properly from the scanner

### DIFF
--- a/packages/shared/src/scanner/scanner.spec.ts
+++ b/packages/shared/src/scanner/scanner.spec.ts
@@ -228,7 +228,7 @@ describe(Scanner, () => {
             setupWaitForPromiseToReturnOriginalPromise();
 
             // Check that logger is called the expected amount of times and that exceptions are tracked
-            loggerMock.setup((lm) => lm.logInfo(`Scan failed with ${combinedScanResult.errors.length} error(s)`)).verifiable(Times.once());
+            loggerMock.setup((lm) => lm.logError(`Scan failed with ${combinedScanResult.errors.length} error(s)`)).verifiable(Times.once());
 
             loggerMock
                 .setup((lm) => lm.trackExceptionAny(It.isAny(), It.isAnyString()))

--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -96,7 +96,7 @@ export class Scanner {
             const combinedScanResult = await this.crawler.crawl(crawlerParameters, this.baselineOptionsBuilder.build(scanArguments));
 
             if (!isEmpty(combinedScanResult.errors)) {
-                this.logger.logInfo(`Scan failed with ${combinedScanResult.errors.length} error(s)`);
+                this.logger.logError(`Scan failed with ${combinedScanResult.errors.length} error(s)`);
                 combinedScanResult.errors.forEach((error) => {
                     this.logAndTrackScanningException(error.error, error.url);
                 });
@@ -154,7 +154,7 @@ export class Scanner {
         }
     }
 
-    private logAndTrackScanningException(error, url: string): void {
+    private logAndTrackScanningException(error: unknown, url: string): void {
         this.logger.trackExceptionAny(error, `An error occurred while scanning website page: ${url}`);
     }
 }

--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -154,7 +154,7 @@ export class Scanner {
         }
     }
 
-    private logAndTrackScanningException(error: string, url: string): void {
+    private logAndTrackScanningException(error, url: string): void {
         this.logger.trackExceptionAny(error, `An error occurred while scanning website page: ${url}`);
     }
 }


### PR DESCRIPTION
#### Details

This fixes an issue causing misleading error messages to appear when configuration issues or other errors cause the accessibility-insights-scan package to return an error.

When an error is surfaced from the scan package it returns it in `CombinedScanResults.errors` with empty `CombinedReportParameters`. We were previously not handling this scenario, so when the next step of the code was attempting to get the `baseUrl` from the `CombinedReportParameters`, it would fail and throw an ambiguous error message about the `baseUrl` that had nothing to do with the actual error.

This adds a check for the `CombinedScanResults.errors` array to ensure it's empty, and if it isn't it surfaces any errors returned in the array and fails the run.

This issue was occuring in the `shared` package that is consumed by both the ADO Extension and the GH Action, so this will remedy the issue in both products.

Previous error message example when a navigation error had occurred:
```text
##[error][Exception]ErrorWithCause: An error occurred while scanning website page https://test-site
    at Logger.trackExceptionAny (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/index.js:189142:29)
    at Scanner.<anonymous> (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/index.js:190329:29)
    at Generator.next (<anonymous>)
    at fulfilled (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/index.js:190244:58)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
caused by: TypeError: Cannot read properties of undefined (reading 'baseUrl')
    at Scanner.getCombinedReportParameters (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/index.js:190343:60)
    at Scanner.<anonymous> (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/index.js:190321:55)
    at Generator.next (<anonymous>)
    at fulfilled (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/index.js:190244:58)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

New error message example when a navigation error has occurred:
```text
Scan failed with 1 error(s)
##[error][Exception]ErrorWithCause: An error occurred while scanning website page: https://test-site
    at Logger.trackExceptionAny (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/index.js:189142:29)
    at Scanner.logAndTrackScanningException (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/index.js:190373:21)
    at /home/brock/projects/ai-action/packages/ado-extension/dist/pkg/index.js:190323:30
    at Array.forEach (<anonymous>)
    at Scanner.<anonymous> (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/index.js:190322:47)
    at Generator.next (<anonymous>)
    at fulfilled (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/index.js:190244:58)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
caused by: Error: '{"errorType":"NavigationError","message":"Unable to get a page response from the browser.","stack":"Error\\n    at PageNavigationHooks.postNavigation (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/node_modules/accessibility-insights-scan/dist/index.js:6551:24)\\n    at PageProcessorBase.postNavigation (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/node_modules/accessibility-insights-scan/dist/index.js:4306:48)\\n    at PuppeteerCrawler._executeHooks (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/node_modules/apify/build/crawlers/basic_crawler.js:592:23)\\n    at PuppeteerCrawler._handleNavigation (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/node_modules/apify/build/crawlers/browser_crawler.js:405:20)\\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\\n    at async PuppeteerCrawler._handleRequestFunction (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/node_modules/apify/build/crawlers/browser_crawler.js:343:13)\\n    at async wrap (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/node_modules/@apify/timeout/index.js:73:27)"}'
    at Logger.trackExceptionAny (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/index.js:189141:94)
    at Scanner.logAndTrackScanningException (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/index.js:190373:21)
    at /home/brock/projects/ai-action/packages/ado-extension/dist/pkg/index.js:190323:30
    at Array.forEach (<anonymous>)
    at Scanner.<anonymous> (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/index.js:190322:47)
    at Generator.next (<anonymous>)
    at fulfilled (/home/brock/projects/ai-action/packages/ado-extension/dist/pkg/index.js:190244:58)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

##### Motivation

Addresses issue #1315

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes #1315
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
