### PR TITLE
feat(docs-tests-telemetry): add ability to pass inputs into e2e mock test runner

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -25,7 +25,7 @@ module.exports = {
         '^.+\\.(jsx?|tsx?)$': 'ts-jest',
     },
     transformIgnorePatterns: ['/node_modules/(?!(serialize-error|get-port))'], // Transform pure ESM with ts-jest
-    testMatch: ['**/*.spec.[tj]s'],
+    testMatch: ['**/*.spec.[tj]s', '**/*.test.[tj]s'],
     testPathIgnorePatterns: ['/dist/', '/out/'],
     verbose: true,
 };

--- a/packages/ado-extension/e2e/ado-extension.test.ts
+++ b/packages/ado-extension/e2e/ado-extension.test.ts
@@ -5,14 +5,15 @@ import * as path from 'path';
 import * as ttm from './mock-test';
 
 describe('Sample task tests', () => {
-    it('should succeed with simple inputs', (done) => {
-        const compiledSourcePath = path.join(__dirname, 'run-simple-inputs.js');
-        const testSubject: ttm.MockTestRunner = new ttm.MockTestRunner(compiledSourcePath);
-
-        testSubject.run();
-
-        // Uncomment the following line to debug e2e tests:
-        // console.log(testSubject);
+    let inputs: { [key: string]: string } = {};
+    beforeEach(() => {
+        inputs = {};
+    });
+    it('should succeed with simple inputs', () => {
+        inputs = {
+            url: 'https://www.washington.edu/accesscomputing/AU/before.html',
+        };
+        const testSubject = runTestWithInputs(inputs);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toEqual(1);
@@ -22,7 +23,29 @@ describe('Sample task tests', () => {
             ),
         ).toBeTruthy();
         expect(testSubject.stdOutContained('Rules: 4 with failures, 14 passed, 35 not applicable')).toBeTruthy();
-
-        done();
     });
+
+    it('should succeed with staticSiteDir inputs', () => {
+        inputs = {
+            staticSiteDir: path.join(__dirname, '..', '..', '..', 'dev', 'website-root'),
+            staticSitePort: '39983',
+        };
+        const testSubject = runTestWithInputs(inputs);
+
+        expect(testSubject.warningIssues.length).toEqual(0);
+        expect(testSubject.errorIssues.length).toEqual(1);
+        expect(testSubject.stdOutContained('Accessibility scanning of URL http://localhost:39983/ completed')).toBeTruthy();
+        expect(testSubject.stdOutContained('Rules: 4 with failures, 12 passed, 38 not applicable')).toBeTruthy();
+    });
+
+    function runTestWithInputs(inputs?: { [key: string]: string }): ttm.MockTestRunner {
+        const compiledSourcePath = path.join(__dirname, 'mock-test-runner.js');
+        const testSubject: ttm.MockTestRunner = new ttm.MockTestRunner(compiledSourcePath, inputs);
+
+        testSubject.run();
+
+        // Uncomment the following line to debug e2e tests:
+        console.log(testSubject.stdout);
+        return testSubject;
+    }
 });

--- a/packages/ado-extension/e2e/ado-extension.test.ts
+++ b/packages/ado-extension/e2e/ado-extension.test.ts
@@ -44,7 +44,6 @@ describe('Sample task tests', () => {
 
         testSubject.run();
 
-        // Uncomment the following line to debug e2e tests:
         console.log(testSubject.stdout);
         return testSubject;
     }

--- a/packages/ado-extension/e2e/mock-test-runner.js
+++ b/packages/ado-extension/e2e/mock-test-runner.js
@@ -5,13 +5,17 @@ const tmrm = require('azure-pipelines-task-lib/mock-run');
 const path = require('path');
 const fs = require('fs');
 
+// Get inputs passed to the task
+const [node, file, ...args] = process.argv;
+const inputsPassedIn = args[0];
+
 // Prepare the task:
 // Apply default input values from task configuration
 const taskConfigPath = path.join(__dirname, '..', 'dist', 'pkg', 'task.json');
 const taskConfig = require(taskConfigPath);
-const inputs = {};
+const inputs = JSON.parse(inputsPassedIn) ?? {};
 for (const inputConfig of taskConfig['inputs']) {
-    if (inputConfig.defaultValue) {
+    if (inputConfig.defaultValue && !inputs[inputConfig.name]) {
         inputs[inputConfig.name] = inputConfig.defaultValue;
     }
 }
@@ -35,7 +39,5 @@ for (const name of Object.keys(inputs)) {
     console.log(`e2e tests is applying input ${name} to value ${inputs[name]}`);
     tmr.setInput(name, inputs[name]);
 }
-
-tmr.setInput('url', 'https://www.washington.edu/accesscomputing/AU/before.html');
 
 tmr.run(true); // Requires true bypass `retrieveSecret` error https://github.com/microsoft/azure-pipelines-task-lib/issues/794

--- a/packages/ado-extension/e2e/mock-test.ts
+++ b/packages/ado-extension/e2e/mock-test.ts
@@ -12,10 +12,14 @@ const COMMAND_TAG = '[command]';
 const COMMAND_LENGTH = COMMAND_TAG.length;
 
 export class MockTestRunner {
-    constructor(testPath: string) {
+    constructor(testPath: string, inputs?: { [key: string]: string }) {
         this._testPath = testPath;
+        if (inputs !== undefined) {
+            this._inputs = inputs;
+        }
     }
 
+    private _inputs: { [key: string]: string } | undefined;
     private _testPath = '';
     public stdout = '';
     public stderr = '';
@@ -58,7 +62,12 @@ export class MockTestRunner {
         this.errorIssues = [];
         this.warningIssues = [];
 
-        const spawn = spawnSync('node', [this._testPath]);
+        const args = [this._testPath];
+        if (this._inputs !== undefined) {
+            args.push(JSON.stringify(this._inputs));
+        }
+
+        const spawn = spawnSync('node', args);
 
         if (spawn.error) {
             console.error('Running test failed');

--- a/packages/ado-extension/package.json
+++ b/packages/ado-extension/package.json
@@ -12,9 +12,9 @@
         "lint:fix": "eslint -c ../../.eslintrc.js \"{src,e2e}/**/*.{js,ts}\" --quiet --fix",
         "package": "cd dist && tfx extension create --manifest-globs ado-extension.json",
         "start": "node scripts/run-locally.js",
-        "test": "jest",
+        "test": "jest --rootDir src",
         "watch:test": "jest --watch",
-        "test:e2e": "jest --testMatch \"**/e2e/?(*.)+(test).ts\" --coverage false"
+        "test:e2e": "jest --rootDir e2e --coverage false"
     },
     "repository": {
         "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3115,10 +3115,10 @@ accessibility-insights-report@4.4.0:
     react-helmet "^6.1.0"
     uuid "^9.0.0"
 
-accessibility-insights-scan@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/accessibility-insights-scan/-/accessibility-insights-scan-1.5.1.tgz#dde1c39be27e53cdbef61ea37f7f290ed11baea3"
-  integrity sha512-hD6qtyffwjwB8m0AOGC5rVsbYM0OENDR1sV6KUHpXN0BSEDggUdD9lUDoVUuggQMb7fiDABa+VSg1KYTeTnZag==
+accessibility-insights-scan@1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/accessibility-insights-scan/-/accessibility-insights-scan-1.5.2.tgz#a14eec1dc20441c4a44e2015789e79588b8f9275"
+  integrity sha512-sAvSFgR8JVGdTR1xZb9H95D+yGdmj0oHX9cdAlx0Yunlf7LUFbhz8twXgR3Dx73MgjIGgm5q0HKy5JS4VNuH+g==
   dependencies:
     "@axe-core/puppeteer" "^4.5.0"
     "@medv/finder" "^2.1.0"


### PR DESCRIPTION
#### Details

This takes the existing E2E infrastructure and adds the ability to pass in varying inputs. It also adjusts the jest config and package.json to run the relevant tests when calling from yarn.

I added an additional E2E test to demonstrate the ability to pass in different inputs with the new setup.

It also updates the yarn.lock file because that didn't happen last week, apparently. 

##### Motivation

Feature work

##### Context

More E2E tests to come in future PRs.

This does not affect the GH Action.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
