### PR TITLE
feat(docs-tests-telemetry): Add E2E test scenarios

### DIFF
--- a/dev/website-baselines/e2e-baseline-1.baseline
+++ b/dev/website-baselines/e2e-baseline-1.baseline
@@ -1,0 +1,57 @@
+{
+  metadata: {
+    fileFormatVersion: '1',
+  },
+  results: [
+    {
+      cssSelector: '#decorative',
+      htmlSnippet: '<img id="decorative" role="presentation" alt="Some alt text" src="./img1.png">',
+      rule: 'aria-allowed-role',
+      urls: [
+        'http://localhost:39983/',
+      ],
+    },
+    {
+      cssSelector: 'html',
+      htmlSnippet: '<html>',
+      rule: 'html-has-lang',
+      urls: [
+        'http://localhost:39983/',
+        'http://localhost:39983/linked1/inner-page.html',
+      ],
+    },
+    {
+      cssSelector: '#non-decorative',
+      htmlSnippet: '<img id="non-decorative" src="./img1.png">',
+      rule: 'image-alt',
+      urls: [
+        'http://localhost:39983/',
+        'http://localhost:39983/linked1/inner-page.html',
+      ],
+    },
+    {
+      cssSelector: '#input-radio-1',
+      htmlSnippet: '<input id="input-radio-1" type="radio" name="color" value="red" checked="">',
+      rule: 'label',
+      urls: [
+        'http://localhost:39983/',
+      ],
+    },
+    {
+      cssSelector: 'input[value="blue"]',
+      htmlSnippet: '<input type="radio" name="color" value="blue">',
+      rule: 'label',
+      urls: [
+        'http://localhost:39983/',
+      ],
+    },
+    {
+      cssSelector: 'input[value="green"]',
+      htmlSnippet: '<input type="radio" name="color" value="green">',
+      rule: 'label',
+      urls: [
+        'http://localhost:39983/',
+      ],
+    },
+  ],
+}

--- a/dev/website-baselines/e2e-baseline-2.baseline
+++ b/dev/website-baselines/e2e-baseline-2.baseline
@@ -1,0 +1,41 @@
+{
+  metadata: {
+    fileFormatVersion: '1',
+  },
+  results: [
+    {
+      cssSelector: '#decorative',
+      htmlSnippet: '<img id="decorative" role="presentation" alt="Some alt text" src="./img1.png">',
+      rule: 'aria-allowed-role',
+      urls: [
+        'http://localhost:39983/',
+      ],
+    },
+    {
+      cssSelector: 'html',
+      htmlSnippet: '<html>',
+      rule: 'html-has-lang',
+      urls: [
+        'http://localhost:39983/',
+        'http://localhost:39983/linked1/inner-page.html',
+      ],
+    },
+    {
+      cssSelector: '#non-decorative',
+      htmlSnippet: '<img id="non-decorative" src="./img1.png">',
+      rule: 'image-alt',
+      urls: [
+        'http://localhost:39983/',
+        'http://localhost:39983/linked1/inner-page.html',
+      ],
+    },
+    {
+      cssSelector: '#input-radio-1',
+      htmlSnippet: '<input id="input-radio-1" type="radio" name="color" value="red" checked="">',
+      rule: 'label',
+      urls: [
+        'http://localhost:39983/',
+      ],
+    },
+  ],
+}

--- a/packages/ado-extension/e2e/ado-extension.test.ts
+++ b/packages/ado-extension/e2e/ado-extension.test.ts
@@ -113,6 +113,20 @@ describe('Sample task tests', () => {
         expect(testSubject.stdOutContained('8 failure instances in baseline')).toBeTruthy();
     });
 
