### PR TITLE
fix: Fix expected output for e2e test

### DIFF
--- a/packages/ado-extension/e2e/ado-extension.test.ts
+++ b/packages/ado-extension/e2e/ado-extension.test.ts
@@ -21,7 +21,7 @@ describe('Sample task tests', () => {
                 'Accessibility scanning of URL https://www.washington.edu/accesscomputing/AU/before.html completed',
             ),
         ).toBeTruthy();
-        expect(testSubject.stdOutContained('Rules: 4 with failures, 11 passed, 39 not applicable')).toBeTruthy();
+        expect(testSubject.stdOutContained('Rules: 4 with failures, 14 passed, 35 not applicable')).toBeTruthy();
 
         done();
     });


### PR DESCRIPTION
#### Details

This PR makes a small change to the expected output. The branch got behind the scan package which had the viewport fix, which I suspect caused the change in number of pass and not applicable.

This PR only impacts the extension.

##### Motivation

Fix broken tests on main.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
