### PR TITLE
chore: Add `retryCountOnTaskFailure` to notice task

### DIFF
--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -121,6 +121,7 @@ jobs:
 
           - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
             displayName: 'generate NOTICE.html file'
+            retryCountOnTaskFailure: 3
             inputs:
                 outputfile: '$(System.DefaultWorkingDirectory)/NOTICE.html'
                 outputformat: html


### PR DESCRIPTION
#### Details

There are reliability issues with the notice file generator API which can require you to rerun failed jobs. After reaching out to the support team for this service, they recommended setting a retry on the task: https://learn.microsoft.com/en-us/azure/devops/release-notes/2021/sprint-195-update#automatic-retries-for-a-task. This PR will ask the task to retry 3 times before failing. 

##### Motivation

Improve contributor experience.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
