### PR TITLE
feat(docs-tests-telemetry): Add auth testing to canary

### DIFF
--- a/pipelines/ado-extension-canary-validation.yaml
+++ b/pipelines/ado-extension-canary-validation.yaml
@@ -3,15 +3,7 @@
 
 trigger: none
 
-pr:
-    branches:
-        include:
-            - main
-    paths:
-        include:
-            - dev
-            - pipelines/ado-extension-canary-validation.yaml
-            - pipelines/ado-extension-validation-template.yaml
+pr: none
 
 resources:
     pipelines:

--- a/pipelines/ado-extension-canary-validation.yaml
+++ b/pipelines/ado-extension-canary-validation.yaml
@@ -15,7 +15,7 @@ pr:
 
 resources:
     pipelines:
-        - pipeline: prod-release
+        - pipeline: canary-release
           source: accessibility-insights-ado-extension-release-canary
           trigger:
               stages:

--- a/pipelines/ado-extension-canary-validation.yaml
+++ b/pipelines/ado-extension-canary-validation.yaml
@@ -26,5 +26,5 @@ pool: a11y-ado-auth
 extends:
     template: ado-extension-validation-template.yaml
     parameters:
-        taskUnderTest: accessibility-insights.canary.task.accessibility-insights@3
+        taskUnderTest: accessibility-insights.canary.task.accessibility-insights@1
         testAuth: true

--- a/pipelines/ado-extension-canary-validation.yaml
+++ b/pipelines/ado-extension-canary-validation.yaml
@@ -7,20 +7,19 @@ pr:
     branches:
         include:
             - main
-            - brocktaylor/canary-test-auth
     paths:
         include:
             - dev
             - pipelines/ado-extension-canary-validation.yaml
             - pipelines/ado-extension-validation-template.yaml
 
-# resources:
-#     pipelines:
-#         - pipeline: canary-release
-#           source: accessibility-insights-ado-extension-release-canary
-#           trigger:
-#               stages:
-#                   - package_publish_canary
+resources:
+    pipelines:
+        - pipeline: canary-release
+          source: accessibility-insights-ado-extension-release-canary
+          trigger:
+              stages:
+                  - package_publish_canary
 
 pool: a11y-ado-auth
 

--- a/pipelines/ado-extension-canary-validation.yaml
+++ b/pipelines/ado-extension-canary-validation.yaml
@@ -19,4 +19,3 @@ extends:
     template: ado-extension-validation-template.yaml
     parameters:
         taskUnderTest: accessibility-insights.canary.task.accessibility-insights@1
-        testAuth: true

--- a/pipelines/ado-extension-canary-validation.yaml
+++ b/pipelines/ado-extension-canary-validation.yaml
@@ -7,24 +7,25 @@ pr:
     branches:
         include:
             - main
+            - brocktaylor/canary-test-auth
     paths:
         include:
             - dev
             - pipelines/ado-extension-canary-validation.yaml
             - pipelines/ado-extension-validation-template.yaml
 
-resources:
-    pipelines:
-        - pipeline: canary-release
-          source: accessibility-insights-ado-extension-release-canary
-          trigger:
-              stages:
-                  - package_publish_canary
+# resources:
+#     pipelines:
+#         - pipeline: canary-release
+#           source: accessibility-insights-ado-extension-release-canary
+#           trigger:
+#               stages:
+#                   - package_publish_canary
 
-pool:
-    vmImage: ubuntu-latest
+pool: ally-ado-auth
 
 extends:
     template: ado-extension-validation-template.yaml
     parameters:
         taskUnderTest: accessibility-insights.canary.task.accessibility-insights@3
+        testAuth: true

--- a/pipelines/ado-extension-canary-validation.yaml
+++ b/pipelines/ado-extension-canary-validation.yaml
@@ -22,7 +22,7 @@ pr:
 #               stages:
 #                   - package_publish_canary
 
-pool: ally-ado-auth
+pool: a11y-ado-auth
 
 extends:
     template: ado-extension-validation-template.yaml

--- a/pipelines/ado-extension-prod-validation.yaml
+++ b/pipelines/ado-extension-prod-validation.yaml
@@ -3,15 +3,7 @@
 
 trigger: none
 
-pr:
-    branches:
-        include:
-            - main
-    paths:
-        include:
-            - dev
-            - pipelines/ado-extension-prod-validation.yaml
-            - pipelines/ado-extension-validation-template.yaml
+pr: none
 
 resources:
     pipelines:
@@ -21,8 +13,7 @@ resources:
               stages:
                   - package_publish_prod
 
-pool:
-    vmImage: ubuntu-latest
+pool: a11y-ado-auth
 
 extends:
     template: ado-extension-validation-template.yaml

--- a/pipelines/ado-extension-staging-validation.yaml
+++ b/pipelines/ado-extension-staging-validation.yaml
@@ -19,4 +19,3 @@ extends:
     template: ado-extension-validation-template.yaml
     parameters:
         taskUnderTest: accessibility-insights.staging.task.accessibility-insights@3
-        testAuth: true

--- a/pipelines/ado-extension-staging-validation.yaml
+++ b/pipelines/ado-extension-staging-validation.yaml
@@ -3,15 +3,7 @@
 
 trigger: none
 
-pr:
-    branches:
-        include:
-            - main
-    paths:
-        include:
-            - dev
-            - pipelines/ado-extension-staging-validation.yaml
-            - pipelines/ado-extension-validation-template.yaml
+pr: none
 
 resources:
     pipelines:

--- a/pipelines/ado-extension-staging-validation.yaml
+++ b/pipelines/ado-extension-staging-validation.yaml
@@ -21,10 +21,10 @@ resources:
               stages:
                   - package_publish_staging
 
