### PR TITLE
fix: Add back defaultValue for staticSiteUrlRelativePath

### DIFF
--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -50,6 +50,7 @@
             "type": "string",
             "label": "Hosting mode: base URL",
             "required": false,
+            "defaultValue": "/",
             "helpMarkDown": "Set the base URL when the site lives at a subpath of the domain, such as `/blog`. If unspecified, the site will be scanned at the root.",
             "visibleRule": "hostingMode = staticSite"
         },


### PR DESCRIPTION
#### Details

This PR will add back the `defaultValue` for `staticSiteUrlRelativePath` which had been removed in #1371.

While working on release validation, I noticed that the static site tests were failing when they should not with:

```
##[error][Exception]ErrorWithCause: An error occurred while scanning website page: undefined
    at Logger.trackExceptionAny (/home/vsts/work/_tasks/accessibility-insights_aebf5565-d905-5999-8faf-a44d4db6c0fa/3.0.5/index.js:189373:29)
    at Scanner.logAndTrackScanningException (/home/vsts/work/_tasks/accessibility-insights_aebf5565-d905-5999-8faf-a44d4db6c0fa/3.0.5/index.js:190604:21)
    at Scanner.<anonymous> (/home/vsts/work/_tasks/accessibility-insights_aebf5565-d905-5999-8faf-a44d4db6c0fa/3.0.5/index.js:190568:22)
    at Generator.next (<anonymous>)
    at fulfilled (/home/vsts/work/_tasks/accessibility-insights_aebf5565-d905-5999-8faf-a44d4db6c0fa/3.0.5/index.js:190475:58)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
caused by: TypeError [ERR_INVALID_ARG_TYPE]: The "url" argument must be of type string. Received undefined
```

Link to build: https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=39235&view=logs&j=6b902995-b73d-5f5c-66fd-a7f66c857d2c&t=aa6fd78e-e64f-5a5a-8f2d-c22add004dd5

This PR only impacts the ADO extension.

##### Motivation

Unblock release, fix regression.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
