### PR TITLE
chore: Enable write permissions for combine-dependabot-prs

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: '0 13 * * 1'
   workflow_dispatch:
+  
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   combine-prs:


### PR DESCRIPTION
#### Details

Enable write permissions for combine-dependabot-prs

##### Motivation

The repo is configured to only allow read permissions to workflows. The combined-dependabot-prs action requires write permissions to create PRs

##### Context

Tested in [accessibility-insights-web](https://github.com/microsoft/accessibility-insights-web/actions/runs/3499742576)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
- [n/a] Described how this PR impacts both the ADO extension and the GitHub action
