### PR TITLE
fix: prevent e2e stdout from triggering build failure on Azure pipeline

### DIFF
--- a/packages/ado-extension/e2e/ado-extension.test.ts
+++ b/packages/ado-extension/e2e/ado-extension.test.ts
@@ -153,9 +153,10 @@ describe('Sample task tests', () => {
     }
 });
 
-// Replace errors with warnings to prevent the stdout from triggering failures in ADO
+// Format stdout for ADO:
+// Prevent errors from stdout from being marked as pipeline failures
 function formatStdout(stdout: string) {
-    console.log('##[group]');
+    console.log('##[group]Test output');
     console.log(
         stdout.replace(/##vso\[task.issue type=error;\]/g, '##[error]').replace(/##vso\[task.complete result=Failed;\]/g, '##[error]'),
     );

--- a/packages/ado-extension/e2e/ado-extension.test.ts
+++ b/packages/ado-extension/e2e/ado-extension.test.ts
@@ -147,9 +147,13 @@ describe('Sample task tests', () => {
 
         testSubject.run();
 
-        // Replace errors with warnings to prevent the stdout from triggering failures in ADO
-        console.log(testSubject.stdout.replace(/type=error/g, 'type=warning').replace(/result=Failed/g, 'result=SucceededWithIssues'));
+        console.log(formatStdout(testSubject.stdout));
 
         return testSubject;
     }
 });
+
+// Replace errors with warnings to prevent the stdout from triggering failures in ADO
+function formatStdout(stdout: string) {
+    return stdout.replace(/##vso\[task.issue type=error;\]/g, '').replace(/##vso\[task.complete result=Failed;\]/g, '');
+}

--- a/packages/ado-extension/e2e/ado-extension.test.ts
+++ b/packages/ado-extension/e2e/ado-extension.test.ts
@@ -13,7 +13,7 @@ describe('Sample task tests', () => {
         inputs = {
             url: 'https://www.washington.edu/accesscomputing/AU/before.html',
         };
-        const testSubject = runTestWithInputs(inputs, expect);
+        const testSubject = runTestWithInputs(inputs);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toEqual(1);
@@ -30,7 +30,7 @@ describe('Sample task tests', () => {
             staticSiteDir: path.join(__dirname, '..', '..', '..', 'dev', 'website-root'),
             staticSitePort: '39983',
         };
-        const testSubject = runTestWithInputs(inputs, expect);
+        const testSubject = runTestWithInputs(inputs);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toEqual(1);
@@ -44,7 +44,7 @@ describe('Sample task tests', () => {
             staticSitePort: '39983',
             maxUrls: '2',
         };
-        const testSubject = runTestWithInputs(inputs, expect);
+        const testSubject = runTestWithInputs(inputs);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toEqual(1);
@@ -58,7 +58,7 @@ describe('Sample task tests', () => {
             inputUrls: 'https://www.washington.edu/accesscomputing/AU/before.html https://www.washington.edu/accesscomputing/AU/after.html',
             maxUrls: '2', //By setting `maxUrls` to 2, only the `inputUrls` will be scanned
         };
-        const testSubject = runTestWithInputs(inputs, expect);
+        const testSubject = runTestWithInputs(inputs);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toEqual(1);
@@ -73,7 +73,7 @@ describe('Sample task tests', () => {
             staticSitePort: '39983',
             inputUrls: 'http://localhost:39983/unlinked',
         };
-        const testSubject = runTestWithInputs(inputs, expect);
+        const testSubject = runTestWithInputs(inputs);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toEqual(1);
@@ -86,7 +86,7 @@ describe('Sample task tests', () => {
             url: 'https://www.washington.edu/accesscomputing/AU/before.html',
             staticSiteDir: path.join(__dirname, '..', '..', '..', 'dev', 'website-root'),
         };
-        const testSubject = runTestWithInputs(inputs, expect);
+        const testSubject = runTestWithInputs(inputs);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toBeGreaterThan(0);
@@ -103,7 +103,7 @@ describe('Sample task tests', () => {
             staticSitePort: '39983',
             baselineFile: path.join(__dirname, '..', '..', '..', 'dev', 'website-baselines', 'e2e-baseline-1.baseline'),
         };
-        const testSubject = runTestWithInputs(inputs, expect);
+        const testSubject = runTestWithInputs(inputs);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toEqual(0);
@@ -119,7 +119,7 @@ describe('Sample task tests', () => {
             staticSitePort: '39983',
             baselineFile: path.join(__dirname, '..', '..', '..', 'dev', 'website-baselines', 'e2e-baseline-2.baseline'),
         };
-        const testSubject = runTestWithInputs(inputs, expect);
+        const testSubject = runTestWithInputs(inputs);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toEqual(1);
@@ -133,7 +133,7 @@ describe('Sample task tests', () => {
             staticSitePort: '39983',
             baselineFile: path.join(__dirname, '..', '..', '..', 'dev', 'website-baselines', 'e2e-baseline-that-does-not-exist.baseline'),
         };
-        const testSubject = runTestWithInputs(inputs, expect);
+        const testSubject = runTestWithInputs(inputs);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues[0]).toEqual('Scan failed');
@@ -141,14 +141,15 @@ describe('Sample task tests', () => {
         expect(testSubject.stdOutContained('8 failure instances')).toBeTruthy();
     });
 
-    function runTestWithInputs(inputs: { [key: string]: string }, expect: jest.Expect): ttm.MockTestRunner {
+    function runTestWithInputs(inputs?: { [key: string]: string }): ttm.MockTestRunner {
         const compiledSourcePath = path.join(__dirname, 'mock-test-runner.js');
         const testSubject: ttm.MockTestRunner = new ttm.MockTestRunner(compiledSourcePath, inputs);
 
         testSubject.run();
 
-        const id = expect.getState().currentTestName ?? 'e2e';
-        console.log(`vso[task.logdetail id=${id}]${testSubject.stdout}`);
+        // Replace errors with warnings to prevent the stdout from triggering failures in ADO
+        console.log(testSubject.stdout.replace(/type=error/g, 'type=warning').replace(/result=Failed/g, 'result=SucceededWithIssues'));
+
         return testSubject;
     }
 });

--- a/packages/ado-extension/e2e/ado-extension.test.ts
+++ b/packages/ado-extension/e2e/ado-extension.test.ts
@@ -156,9 +156,7 @@ describe('Sample task tests', () => {
 // Format stdout for ADO:
 // Prevent errors from stdout from being marked as pipeline failures
 function formatStdout(stdout: string) {
-    console.log('##[group]Test output');
     console.log(
         stdout.replace(/##vso\[task.issue type=error;\]/g, '##[error]').replace(/##vso\[task.complete result=Failed;\]/g, '##[error]'),
     );
-    console.log('##[endgroup]');
 }

--- a/packages/ado-extension/e2e/ado-extension.test.ts
+++ b/packages/ado-extension/e2e/ado-extension.test.ts
@@ -147,7 +147,7 @@ describe('Sample task tests', () => {
 
         testSubject.run();
 
-        console.log(testSubject.stdout);
+        // console.log(testSubject.stdout);
         return testSubject;
     }
 });

--- a/packages/ado-extension/e2e/ado-extension.test.ts
+++ b/packages/ado-extension/e2e/ado-extension.test.ts
@@ -147,7 +147,7 @@ describe('Sample task tests', () => {
 
         testSubject.run();
 
-        console.log(formatStdout(testSubject.stdout));
+        formatStdout(testSubject.stdout);
 
         return testSubject;
     }
@@ -155,5 +155,9 @@ describe('Sample task tests', () => {
 
 // Replace errors with warnings to prevent the stdout from triggering failures in ADO
 function formatStdout(stdout: string) {
-    return stdout.replace(/##vso\[task.issue type=error;\]/g, '').replace(/##vso\[task.complete result=Failed;\]/g, '');
+    console.log('##[group]');
+    console.log(
+        stdout.replace(/##vso\[task.issue type=error;\]/g, '##[error]').replace(/##vso\[task.complete result=Failed;\]/g, '##[error]'),
+    );
+    console.log('##[endgroup]');
 }

--- a/packages/ado-extension/e2e/ado-extension.test.ts
+++ b/packages/ado-extension/e2e/ado-extension.test.ts
@@ -13,7 +13,7 @@ describe('Sample task tests', () => {
         inputs = {
             url: 'https://www.washington.edu/accesscomputing/AU/before.html',
         };
-        const testSubject = runTestWithInputs(inputs);
+        const testSubject = runTestWithInputs(inputs, expect);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toEqual(1);
@@ -30,7 +30,7 @@ describe('Sample task tests', () => {
             staticSiteDir: path.join(__dirname, '..', '..', '..', 'dev', 'website-root'),
             staticSitePort: '39983',
         };
-        const testSubject = runTestWithInputs(inputs);
+        const testSubject = runTestWithInputs(inputs, expect);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toEqual(1);
@@ -44,7 +44,7 @@ describe('Sample task tests', () => {
             staticSitePort: '39983',
             maxUrls: '2',
         };
-        const testSubject = runTestWithInputs(inputs);
+        const testSubject = runTestWithInputs(inputs, expect);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toEqual(1);
@@ -58,7 +58,7 @@ describe('Sample task tests', () => {
             inputUrls: 'https://www.washington.edu/accesscomputing/AU/before.html https://www.washington.edu/accesscomputing/AU/after.html',
             maxUrls: '2', //By setting `maxUrls` to 2, only the `inputUrls` will be scanned
         };
-        const testSubject = runTestWithInputs(inputs);
+        const testSubject = runTestWithInputs(inputs, expect);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toEqual(1);
@@ -73,7 +73,7 @@ describe('Sample task tests', () => {
             staticSitePort: '39983',
             inputUrls: 'http://localhost:39983/unlinked',
         };
-        const testSubject = runTestWithInputs(inputs);
+        const testSubject = runTestWithInputs(inputs, expect);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toEqual(1);
@@ -86,7 +86,7 @@ describe('Sample task tests', () => {
             url: 'https://www.washington.edu/accesscomputing/AU/before.html',
             staticSiteDir: path.join(__dirname, '..', '..', '..', 'dev', 'website-root'),
         };
-        const testSubject = runTestWithInputs(inputs);
+        const testSubject = runTestWithInputs(inputs, expect);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toBeGreaterThan(0);
@@ -103,7 +103,7 @@ describe('Sample task tests', () => {
             staticSitePort: '39983',
             baselineFile: path.join(__dirname, '..', '..', '..', 'dev', 'website-baselines', 'e2e-baseline-1.baseline'),
         };
-        const testSubject = runTestWithInputs(inputs);
+        const testSubject = runTestWithInputs(inputs, expect);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toEqual(0);
@@ -119,7 +119,7 @@ describe('Sample task tests', () => {
             staticSitePort: '39983',
             baselineFile: path.join(__dirname, '..', '..', '..', 'dev', 'website-baselines', 'e2e-baseline-2.baseline'),
         };
-        const testSubject = runTestWithInputs(inputs);
+        const testSubject = runTestWithInputs(inputs, expect);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toEqual(1);
@@ -133,7 +133,7 @@ describe('Sample task tests', () => {
             staticSitePort: '39983',
             baselineFile: path.join(__dirname, '..', '..', '..', 'dev', 'website-baselines', 'e2e-baseline-that-does-not-exist.baseline'),
         };
-        const testSubject = runTestWithInputs(inputs);
+        const testSubject = runTestWithInputs(inputs, expect);
 
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues[0]).toEqual('Scan failed');
@@ -141,13 +141,14 @@ describe('Sample task tests', () => {
         expect(testSubject.stdOutContained('8 failure instances')).toBeTruthy();
     });
 
-    function runTestWithInputs(inputs?: { [key: string]: string }): ttm.MockTestRunner {
+    function runTestWithInputs(inputs: { [key: string]: string }, expect: jest.Expect): ttm.MockTestRunner {
         const compiledSourcePath = path.join(__dirname, 'mock-test-runner.js');
         const testSubject: ttm.MockTestRunner = new ttm.MockTestRunner(compiledSourcePath, inputs);
 
         testSubject.run();
 
-        // console.log(testSubject.stdout);
+        const id = expect.getState().currentTestName ?? 'e2e';
+        console.log(`vso[task.logdetail id=${id}]${testSubject.stdout}`);
         return testSubject;
     }
 });


### PR DESCRIPTION
#### Details

I noticed that the e2e tests on the ADO pipeline are failing. I believe this is because when we log the stdout from the e2e tests, the errors collected from the tests are triggering failures in the pipeline. This pull request will add a small function that will replace the ADO logging commands with `##[error]` which will format as an error in the pipeline, but not fail the pipeline.

Example failing build: https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=39572&view=logs&j=81b7b1a0-9e2e-58a5-1601-69aaad9b82d6&t=5cf72e78-07c0-5125-1262-b1e05b2475fe

##### Motivation

Unblock pipeline.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

For visibility, it would be ideal to keep printing the stdout with each test, but I'm not sure how to prevent the collected errors from pulling through. I tried:

- [x] Wrapping the stdout in a LogIssue warning logging command: https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logissue-log-an-error-or-warning -- didn't work
- [x] LogDetail logging command: https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logdetail-create-or-update-a-timeline-record-for-a-task -- didn't work
- [x] Use a string replacement to change errors to warnings -- worked!

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
