### PR TITLE
chore: add release change log generation tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^2.7.1",
         "rimraf": "^3.0.2",
+        "simple-git": "^3.14.1",
         "ts-jest": "^29.0.3",
         "ts-loader": "^9.4.1",
         "typemoq": "^2.1.0",

--- a/tools/get-change-log-for-release.js
+++ b/tools/get-change-log-for-release.js
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+const fs = require('fs');
+const path = require('path');
+const commander = require('commander');
+const simpleGit = require('simple-git');
+
+const main = async () => {
+    const params = parseCommandLineArguments();
+
+    validateCommandLineArguments(params);
+
+    const gitLogs = await getGitLogs(params.from, params.to);
+
+    const outputContent = generateOutputContent(gitLogs, params.to);
+
+    ensureOutputFileExist(params.output);
+
+    fs.writeFileSync(params.output, outputContent);
+};
+
+const getGitLogs = async (from, to) => {
+    const git = simpleGit();
+
+    const gitLogs = await git.log({ from, to });
+
+    return gitLogs;
+};
+
+const getCommitType = (commitMessage) => {
+    const separator = ':';
+    const separatorIndex = commitMessage.indexOf(separator);
+
+    if (separatorIndex === -1) {
+        return 'NONE';
+    }
+
+    return commitMessage.substr(0, separatorIndex).trim();
+};
+
+const ensureOutputFileExist = (outputPath) => {
+    const dir = path.dirname(outputPath);
+
+    fs.mkdirSync(dir, {
+        recursive: true,
+    });
+};
+
+const csvEscape = (original) => {
+    return original.replace(/"/g, '""');
+};
+
+// Best-effort; returns empty string if PR number wasn't detected at end of message
+const extractPrNumber = (original) => {
+    // Handles messages of format "some text (#123)", extracting 123 as "prNumber"
+    const matches = /\(#(?<prNumber>\d+)\)$/.exec(original);
+    return matches == null ? '' : matches.groups.prNumber;
+};
+
+const makePrLink = (pr) => {
+    if (pr === '') {
+        return pr;
+    }
+
+    return `=HYPERLINK("https://github.com/microsoft/accessibility-insights-action/pull/${pr}", "#${pr}")`;
+};
+
+const makeCommitLink = (commit) => {
+    return `=HYPERLINK("https://github.com/microsoft/accessibility-insights-action/commit/${commit}", "${commit}")`;
+};
+
+const generateOutputContent = (gitLogs, version) => {
+    const csvLogs = gitLogs.all
+        .map((log) => {
+            return {
+                dev: csvEscape(log.author_name),
+                commit: csvEscape(makeCommitLink(log.hash.substr(0, 7))),
+                pr: csvEscape(makePrLink(extractPrNumber(log.message))),
+                change: csvEscape(log.message),
+                group: csvEscape(getCommitType(log.message)),
+                version,
+                date: log.date,
+            };
+        })
+        .map((log) => {
+            // the order here is important, it needs to match the headers order down below
+            return `,,"${log.dev}","${log.commit}","${log.pr}","${log.change}","${log.group}","${log.version}","${log.date}"`;
+        });
+
+    // prettier-ignore
+    const headers = ['tester', 'verified', 'dev', 'commit', 'pr', 'change', 'group', 'version', 'date'];
+
+    const headersContent = headers.join(',');
+    return `${headersContent}\n`.concat(csvLogs.join('\n'));
+};
+
+const parseCommandLineArguments = () => {
+    const program = new commander.Command();
+
+    program
+        .requiredOption('-f, --from <commit_hash or tag>', 'Starting point to get the logs. Required.')
+        .requiredOption('-t, --to <commit_hash or tag>', 'Ending point to get the logs. Required.')
+        .option('-o, --output <output_path>', 'Path to the output file. Default: change-log.<from>-<to>.csv')
+        .parse(process.argv);
+
+    return program.opts();
+};
+
+const validateCommandLineArguments = (program) => {
+    const errors = [];
+
+    if (!program.from) {
+        errors.push('Missing param: from');
+    }
+
+    if (!program.to) {
+        errors.push('Missing param: to');
+    }
+
+    if (!program.output) {
+        program.output = `change-log.${program.from}-${program.to}.csv`;
+    }
+
+    if (errors.length !== 0) {
+        errors.forEach((error) => console.error(error));
+        process.exit(1);
+    }
+};
+
+main().catch(console.error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1180,6 +1180,18 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@kwsites/file-exists@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/file-exists/-/file-exists-1.1.1.tgz#ad1efcac13e1987d8dbaf235ef3be5b0d96faa99"
+  integrity sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==
+  dependencies:
+    debug "^4.1.1"
+
+"@kwsites/promise-deferred@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
+  integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
+
 "@lerna/add@6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-6.0.1.tgz#6d71084fe7918c96c909bebdc5c27ed6006e09d6"
@@ -9980,6 +9992,15 @@ simple-get@^3.0.3:
     decompress-response "^4.2.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
+
+simple-git@^3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.14.1.tgz#68018a5f168f8a568862e30b692004b37c3b5ced"
+  integrity sha512-1ThF4PamK9wBORVGMK9HK5si4zoGS2GpRO7tkAFObA4FZv6dKaCVHLQT+8zlgiBm6K2h+wEU9yOaFCu/SR3OyA==
+  dependencies:
+    "@kwsites/file-exists" "^1.1.1"
+    "@kwsites/promise-deferred" "^1.1.1"
+    debug "^4.3.4"
 
 sisteransi@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
#### Details

This adds a script to generate a changelog during release. This copies from the optional script we have for Accessibility Insights for Web releases.

It auto-generates the tester, verified, dev, commit, pr, change description, group, version, and date columns for all the changes between the current release and the previous.

To run it, in the root of the action repo you run the following command, for this example I'm using the previous two release tags:
`node ./tools/get-change-log-for-release.js --from v3.1.0 --to v3.1.1 `

This is the resulting file from that command:
[change-log.v3.1.0-v3.1.1.csv](https://github.com/microsoft/accessibility-insights-action/files/9933118/change-log.v3.1.0-v3.1.1.csv)

Once the table is generated and filtered, it looks like this (an example of what the previous release's table would have looked like):
![image](https://user-images.githubusercontent.com/13286385/199837391-68264996-e358-4d8b-97a1-5485fef626b8.png)

##### Motivation

Additional tooling to simplify the release process

##### Context

This will work the same for both the GH action and the ADO Extension.

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action

