### PR TITLE
chore: update vscode settings to format on save and add copyright on new files

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint", "psioniq.psi-header"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "files.eol": "\n",
     "files.insertFinalNewline": true,
     "prettier.requireConfig": true,
@@ -13,5 +14,36 @@
         "**/.git": true,
         "**/out": true,
         "**/test-results": true
-    }
+    },
+    "psi-header.changes-tracking": {
+        "autoHeader": "autoSave",
+        "isActive": true
+    },
+    "psi-header.config": {
+        "forceToTop": true
+    },
+    "psi-header.lang-config": [
+        {
+            "language": "*",
+            "begin": "",
+            "end": "",
+            "prefix": "// "
+        },
+        {
+            "language": "html",
+            "begin": "<!--",
+            "end": "-->",
+            "prefix": ""
+        },
+        {
+            "language": "markdown",
+            "mapTo": "html"
+        }
+    ],
+    "psi-header.templates": [
+        {
+            "language": "*",
+            "template": ["Copyright (c) Microsoft Corporation. All rights reserved.", "Licensed under the MIT License."]
+        }
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,6 +38,12 @@
         {
             "language": "markdown",
             "mapTo": "html"
+        },
+        {
+            "language": "yaml",
+            "begin": "",
+            "end": "",
+            "prefix": "# "
         }
     ],
     "psi-header.templates": [


### PR DESCRIPTION
#### Details

This pull request will update the vscode files to:

- set `editor.defaultFormatter` this seems to help make prettier format on save
- set `psi-header` configuration to automatically add copyright on new files
-  add `extensions.json` with recommended extensions for this workspace

##### Motivation

Synchronize vscode settings across projects and improve contributor efficiency 

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
