### PR TITLE
chore: Adding new telemetry entry point for baseline issues count

### DIFF
--- a/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.spec.ts
@@ -123,7 +123,7 @@ describe(TelemetrySender, () => {
             if (generateWithBaselineEnabled) {
                 eventProperties.baselineFailuresFixed = baselineFailuresFixed;
                 eventProperties.baselineNewFailures = baselineNewFailures;
-                eventProperties.baselineTotalNewViolations = baselineViolations;
+                eventProperties.baselineFailuresCount = baselineViolations;
             }
 
             telemetryClientMock

--- a/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.spec.ts
@@ -116,7 +116,7 @@ describe(TelemetrySender, () => {
 
             eventProperties.rulesFailedListWithCounts = [
                 { ruleId: 'failed-rule-1', failureCount: 4 },
-                { ruleId: 'failed-rule-2', failureCount: 4 }, 
+                { ruleId: 'failed-rule-2', failureCount: 4 },
             ];
 
             eventProperties.baselineIsEnabled = generateWithBaselineEnabled;

--- a/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.spec.ts
@@ -15,6 +15,7 @@ describe(TelemetrySender, () => {
     let telemetrySender: TelemetrySender;
     const baselineFailuresFixed = 3;
     const baselineNewFailures = 1;
+    const baselineViolations = 2;
 
     beforeEach(() => {
         adoTaskConfigMock = Mock.ofType<ADOTaskConfig>(undefined, MockBehavior.Strict);
@@ -33,6 +34,7 @@ describe(TelemetrySender, () => {
             const baselineEvaluationStub = {
                 totalNewViolations: baselineNewFailures,
                 totalFixedViolations: baselineFailuresFixed,
+                totalBaselineViolations: baselineViolations,
             } as BaselineEvaluation;
             const telemetrySender = buildTelemetrySenderWithMocks();
             setupTelemetryClientWithEvent(true);
@@ -114,13 +116,14 @@ describe(TelemetrySender, () => {
 
             eventProperties.rulesFailedListWithCounts = [
                 { ruleId: 'failed-rule-1', failureCount: 4 },
-                { ruleId: 'failed-rule-2', failureCount: 4 },
+                { ruleId: 'failed-rule-2', failureCount: 4 }, 
             ];
 
             eventProperties.baselineIsEnabled = generateWithBaselineEnabled;
             if (generateWithBaselineEnabled) {
                 eventProperties.baselineFailuresFixed = baselineFailuresFixed;
                 eventProperties.baselineNewFailures = baselineNewFailures;
+                eventProperties.baselineTotalNewViolations = baselineViolations;
             }
 
             telemetryClientMock

--- a/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.ts
+++ b/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.ts
@@ -40,7 +40,7 @@ export class TelemetrySender extends ProgressReporter {
             eventProperties.baselineIsEnabled = true;
             eventProperties.baselineFailuresFixed = baselineEvaluation.totalFixedViolations;
             eventProperties.baselineNewFailures = baselineEvaluation.totalNewViolations;
-            eventProperties.baselineTotalNewViolations = baselineEvaluation.totalNewViolations;
+            eventProperties.baselineTotalNewViolations = baselineEvaluation.totalBaselineViolations;
         }
 
         this.telemetryClient.trackEvent({

--- a/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.ts
+++ b/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.ts
@@ -40,7 +40,7 @@ export class TelemetrySender extends ProgressReporter {
             eventProperties.baselineIsEnabled = true;
             eventProperties.baselineFailuresFixed = baselineEvaluation.totalFixedViolations;
             eventProperties.baselineNewFailures = baselineEvaluation.totalNewViolations;
-            eventProperties.baselineTotalNewViolations = baselineEvaluation.totalBaselineViolations;
+            eventProperties.baselineFailuresCount = baselineEvaluation.totalBaselineViolations;
         }
 
         this.telemetryClient.trackEvent({

--- a/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.ts
+++ b/packages/ado-extension/src/progress-reporter/telemetry/telemetry-sender.ts
@@ -40,6 +40,7 @@ export class TelemetrySender extends ProgressReporter {
             eventProperties.baselineIsEnabled = true;
             eventProperties.baselineFailuresFixed = baselineEvaluation.totalFixedViolations;
             eventProperties.baselineNewFailures = baselineEvaluation.totalNewViolations;
+            eventProperties.baselineTotalNewViolations = baselineEvaluation.totalNewViolations;
         }
 
         this.telemetryClient.trackEvent({


### PR DESCRIPTION
#### Details

This PR adds a new telemetry entry point to count the number of issues found in a baseline file.

##### Motivation

This will help us understand if users are fixing issues over baseline, introducing new ones, or updating baseline files.

##### Context

This change will affect exclusively ADO Extension side.
Right now we don't have a sure way of knowing what was the initial state of a baseline file, this PR will help us understand how many issues were found in the baseline file and will bright us more insights to determine if baseline was modified over a period of time.
I tested locally using dev telemetry and everything looks right, the new entry point now shows in the telemetry reports.

<img width="176" alt="image" src="https://user-images.githubusercontent.com/32908302/199128623-66ef58ea-997c-49d8-913f-38d3261ea60c.png">
(Image showing the number of baseline failures in test results)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