-pool:
-    vmImage: ubuntu-latest
+pool: a11y-ado-auth
 
 extends:
     template: ado-extension-validation-template.yaml
     parameters:
         taskUnderTest: accessibility-insights.staging.task.accessibility-insights@3
+        testAuth: true

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -11,9 +11,6 @@
 parameters:
     - name: taskUnderTest
       type: string
-    - name: testAuth
-      type: boolean
-      default: false
 
 variables:
     - group: 'ado-auth-example-secrets'
@@ -129,5 +126,5 @@ steps:
           serviceAccountPassword: $(a11yinsscan-service-acct-password)
           authType: 'AAD'
           outputArtifactName: 'accessibility-reports-case-12'
-      condition: and(succeededOrFailed(), eq('${{ parameters.testAuth }}', true))
+      condition: succeededOrFailed()
       continueOnError: true

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -11,6 +11,9 @@
 parameters:
     - name: taskUnderTest
       type: string
+    - name: testAuth
+      type: boolean
+      default: false
 
 steps:
     # reused by all "url" cases
@@ -113,4 +116,25 @@ steps:
           # siteDir instead of staticSiteDir
           siteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
       condition: succeededOrFailed()
+      continueOnError: true
+
+    # necessary for auth testing in next case
+    - task: AzureKeyVault@2
+      inputs:
+          azureSubscription: $(azureSubscription)
+          KeyVaultName: $(keyVaultName)
+          SecretsFilter: $(secretsFilter)
+          RunAsPreJob: false
+      condition: and(succeededOrFailed(), eq('${{ parameters.testAuth }}', true))
+      continueOnError: true
+
+    - task: ${{ parameters.taskUnderTest }}
+      displayName: '[should fail] case 12: url, azure portal auth test'
+      inputs:
+          url: 'https://portal.azure.com'
+          serviceAccountName: $($(usernameKvName))
+          serviceAccountPassword: $($(passwordKvName))
+          authType: 'AAD'
+          outputArtifactName: 'accessibility-reports-case-12'
+      condition: and(succeededOrFailed(), eq('${{ parameters.testAuth }}', true))
       continueOnError: true

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -16,7 +16,7 @@ parameters:
       default: false
 
 variables:
-    - group: 'ado-extension-canary'
+    - group: 'ado-auth-example-secrets'
 
 steps:
     # reused by all "url" cases
@@ -121,22 +121,22 @@ steps:
       condition: succeededOrFailed()
       continueOnError: true
 
-    # necessary for auth testing in next case
-    - task: AzureKeyVault@2
-      inputs:
-          azureSubscription: $(azureSubscription)
-          KeyVaultName: $(keyVaultName)
-          SecretsFilter: $(secretsFilter)
-          RunAsPreJob: false
-      condition: and(succeededOrFailed(), eq('${{ parameters.testAuth }}', true))
-      continueOnError: true
+    # # necessary for auth testing in next case
+    # - task: AzureKeyVault@2
+    #   inputs:
+    #       azureSubscription: $(azureSubscription)
+    #       KeyVaultName: $(keyVaultName)
+    #       SecretsFilter: $(secretsFilter)
+    #       RunAsPreJob: false
+    #   condition: and(succeededOrFailed(), eq('${{ parameters.testAuth }}', true))
+    #   continueOnError: true
 
     - task: ${{ parameters.taskUnderTest }}
       displayName: '[should fail] case 12: url, azure portal auth test'
       inputs:
           url: 'https://portal.azure.com'
-          serviceAccountName: $($(usernameKvName))
-          serviceAccountPassword: $($(passwordKvName))
+          serviceAccountName: $(a11yinsscan-service-acct-username)
+          serviceAccountPassword: $(a11yinsscan-service-acct-password)
           authType: 'AAD'
           outputArtifactName: 'accessibility-reports-case-12'
       condition: and(succeededOrFailed(), eq('${{ parameters.testAuth }}', true))

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -121,16 +121,6 @@ steps:
       condition: succeededOrFailed()
       continueOnError: true
 
-    # # necessary for auth testing in next case
-    # - task: AzureKeyVault@2
-    #   inputs:
-    #       azureSubscription: $(azureSubscription)
-    #       KeyVaultName: $(keyVaultName)
-    #       SecretsFilter: $(secretsFilter)
-    #       RunAsPreJob: false
-    #   condition: and(succeededOrFailed(), eq('${{ parameters.testAuth }}', true))
-    #   continueOnError: true
-
     - task: ${{ parameters.taskUnderTest }}
       displayName: '[should fail] case 12: url, azure portal auth test'
       inputs:

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -15,6 +15,9 @@ parameters:
       type: boolean
       default: false
 
+variables:
+    - group: 'ado-extension-canary'
+
 steps:
     # reused by all "url" cases
     - script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -122,7 +122,7 @@ steps:
       continueOnError: true
 
     - task: ${{ parameters.taskUnderTest }}
-      displayName: '[should fail] case 12: url, azure portal auth test'
+      displayName: 'case 12: url, azure portal auth test'
       inputs:
           url: 'https://portal.azure.com'
           serviceAccountName: $(a11yinsscan-service-acct-username)


### PR DESCRIPTION
#### Details

This adds auth testing to the canary pipeline. It uses a variable group to supply the service account credentials to the pipeline.

Here is a [run of the new canary pipeline](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=40041&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=68db983b-a3f3-5e3d-e1bc-86012b574de0)

##### Motivation

Feature work

##### Context

Both the canary and staging pipelines were setup to run on PR, but were running against the canary and staging extensions respectively. This doesn't make sense as it doesn't test the actual changes in the PR, it only tests the already published staging or canary extension. Due to this I've removed the PR trigger but left the resources trigger that will run the pipeline after the staging and canary extensions finish publishing.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran prechecking (`yarn prechecking`)
