### PR TITLE
fix: remove ending period in helpMarkdown to fix link path rendered in pipeline

### DIFF
--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -4,7 +4,7 @@
     "name": "accessibility-insights",
     "friendlyName": "Accessibility Insights Azure DevOps Task",
     "description": "Scan for accessibility issues in an Azure DevOps pipeline",
-    "helpMarkDown": "Learn [how to add Accessibility Insights Azure DevOps Task](https://aka.ms/ado-extension-usage) to your pipeline. For authenticated sites, learn [how to setup authentication](https://aka.ms/AI-action-auth).",
+    "helpMarkDown": "Learn [how to add Accessibility Insights Azure DevOps Task](https://aka.ms/ado-extension-usage) to your pipeline. For authenticated sites, learn [how to setup authentication](https://aka.ms/AI-action-auth)",
     "category": "Test",
     "author": "Accessibility Insights",
     "version": {


### PR DESCRIPTION
#### Details

In #1371 we added documentation links to the pipeline. I noticed that the trailing period in `helpMarkdown` caused the last URL to become malformed (link text: "how to setup authentication"). This PR will remove the period. 

I pushed this branch to a staging extension. You can validate the working links on line 7 in the following build: https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=39206&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=7384d774-f7ca-599c-ee57-ab2c05be9247&l=7

This change only impact the extension.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
