### PR TITLE
fix: Update links to extension docs with aka.ms links

### DIFF
--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -182,7 +182,7 @@ export class ADOTaskConfig extends TaskConfig {
     }
 
     public getUsageDocsUrl(): string {
-        const url = 'https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md';
+        const url = 'https://aka.ms/ado-extension-usage';
         return url;
     }
 }

--- a/packages/shared/src/console-output/__snapshots__/result-console-log-builder.spec.ts.snap
+++ b/packages/shared/src/console-output/__snapshots__/result-console-log-builder.spec.ts.snap
@@ -72,7 +72,7 @@ No failures were detected by automatic scanning except those which exist in the 
 Next step: Manually assess keyboard accessibility with Accessibility Insights Tab Stops (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 6 failure instances in baseline
-(not shown; see baselining docs (https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file))
+(not shown; see baselining docs (https://aka.ms/ado-extension-usage-baseline))
 
 To see all failures and scan details, download the accessibility report (artifacts-url)
 
@@ -97,7 +97,7 @@ Accessibility Insights
 * (1) rule id:  rule description
 
 9 failure instances in baseline
-(not shown; see baselining docs (https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
+(not shown; see baselining docs (https://aka.ms/ado-extension-usage-baseline) for how to integrate your changes into the baseline)
 
 To see all failures and scan details, download the accessibility report (artifacts-url)
 
@@ -121,7 +121,7 @@ Accessibility Insights
 0 failure instances not in baseline
 
 9 failure instances in baseline
-(not shown; see baselining docs (https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
+(not shown; see baselining docs (https://aka.ms/ado-extension-usage-baseline) for how to integrate your changes into the baseline)
 
 To see all failures and scan details, download the accessibility report (artifacts-url)
 
@@ -144,7 +144,7 @@ Accessibility Insights
 * (1) rule id 2:  rule description 2
 
 2 failure instances in baseline
-(not shown; see baselining docs (https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
+(not shown; see baselining docs (https://aka.ms/ado-extension-usage-baseline) for how to integrate your changes into the baseline)
 
 To see all failures and scan details, download the accessibility report (artifacts-url)
 
@@ -168,7 +168,7 @@ No failures were detected by automatic scanning except those which exist in the 
 Next step: Manually assess keyboard accessibility with Accessibility Insights Tab Stops (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 1 failure instances in baseline
-(not shown; see baselining docs (https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file))
+(not shown; see baselining docs (https://aka.ms/ado-extension-usage-baseline))
 
 To see all failures and scan details, download the accessibility report (artifacts-url)
 
@@ -191,7 +191,7 @@ Accessibility Insights
 * (1) rule id 2:  rule description 2
 
 Baseline not detected
-To update the baseline with these changes, copy the updated baseline file to scan arguments (artifacts-url). See baselining docs (https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+To update the baseline with these changes, copy the updated baseline file to scan arguments (artifacts-url). See baselining docs (https://aka.ms/ado-extension-usage-baseline) for more.
 
 To see all failures and scan details, download the accessibility report (artifacts-url)
 
@@ -214,7 +214,7 @@ Accessibility Insights
 * (1) rule id 2:  rule description 2
 
 Baseline not detected
-To update the baseline with these changes, copy the updated baseline file to scan arguments (artifacts-url). See baselining docs (https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+To update the baseline with these changes, copy the updated baseline file to scan arguments (artifacts-url). See baselining docs (https://aka.ms/ado-extension-usage-baseline) for more.
 
 To see all failures and scan details, download the accessibility report (artifacts-url)
 
@@ -261,7 +261,7 @@ No failures were detected by automatic scanning.
 Next step: Manually assess keyboard accessibility with Accessibility Insights Tab Stops (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 Baseline not configured
-A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See baselining docs (https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See baselining docs (https://aka.ms/ado-extension-usage-baseline) for more.
 
 To see scan details, download the accessibility report (artifacts-url)
 
@@ -285,7 +285,7 @@ No failures were detected by automatic scanning.
 Next step: Manually assess keyboard accessibility with Accessibility Insights Tab Stops (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 Baseline not detected
-To update the baseline with these changes, copy the updated baseline file to scan arguments (artifacts-url). See baselining docs (https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+To update the baseline with these changes, copy the updated baseline file to scan arguments (artifacts-url). See baselining docs (https://aka.ms/ado-extension-usage-baseline) for more.
 
 To see scan details, download the accessibility report (artifacts-url)
 
@@ -308,7 +308,7 @@ Accessibility Insights
 * (1) rule id 2:  rule description 2
 
 Baseline not configured
-A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See baselining docs (https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See baselining docs (https://aka.ms/ado-extension-usage-baseline) for more.
 
 To see all failures and scan details, download the accessibility report (artifacts-url)
 

--- a/packages/shared/src/console-output/result-console-log-builder.ts
+++ b/packages/shared/src/console-output/result-console-log-builder.ts
@@ -88,7 +88,7 @@ export class ResultConsoleLogBuilder {
     private baselineDetails = (baselineInfo: BaselineInfo): string => {
         const baselineFileName = baselineInfo.baselineFileName;
         const baselineEvaluation = baselineInfo.baselineEvaluation;
-        const baseliningDocsUrl = `https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file`;
+        const baseliningDocsUrl = `https://aka.ms/ado-extension-usage-baseline`;
         const baseliningDocsLink = link(baseliningDocsUrl, 'baselining docs');
         const scanArgumentsLink = link(this.artifactsInfoProvider.getArtifactsUrl(), 'scan arguments');
         const baselineNotConfiguredHelpText = `A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See ${baseliningDocsLink} for more.`;

--- a/packages/shared/src/input-validator.spec.ts
+++ b/packages/shared/src/input-validator.spec.ts
@@ -46,7 +46,7 @@ describe(InputValidator, () => {
             setupLoggerWithErrorMessage(errorMessage);
             setupTelemetryClientWithEvent(errorMessage);
 
-            const usageLink = 'https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md';
+            const usageLink = 'https://aka.ms/ado-extension-usage';
             setupGetUsageDocsUrl(usageLink);
             setupLoggerWithInfoMessage(`usage documentation (${usageLink})`);
 
@@ -67,7 +67,7 @@ describe(InputValidator, () => {
             setupLoggerWithErrorMessage(errorMessage);
             setupTelemetryClientWithEvent(errorMessage);
 
-            const usageLink = 'https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md';
+            const usageLink = 'https://aka.ms/ado-extension-usage';
             setupGetUsageDocsUrl(usageLink);
             setupLoggerWithInfoMessage(`usage documentation (${usageLink})`);
 
@@ -88,7 +88,7 @@ describe(InputValidator, () => {
             setupLoggerWithErrorMessage(errorMessage);
             setupTelemetryClientWithEvent(errorMessage);
 
-            const usageLink = 'https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md';
+            const usageLink = 'https://aka.ms/ado-extension-usage';
             setupGetUsageDocsUrl(usageLink);
             setupLoggerWithInfoMessage(`usage documentation (${usageLink})`);
 
@@ -110,7 +110,7 @@ describe(InputValidator, () => {
             setupLoggerWithErrorMessage(errorMessage);
             setupTelemetryClientWithEvent(errorMessage);
 
-            const usageLink = 'https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md';
+            const usageLink = 'https://aka.ms/ado-extension-usage';
             setupGetUsageDocsUrl(usageLink);
             setupLoggerWithInfoMessage(`usage documentation (${usageLink})`);
 
@@ -133,7 +133,7 @@ describe(InputValidator, () => {
             setupLoggerWithErrorMessage(errorMessage);
             setupTelemetryClientWithEvent(errorMessage);
 
-            const usageLink = 'https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md';
+            const usageLink = 'https://aka.ms/ado-extension-usage';
             setupGetUsageDocsUrl(usageLink);
             setupLoggerWithInfoMessage(`usage documentation (${usageLink})`);
 
@@ -161,7 +161,7 @@ describe(InputValidator, () => {
             setupGetStaticSitePort(undefined);
             setupGetUrl(undefined);
 
-            const usageLink = 'https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md';
+            const usageLink = 'https://aka.ms/ado-extension-usage';
             setupGetUsageDocsUrl(usageLink);
 
             inputValidator = buildInputValidatorWithMocks();
@@ -176,7 +176,7 @@ describe(InputValidator, () => {
             setupGetUrl('url');
             setupInputName('hosting-mode', 'HostingMode');
 
-            const usageLink = 'https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md';
+            const usageLink = 'https://aka.ms/ado-extension-usage';
             setupGetUsageDocsUrl(usageLink);
 
             inputValidator = buildInputValidatorWithMocks();
@@ -190,7 +190,7 @@ describe(InputValidator, () => {
             setupGetStaticSitePort(undefined);
             setupGetUrl('url');
 
-            const usageLink = 'https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md';
+            const usageLink = 'https://aka.ms/ado-extension-usage';
             setupGetUsageDocsUrl(usageLink);
 
             inputValidator = buildInputValidatorWithMocks();

--- a/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
+++ b/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
@@ -115,7 +115,7 @@ No failures were detected by automatic scanning except those which exist in the 
 **👉 Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **6 failure instances in baseline**
-(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file))
+(not shown; see [baselining docs](https://aka.ms/ado-extension-usage-baseline))
 
 To see all failures and scan details, [download the accessibility report](artifacts-url)
 
@@ -137,7 +137,7 @@ No failures were detected by automatic scanning except those which exist in the 
 **:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **6 failure instances in baseline**
-(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file))
+(not shown; see [baselining docs](https://aka.ms/ado-extension-usage-baseline))
 
 To see all failures and scan details, [download the accessibility report](artifacts-url)
 
@@ -160,7 +160,7 @@ exports[`ResultMarkdownBuilder with baseline builds content when some baseline f
 * (1) **rule id**:  rule description
 
 **9 failure instances in baseline**
-(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
+(not shown; see [baselining docs](https://aka.ms/ado-extension-usage-baseline) for how to integrate your changes into the baseline)
 
 To see all failures and scan details, [download the accessibility report](artifacts-url)
 
@@ -183,7 +183,7 @@ exports[`ResultMarkdownBuilder with baseline builds content when some baseline f
 * (1) **rule id**:  rule description
 
 **9 failure instances in baseline**
-(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
+(not shown; see [baselining docs](https://aka.ms/ado-extension-usage-baseline) for how to integrate your changes into the baseline)
 
 To see all failures and scan details, [download the accessibility report](artifacts-url)
 
@@ -205,7 +205,7 @@ exports[`ResultMarkdownBuilder with baseline builds content when some baseline f
 **0 failure instances not in baseline**
 
 **9 failure instances in baseline**
-(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
+(not shown; see [baselining docs](https://aka.ms/ado-extension-usage-baseline) for how to integrate your changes into the baseline)
 
 To see all failures and scan details, [download the accessibility report](artifacts-url)
 
@@ -227,7 +227,7 @@ exports[`ResultMarkdownBuilder with baseline builds content when some baseline f
 **0 failure instances not in baseline**
 
 **9 failure instances in baseline**
-(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
+(not shown; see [baselining docs](https://aka.ms/ado-extension-usage-baseline) for how to integrate your changes into the baseline)
 
 To see all failures and scan details, [download the accessibility report](artifacts-url)
 
@@ -248,7 +248,7 @@ exports[`ResultMarkdownBuilder with baseline builds content when there are basel
 * (1) **rule id 2**:  rule description 2
 
 **2 failure instances in baseline**
-(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
+(not shown; see [baselining docs](https://aka.ms/ado-extension-usage-baseline) for how to integrate your changes into the baseline)
 
 To see all failures and scan details, [download the accessibility report](artifacts-url)
 
@@ -269,7 +269,7 @@ exports[`ResultMarkdownBuilder with baseline builds content when there are basel
 * (1) **rule id 2**:  rule description 2
 
 **2 failure instances in baseline**
-(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
+(not shown; see [baselining docs](https://aka.ms/ado-extension-usage-baseline) for how to integrate your changes into the baseline)
 
 To see all failures and scan details, [download the accessibility report](artifacts-url)
 
@@ -291,7 +291,7 @@ No failures were detected by automatic scanning except those which exist in the 
 **👉 Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **1 failure instances in baseline**
-(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file))
+(not shown; see [baselining docs](https://aka.ms/ado-extension-usage-baseline))
 
 To see all failures and scan details, [download the accessibility report](artifacts-url)
 
@@ -313,7 +313,7 @@ No failures were detected by automatic scanning except those which exist in the 
 **:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **1 failure instances in baseline**
-(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file))
+(not shown; see [baselining docs](https://aka.ms/ado-extension-usage-baseline))
 
 To see all failures and scan details, [download the accessibility report](artifacts-url)
 
@@ -334,7 +334,7 @@ exports[`ResultMarkdownBuilder with baseline builds content when there are new f
 * (1) **rule id 2**:  rule description 2
 
 **Baseline not detected**
-To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://aka.ms/ado-extension-usage-baseline) for more.
 
 To see all failures and scan details, [download the accessibility report](artifacts-url)
 
@@ -355,7 +355,7 @@ exports[`ResultMarkdownBuilder with baseline builds content when there are new f
 * (1) **rule id 2**:  rule description 2
 
 **Baseline not detected**
-To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://aka.ms/ado-extension-usage-baseline) for more.
 
 To see all failures and scan details, [download the accessibility report](artifacts-url)
 
@@ -376,7 +376,7 @@ exports[`ResultMarkdownBuilder with baseline builds content when there are new f
 * (1) **rule id 2**:  rule description 2
 
 **Baseline not detected**
-To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://aka.ms/ado-extension-usage-baseline) for more.
 
 To see all failures and scan details, [download the accessibility report](artifacts-url)
 
@@ -397,7 +397,7 @@ exports[`ResultMarkdownBuilder with baseline builds content when there are new f
 * (1) **rule id 2**:  rule description 2
 
 **Baseline not detected**
-To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://aka.ms/ado-extension-usage-baseline) for more.
 
 To see all failures and scan details, [download the accessibility report](artifacts-url)
 
@@ -461,7 +461,7 @@ No failures were detected by automatic scanning.
 **👉 Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **Baseline not configured**
-A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See [baselining docs](https://aka.ms/ado-extension-usage-baseline) for more.
 
 To see scan details, [download the accessibility report](artifacts-url)
 
@@ -483,7 +483,7 @@ No failures were detected by automatic scanning.
 **:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **Baseline not configured**
-A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See [baselining docs](https://aka.ms/ado-extension-usage-baseline) for more.
 
 To see scan details, [download the accessibility report](artifacts-url)
 
@@ -505,7 +505,7 @@ No failures were detected by automatic scanning.
 **👉 Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **Baseline not detected**
-To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://aka.ms/ado-extension-usage-baseline) for more.
 
 To see scan details, [download the accessibility report](artifacts-url)
 
@@ -527,7 +527,7 @@ No failures were detected by automatic scanning.
 **:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **Baseline not detected**
-To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://aka.ms/ado-extension-usage-baseline) for more.
 
 To see scan details, [download the accessibility report](artifacts-url)
 
@@ -548,7 +548,7 @@ exports[`ResultMarkdownBuilder with baseline builds content when there is no bas
 * (1) **rule id 2**:  rule description 2
 
 **Baseline not configured**
-A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See [baselining docs](https://aka.ms/ado-extension-usage-baseline) for more.
 
 To see all failures and scan details, [download the accessibility report](artifacts-url)
 
@@ -569,7 +569,7 @@ exports[`ResultMarkdownBuilder with baseline builds content when there is no bas
 * (1) **rule id 2**:  rule description 2
 
 **Baseline not configured**
-A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
+A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See [baselining docs](https://aka.ms/ado-extension-usage-baseline) for more.
 
 To see all failures and scan details, [download the accessibility report](artifacts-url)
 

--- a/packages/shared/src/mark-down/result-markdown-builder.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.ts
@@ -94,7 +94,7 @@ export class ResultMarkdownBuilder {
     private baselineDetails = (baselineInfo: BaselineInfo): string => {
         const baselineFileName = baselineInfo.baselineFileName;
         const baselineEvaluation = baselineInfo.baselineEvaluation;
-        const baseliningDocsUrl = `https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file`;
+        const baseliningDocsUrl = `https://aka.ms/ado-extension-usage-baseline`;
         const baseliningDocsLink = link(baseliningDocsUrl, 'baselining docs');
         const scanArgumentsLink = link(this.artifactsInfoProvider.getArtifactsUrl(), 'scan arguments');
         const baselineNotConfiguredHelpText = `A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See ${baseliningDocsLink} for more.`;


### PR DESCRIPTION
#### Details

Updates a few hardcoded documentation links with aka.ms links. This will not only allow us to direct users to the new documentation page, but also allow us to update the target in the future without needing to release the extension.

##### Motivation

Keep documentation references up-to-date

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- ~~[ ] Described how this PR impacts both the ADO extension and the GitHub action~~
