### PR TITLE
fix: Add empty option for authType

### DIFF
--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -91,7 +91,7 @@
             "required": false,
             "defaultValue": "",
             "options": {
-                "": "",
+                "": "None",
                 "AAD": "Azure Active Directory"
             },
             "helpMarkDown": "Use with serviceAccountName and serviceAccountPassword to specify the authentication type."

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -89,7 +89,9 @@
             "type": "pickList",
             "label": "Authentication type",
             "required": false,
+            "defaultValue": "",
             "options": {
+                "": "",
                 "AAD": "Azure Active Directory"
             },
             "helpMarkDown": "Use with serviceAccountName and serviceAccountPassword to specify the authentication type."


### PR DESCRIPTION
#### Details

Adds an empty option for authType in the ADO extension's task.json. This will fix an issue where classic pipeline users saw an invalid option error for the field.

This change does not impact the GitHub action.

##### Motivation

Address issue #1357 

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

I pushed this branch to a staging task and was able to verify the expected behavior.

In the screenshot below. I am able to bypass the Authentication type error as the dropdown automatically selects the empty value. The YAML shows that `authType` is not set. I am able to save and queue the pipeline:

![](https://user-images.githubusercontent.com/2180540/198067905-a9c65295-3b3c-4697-af46-ea6d855de93c.png)

In the screenshot below, I am able to add an auth type and (fake) service account name and password. The YAML shows that `authType`, `serviceAccountName`, and `serviceAccountPassword` are set as expected.  I am able to save and queue the pipeline:

![](https://user-images.githubusercontent.com/2180540/198068672-705fc12b-ee02-4de9-a1cc-9966bf101a83.png)



<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes #1357 
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
