### PR TITLE
fix: browser resolution set by ai-scan is 800x600

### DIFF
--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -200,4 +200,4 @@ Here are some example pipelines with various configuration scenarios:
 -   If the action didn't trigger as you expected, check the `trigger` or `pr` sections of your yml file. Make sure any listed branch names are correct for your repository.
 -   If the action fails to complete, you can check the build logs for execution errors. Using the template above, these logs will be in the `Scan for accessibility issues` step.
 -   If the scan takes longer than 90 seconds, you can override the default timeout by providing a value for `scanTimeout` in milliseconds.
--   The default viewport that the action uses is `800x600`.
+-   The default viewport that the action uses has a width of 800px and a height of 600px.

--- a/docs/ado-extension-usage.md
+++ b/docs/ado-extension-usage.md
@@ -200,3 +200,4 @@ Here are some example pipelines with various configuration scenarios:
 -   If the action didn't trigger as you expected, check the `trigger` or `pr` sections of your yml file. Make sure any listed branch names are correct for your repository.
 -   If the action fails to complete, you can check the build logs for execution errors. Using the template above, these logs will be in the `Scan for accessibility issues` step.
 -   If the scan takes longer than 90 seconds, you can override the default timeout by providing a value for `scanTimeout` in milliseconds.
+-   The default viewport that the action uses is `800x600`.

--- a/docs/gh-action-usage.md
+++ b/docs/gh-action-usage.md
@@ -169,4 +169,4 @@ Version 3.x of the action contains several breaking changes from version 2.x. To
 -   If the action fails to complete, you can check the build logs for execution errors. Using the template above, these logs will be in the `Scan for accessibility issues` step.
 -   If you can't find an artifact, note that your workflow must include an `actions/upload-artifact` step to add the report folder to your check results. See the "Basic template" above.
 -   If the scan takes longer than 90 seconds, you can override the default timeout by providing a value for `scan-timeout` in milliseconds.
--   The default viewport that the action uses is `800x600`.
+-   The default viewport that the action uses has a width of 800px and a height of 600px.

--- a/docs/gh-action-usage.md
+++ b/docs/gh-action-usage.md
@@ -169,3 +169,4 @@ Version 3.x of the action contains several breaking changes from version 2.x. To
 -   If the action fails to complete, you can check the build logs for execution errors. Using the template above, these logs will be in the `Scan for accessibility issues` step.
 -   If you can't find an artifact, note that your workflow must include an `actions/upload-artifact` step to add the report folder to your check results. See the "Basic template" above.
 -   If the scan takes longer than 90 seconds, you can override the default timeout by providing a value for `scan-timeout` in milliseconds.
+-   The default viewport that the action uses is `800x600`.

--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -138,7 +138,7 @@ export class Scanner {
             urlCount: combinedScanResult.urlCount,
             scanStarted,
             scanEnded,
-            browserResolution: '1920x1080', // resoluton is fixed by crawler implementation
+            browserResolution: '800x600', // resolution is fixed by crawler implementation
         };
 
         return this.combinedReportDataConverter.convertCrawlingResults(combinedScanResult.combinedAxeResults, scanResultData);


### PR DESCRIPTION
#### Details

The browser resolution set by ai-scan is 800x600, this pull request updates the set `scanResultData.browserResolution` to match. This value is printed at the bottom of reports. This pull request will also add a bullet point to each usage document to specify the viewport size.

![The screenshot is the footnote shown at the bottom of AI scans. It reads "with a display resolution of 1920x1080" when it should say "with a display resolution of 800x600"](https://user-images.githubusercontent.com/2180540/199054241-1b93501c-a418-44b3-9e58-08e50fadcfd3.png)



##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

Is there a way to pull this from the ai-scan to prevent future mismatches? It doesn't look likely. This is something we should consider if we decide to create viewport inputs.


<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