+    it('should find additional failures when the baseline does not cover all failures', () => {
+        inputs = {
+            staticSiteDir: path.join(__dirname, '..', '..', '..', 'dev', 'website-root'),
+            staticSitePort: '39983',
+            baselineFile: path.join(__dirname, '..', '..', '..', 'dev', 'website-baselines', 'e2e-baseline-2.baseline'),
+        };
+        const testSubject = runTestWithInputs(inputs);
+
+        expect(testSubject.warningIssues.length).toEqual(0);
+        expect(testSubject.errorIssues.length).toEqual(1);
+        expect(testSubject.stdOutContained('2 failure instances not in baseline')).toBeTruthy();
+        expect(testSubject.stdOutContained('6 failure instances in baseline')).toBeTruthy();
+    });
+
     it('should fail scan and generate a baseline file if baselineFile input is specified and file does not exist', () => {
         inputs = {
             staticSiteDir: path.join(__dirname, '..', '..', '..', 'dev', 'website-root'),

--- a/packages/ado-extension/e2e/ado-extension.test.ts
+++ b/packages/ado-extension/e2e/ado-extension.test.ts
@@ -38,6 +38,95 @@ describe('Sample task tests', () => {
         expect(testSubject.stdOutContained('Rules: 4 with failures, 12 passed, 38 not applicable')).toBeTruthy();
     });
 
+    it('limits the number of pages crawled and scanned when maxUrls input is set', () => {
+        inputs = {
+            staticSiteDir: path.join(__dirname, '..', '..', '..', 'dev', 'website-root'),
+            staticSitePort: '39983',
+            maxUrls: '2',
+        };
+        const testSubject = runTestWithInputs(inputs);
+
+        expect(testSubject.warningIssues.length).toEqual(0);
+        expect(testSubject.errorIssues.length).toEqual(1);
+        expect(testSubject.stdOutContained('Accessibility scanning of URL http://localhost:39983/ completed')).toBeTruthy();
+        expect(testSubject.stdOutContained('URLs: 1 with failures, 1 passed, 0 not scannable')).toBeTruthy();
+    });
+
+    it('only scans the inputUrls when maxUrls input matches number of inputUrls, (url input can be anything)', () => {
+        inputs = {
+            url: 'https://www.washington.edu', // this input must be set to something, but it is ignored
+            inputUrls: 'https://www.washington.edu/accesscomputing/AU/before.html https://www.washington.edu/accesscomputing/AU/after.html',
+            maxUrls: '2', //By setting `maxUrls` to 2, only the `inputUrls` will be scanned
+        };
+        const testSubject = runTestWithInputs(inputs);
+
+        expect(testSubject.warningIssues.length).toEqual(0);
+        expect(testSubject.errorIssues.length).toEqual(1);
+        expect(testSubject.stdOutContained('Processing page https://www.washington.edu/accesscomputing/AU/after.html')).toBeTruthy();
+        expect(testSubject.stdOutContained('Processing page https://www.washington.edu/accesscomputing/AU/before.html')).toBeTruthy();
+        expect(testSubject.stdOutContained('URLs: 1 with failures, 1 passed, 0 not scannable')).toBeTruthy();
+    });
+
+    it('scans pages that are passed in as inputUrls', () => {
+        inputs = {
+            staticSiteDir: path.join(__dirname, '..', '..', '..', 'dev', 'website-root'),
+            staticSitePort: '39983',
+            inputUrls: 'http://localhost:39983/unlinked',
+        };
+        const testSubject = runTestWithInputs(inputs);
+
+        expect(testSubject.warningIssues.length).toEqual(0);
+        expect(testSubject.errorIssues.length).toEqual(1);
+        expect(testSubject.stdOutContained('Processing page http://localhost:39983/unlinked/')).toBeTruthy();
+        expect(testSubject.stdOutContained('Rules: 4 with failures, 12 passed, 38 not applicable')).toBeTruthy();
+    });
+
+    it('should fail if both URL and staticSiteDir are defined', () => {
+        inputs = {
+            url: 'https://www.washington.edu/accesscomputing/AU/before.html',
+            staticSiteDir: path.join(__dirname, '..', '..', '..', 'dev', 'website-root'),
+        };
+        const testSubject = runTestWithInputs(inputs);
+
+        expect(testSubject.warningIssues.length).toEqual(0);
+        expect(testSubject.errorIssues.length).toBeGreaterThan(0);
+        expect(
+            testSubject.stdOutContained(
+                'A configuration error has occurred, only one of the following inputs can be set at a time: url or staticSiteDir',
+            ),
+        ).toBeTruthy();
+    });
+
+    it('should find no additional failures when a baseline is properly configured', () => {
+        inputs = {
+            staticSiteDir: path.join(__dirname, '..', '..', '..', 'dev', 'website-root'),
+            staticSitePort: '39983',
+            baselineFile: path.join(__dirname, '..', '..', '..', 'dev', 'website-baselines', 'e2e-baseline-1.baseline'),
+        };
+        const testSubject = runTestWithInputs(inputs);
+
+        expect(testSubject.warningIssues.length).toEqual(0);
+        expect(testSubject.errorIssues.length).toEqual(0);
+        expect(
+            testSubject.stdOutContained('No failures were detected by automatic scanning except those which exist in the baseline.'),
+        ).toBeTruthy();
+        expect(testSubject.stdOutContained('8 failure instances in baseline')).toBeTruthy();
+    });
+
+    it('should fail scan and generate a baseline file if baselineFile input is specified and file does not exist', () => {
+        inputs = {
+            staticSiteDir: path.join(__dirname, '..', '..', '..', 'dev', 'website-root'),
+            staticSitePort: '39983',
+            baselineFile: path.join(__dirname, '..', '..', '..', 'dev', 'website-baselines', 'e2e-baseline-that-does-not-exist.baseline'),
+        };
+        const testSubject = runTestWithInputs(inputs);
+
+        expect(testSubject.warningIssues.length).toEqual(0);
+        expect(testSubject.errorIssues[0]).toEqual('Scan failed');
+        expect(testSubject.stdOutContained('##[debug]Saved new baseline file at')).toBeTruthy();
+        expect(testSubject.stdOutContained('8 failure instances')).toBeTruthy();
+    });
+
     function runTestWithInputs(inputs?: { [key: string]: string }): ttm.MockTestRunner {
         const compiledSourcePath = path.join(__dirname, 'mock-test-runner.js');
         const testSubject: ttm.MockTestRunner = new ttm.MockTestRunner(compiledSourcePath, inputs);


### PR DESCRIPTION
#### Details

This adds various E2E test scenarios that will run on PR. The scenarios added are:

The ADO Extension:
- Limits the number of pages crawled and scanned when `MaxUrls` input is set
- Only scans the `inputUrls` when `maxUrls` input matches the number of `inputUrls`
- Scans pages that are passed in as `inputUrls`
- Should fail if both `url` and `staticSiteDir` are defined
- Should find no additional failures when a baseline is properly configured
- Should find additional failures when the baseline does not cover all failures
- Should fail scan and generate a baseline file if `baselineFile` input is specified and the file does not exist

##### Motivation

Feature work

##### Context

This does not impact the GH Action

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran prechecking (`yarn prechecking`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
