### PR TITLE
feat(decommission-gh-action): Remove action specific code from shared package

### DIFF
--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.spec.ts
@@ -47,7 +47,7 @@ describe(AdoConsoleCommentCreator, () => {
         pathStub = { join: (...paths) => paths.join('/'), basename: (filepath) => baselineFilenameStub } as typeof path;
 
         reportMarkdownConvertorMock
-            .setup((o) => o.convert(reportStub, 'ADO', undefined, baselineInfoStub))
+            .setup((o) => o.convert(reportStub, undefined, baselineInfoStub))
             .returns(() => reportMarkdownStub)
             .verifiable(Times.atMostOnce());
 
@@ -165,7 +165,7 @@ describe(AdoConsoleCommentCreator, () => {
                 const baselineInfoWithEvalStub = { baselineFileName: baselineFilenameStub, baselineEvaluation: baselineEvaluationStub };
 
                 reportMarkdownConvertorMock
-                    .setup((o) => o.convert(reportStub, 'ADO', undefined, baselineInfoWithEvalStub))
+                    .setup((o) => o.convert(reportStub, undefined, baselineInfoWithEvalStub))
                     .returns(() => reportMarkdownStub)
                     .verifiable(Times.atMostOnce());
 

--- a/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
+++ b/packages/ado-extension/src/progress-reporter/console/ado-console-comment-creator.ts
@@ -59,7 +59,7 @@ export class AdoConsoleCommentCreator extends ProgressReporter {
         combinedReportResult: CombinedReportParameters,
         baselineInfo?: BaselineInfo,
     ): void {
-        const reportMarkdown = this.reportMarkdownConvertor.convert(combinedReportResult, 'ADO', undefined, baselineInfo);
+        const reportMarkdown = this.reportMarkdownConvertor.convert(combinedReportResult, undefined, baselineInfo);
         const outDirectory = this.taskConfig.getReportOutDir();
 
         const summaryFilePath = this.pathObj.join(outDirectory, this.summaryMarkdownFileName(artifactName));

--- a/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
+++ b/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
@@ -13,19 +13,6 @@ exports[`ResultMarkdownBuilder builds content with failures, executionEnv: ADO 1
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder builds content with failures, executionEnv: github 1`] = `
-"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
-* **URLs**: 5 URL(s) failed, 1 URL(s) passed, and 7 were not scannable
-* **Rules**: 2 check(s) failed, 1 check(s) passed, and 2 were not applicable
-* Download the **Accessibility Insights artifact** to view the detailed results of these checks
-#### Failed instances
-* **3 × rule id**:  rule description
-* **1 × rule id 2**:  rule description 2
-
----
-This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
-`;
-
 exports[`ResultMarkdownBuilder builds content with no failures, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights: All applicable checks passed
 * **URLs**: 1 URL(s) passed, and 7 were not scannable
@@ -35,26 +22,7 @@ exports[`ResultMarkdownBuilder builds content with no failures, executionEnv: AD
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder builds content with no failures, executionEnv: github 1`] = `
-"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights: All applicable checks passed
-* **URLs**: 1 URL(s) passed, and 7 were not scannable
-* **Rules**: 1 check(s) passed, and 2 were not applicable
-* Download the **Accessibility Insights artifact** to view the detailed results of these checks
----
-This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
-`;
-
 exports[`ResultMarkdownBuilder builds content with title, executionEnv: ADO 1`] = `
-"### some title
-### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights: All applicable checks passed
-* **URLs**: 1 URL(s) passed, and 7 were not scannable
-* **Rules**: 1 check(s) passed, and 2 were not applicable
-* Download the **Accessibility Insights artifact** to view the detailed results of these checks
----
-This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
-`;
-
-exports[`ResultMarkdownBuilder builds content with title, executionEnv: github 1`] = `
 "### some title
 ### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights: All applicable checks passed
 * **URLs**: 1 URL(s) passed, and 7 were not scannable
@@ -89,23 +57,6 @@ No failures were detected by automatic scanning.
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder uploadOutputArtifact is false skips artifact link line when artifactsUrl returns undefined, executionEnv: github 1`] = `
-"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
-
-**:white_check_mark: No failures detected**
-No failures were detected by automatic scanning.
-
-**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
-
----
-#### Scan summary
-**URLs**: 0 with failures, 1 passed, 7 not scannable
-**Rules**: 0 with failures, 1 passed, 2 not applicable
-
----
-This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
-`;
-
 exports[`ResultMarkdownBuilder with baseline builds content when baseline failures and scanned failures are the same (no new failures, executionEnv: ADO) 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
@@ -128,52 +79,7 @@ To see all failures and scan details, [download the accessibility report](artifa
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when baseline failures and scanned failures are the same (no new failures, executionEnv: github) 1`] = `
-"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
-
-**:white_check_mark: No new failures**
-No failures were detected by automatic scanning except those which exist in the baseline.
-
-**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
-
-**6 failure instances in baseline**
-(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file))
-
-To see all failures and scan details, [download the accessibility report](artifacts-url)
-
----
-#### Scan summary
-**URLs**: 5 with failures, 1 passed, 7 not scannable
-**Rules**: 2 with failures, 1 passed, 2 not applicable
-
----
-This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
-`;
-
 exports[`ResultMarkdownBuilder with baseline builds content when some baseline failures have been fixed and some new ones have been introduced, executionEnv: ADO 1`] = `
-"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
-**3 failure instances from baseline no longer exist:**
-* (2) **rule id**
-* (1) **rule id 2**
-
-**1 failure instances not in baseline**
-* (1) **rule id**:  rule description
-
-**9 failure instances in baseline**
-(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
-
-To see all failures and scan details, [download the accessibility report](artifacts-url)
-
----
-#### Scan summary
-**URLs**: 5 with failures, 1 passed, 7 not scannable
-**Rules**: 2 with failures, 1 passed, 2 not applicable
-
----
-This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
-`;
-
-exports[`ResultMarkdownBuilder with baseline builds content when some baseline failures have been fixed and some new ones have been introduced, executionEnv: github 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 **3 failure instances from baseline no longer exist:**
 * (2) **rule id**
@@ -218,50 +124,7 @@ To see all failures and scan details, [download the accessibility report](artifa
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when some baseline failures have been fixed and some still occur, executionEnv: github 1`] = `
-"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
-**3 failure instances from baseline no longer exist:**
-* (2) **rule id**
-* (1) **rule id 2**
-
-**0 failure instances not in baseline**
-
-**9 failure instances in baseline**
-(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
-
-To see all failures and scan details, [download the accessibility report](artifacts-url)
-
----
-#### Scan summary
-**URLs**: 5 with failures, 1 passed, 7 not scannable
-**Rules**: 2 with failures, 1 passed, 2 not applicable
-
----
-This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
-`;
-
 exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and new failures, executionEnv: ADO 1`] = `
-"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
-
-**4 failure instances not in baseline**
-* (3) **rule id**:  rule description
-* (1) **rule id 2**:  rule description 2
-
-**2 failure instances in baseline**
-(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for how to integrate your changes into the baseline)
-
-To see all failures and scan details, [download the accessibility report](artifacts-url)
-
----
-#### Scan summary
-**URLs**: 5 with failures, 1 passed, 7 not scannable
-**Rules**: 2 with failures, 1 passed, 2 not applicable
-
----
-This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
-`;
-
-exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and new failures, executionEnv: github 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **4 failure instances not in baseline**
@@ -304,50 +167,7 @@ To see all failures and scan details, [download the accessibility report](artifa
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and no additional failures, executionEnv: github 1`] = `
-"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
-
-**:white_check_mark: No new failures**
-No failures were detected by automatic scanning except those which exist in the baseline.
-
-**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
-
-**1 failure instances in baseline**
-(not shown; see [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file))
-
-To see all failures and scan details, [download the accessibility report](artifacts-url)
-
----
-#### Scan summary
-**URLs**: 0 with failures, 1 passed, 7 not scannable
-**Rules**: 0 with failures, 1 passed, 2 not applicable
-
----
-This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
-`;
-
 exports[`ResultMarkdownBuilder with baseline builds content when there are new failures and no baseline detected, executionEnv: ADO 1`] = `
-"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
-
-**6 failure instances**
-* (5) **rule id**:  rule description
-* (1) **rule id 2**:  rule description 2
-
-**Baseline not detected**
-To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
-
-To see all failures and scan details, [download the accessibility report](artifacts-url)
-
----
-#### Scan summary
-**URLs**: 5 with failures, 1 passed, 7 not scannable
-**Rules**: 2 with failures, 1 passed, 2 not applicable
-
----
-This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
-`;
-
-exports[`ResultMarkdownBuilder with baseline builds content when there are new failures and no baseline detected, executionEnv: github 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **6 failure instances**
@@ -389,27 +209,6 @@ To see all failures and scan details, [download the accessibility report](artifa
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are new failures and no baseline failures, executionEnv: github 1`] = `
-"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
-
-**6 failure instances**
-* (5) **rule id**:  rule description
-* (1) **rule id 2**:  rule description 2
-
-**Baseline not detected**
-To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
-
-To see all failures and scan details, [download the accessibility report](artifacts-url)
-
----
-#### Scan summary
-**URLs**: 5 with failures, 1 passed, 7 not scannable
-**Rules**: 2 with failures, 1 passed, 2 not applicable
-
----
-This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
-`;
-
 exports[`ResultMarkdownBuilder with baseline builds content when there are no baseline failures and no new failures, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
@@ -431,27 +230,6 @@ To see scan details, [download the accessibility report](artifacts-url)
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are no baseline failures and no new failures, executionEnv: github 1`] = `
-"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
-
-**:white_check_mark: No failures detected**
-No failures were detected by automatic scanning.
-
-**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
-
-
-
-To see scan details, [download the accessibility report](artifacts-url)
-
----
-#### Scan summary
-**URLs**: 0 with failures, 1 passed, 7 not scannable
-**Rules**: 0 with failures, 1 passed, 2 not applicable
-
----
-This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
-`;
-
 exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and baseline failures are undefined, executionEnv: ADO 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
@@ -459,28 +237,6 @@ exports[`ResultMarkdownBuilder with baseline builds content when there are no ne
 No failures were detected by automatic scanning.
 
 **👉 Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
-
-**Baseline not configured**
-A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
-
-To see scan details, [download the accessibility report](artifacts-url)
-
----
-#### Scan summary
-**URLs**: 0 with failures, 1 passed, 7 not scannable
-**Rules**: 0 with failures, 1 passed, 2 not applicable
-
----
-This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
-`;
-
-exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and baseline failures are undefined, executionEnv: github 1`] = `
-"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
-
-**:white_check_mark: No failures detected**
-No failures were detected by automatic scanning.
-
-**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
 
 **Baseline not configured**
 A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
@@ -518,50 +274,7 @@ To see scan details, [download the accessibility report](artifacts-url)
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and no baseline detected, executionEnv: github 1`] = `
-"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
-
-**:white_check_mark: No failures detected**
-No failures were detected by automatic scanning.
-
-**:point_right: Next step:** Manually assess keyboard accessibility with [Accessibility Insights Tab Stops](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/#complete-the-manual-test-for-tab-stops)
-
-**Baseline not detected**
-To update the baseline with these changes, copy the updated baseline file to [scan arguments](artifacts-url). See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
-
-To see scan details, [download the accessibility report](artifacts-url)
-
----
-#### Scan summary
-**URLs**: 0 with failures, 1 passed, 7 not scannable
-**Rules**: 0 with failures, 1 passed, 2 not applicable
-
----
-This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
-`;
-
 exports[`ResultMarkdownBuilder with baseline builds content when there is no baseline configured, executionEnv: ADO 1`] = `
-"### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
-
-**6 failure instances**
-* (5) **rule id**:  rule description
-* (1) **rule id 2**:  rule description 2
-
-**Baseline not configured**
-A baseline lets you mark known failures so it's easier to identify new failures as they're introduced. See [baselining docs](https://github.com/microsoft/accessibility-insights-action/blob/main/docs/ado-extension-usage.md#using-a-baseline-file) for more.
-
-To see all failures and scan details, [download the accessibility report](artifacts-url)
-
----
-#### Scan summary
-**URLs**: 5 with failures, 1 passed, 7 not scannable
-**Rules**: 2 with failures, 1 passed, 2 not applicable
-
----
-This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
-`;
-
-exports[`ResultMarkdownBuilder with baseline builds content when there is no baseline configured, executionEnv: github 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **6 failure instances**

--- a/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
+++ b/packages/shared/src/mark-down/__snapshots__/result-markdown-builder.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ResultMarkdownBuilder builds content with failures, executionEnv: ADO 1`] = `
+exports[`ResultMarkdownBuilder builds content with failures 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 * **URLs**: 5 URL(s) failed, 1 URL(s) passed, and 7 were not scannable
 * **Rules**: 2 check(s) failed, 1 check(s) passed, and 2 were not applicable
@@ -13,7 +13,7 @@ exports[`ResultMarkdownBuilder builds content with failures, executionEnv: ADO 1
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder builds content with no failures, executionEnv: ADO 1`] = `
+exports[`ResultMarkdownBuilder builds content with no failures 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights: All applicable checks passed
 * **URLs**: 1 URL(s) passed, and 7 were not scannable
 * **Rules**: 1 check(s) passed, and 2 were not applicable
@@ -22,7 +22,7 @@ exports[`ResultMarkdownBuilder builds content with no failures, executionEnv: AD
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder builds content with title, executionEnv: ADO 1`] = `
+exports[`ResultMarkdownBuilder builds content with title 1`] = `
 "### some title
 ### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights: All applicable checks passed
 * **URLs**: 1 URL(s) passed, and 7 were not scannable
@@ -40,7 +40,7 @@ You can review the log to troubleshoot the issue. Fix it and re-run the workflow
 "
 `;
 
-exports[`ResultMarkdownBuilder uploadOutputArtifact is false skips artifact link line when artifactsUrl returns undefined, executionEnv: ADO 1`] = `
+exports[`ResultMarkdownBuilder uploadOutputArtifact is false skips artifact link line when artifactsUrl returns undefined 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **✅ No failures detected**
@@ -57,7 +57,7 @@ No failures were detected by automatic scanning.
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when baseline failures and scanned failures are the same (no new failures, executionEnv: ADO) 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when baseline failures and scanned failures are the same (no new failures) 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **✅ No new failures**
@@ -79,7 +79,7 @@ To see all failures and scan details, [download the accessibility report](artifa
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when some baseline failures have been fixed and some new ones have been introduced, executionEnv: ADO 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when some baseline failures have been fixed and some new ones have been introduced 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 **3 failure instances from baseline no longer exist:**
 * (2) **rule id**
@@ -102,7 +102,7 @@ To see all failures and scan details, [download the accessibility report](artifa
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when some baseline failures have been fixed and some still occur, executionEnv: ADO 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when some baseline failures have been fixed and some still occur 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 **3 failure instances from baseline no longer exist:**
 * (2) **rule id**
@@ -124,7 +124,7 @@ To see all failures and scan details, [download the accessibility report](artifa
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and new failures, executionEnv: ADO 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and new failures 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **4 failure instances not in baseline**
@@ -145,7 +145,7 @@ To see all failures and scan details, [download the accessibility report](artifa
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and no additional failures, executionEnv: ADO 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when there are baseline failures and no additional failures 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **✅ No new failures**
@@ -167,7 +167,7 @@ To see all failures and scan details, [download the accessibility report](artifa
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are new failures and no baseline detected, executionEnv: ADO 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when there are new failures and no baseline detected 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **6 failure instances**
@@ -188,7 +188,7 @@ To see all failures and scan details, [download the accessibility report](artifa
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are new failures and no baseline failures, executionEnv: ADO 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when there are new failures and no baseline failures 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **6 failure instances**
@@ -209,7 +209,7 @@ To see all failures and scan details, [download the accessibility report](artifa
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are no baseline failures and no new failures, executionEnv: ADO 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when there are no baseline failures and no new failures 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **✅ No failures detected**
@@ -230,7 +230,7 @@ To see scan details, [download the accessibility report](artifacts-url)
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and baseline failures are undefined, executionEnv: ADO 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and baseline failures are undefined 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **✅ No failures detected**
@@ -252,7 +252,7 @@ To see scan details, [download the accessibility report](artifacts-url)
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and no baseline detected, executionEnv: ADO 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when there are no new failures and no baseline detected 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **✅ No failures detected**
@@ -274,7 +274,7 @@ To see scan details, [download the accessibility report](artifacts-url)
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) with userAgent."
 `;
 
-exports[`ResultMarkdownBuilder with baseline builds content when there is no baseline configured, executionEnv: ADO 1`] = `
+exports[`ResultMarkdownBuilder with baseline builds content when there is no baseline configured 1`] = `
 "### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 
 **6 failure instances**

--- a/packages/shared/src/mark-down/report-markdown-convertor.spec.ts
+++ b/packages/shared/src/mark-down/report-markdown-convertor.spec.ts
@@ -4,7 +4,7 @@ import 'reflect-metadata';
 
 import { IMock, Mock } from 'typemoq';
 import { ReportMarkdownConvertor } from './report-markdown-convertor';
-import { ExecutionEnvironment, ResultMarkdownBuilder } from './result-markdown-builder';
+import { ResultMarkdownBuilder } from './result-markdown-builder';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 import { BaselineEvaluation } from 'accessibility-insights-scan';
 
@@ -12,7 +12,6 @@ describe(ReportMarkdownConvertor, () => {
     let resultMarkdownBuilderMock: IMock<ResultMarkdownBuilder>;
     let reportMarkdownConvertor: ReportMarkdownConvertor;
     let combinedReportResult: CombinedReportParameters;
-    const executionEnvArray = ['ADO'];
 
     beforeEach(() => {
         resultMarkdownBuilderMock = Mock.ofType(ResultMarkdownBuilder);
@@ -37,37 +36,27 @@ describe(ReportMarkdownConvertor, () => {
     });
 
     describe('convert', () => {
-        it.each(executionEnvArray)(
-            'should convert with baseline and title undefined and execution env %s',
-            (executionEnv: ExecutionEnvironment) => {
-                resultMarkdownBuilderMock
-                    .setup((o) => o.buildContent(combinedReportResult, executionEnv, undefined, undefined))
-                    .verifiable();
+        it('should convert with baseline and title undefined', () => {
+            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, undefined, undefined)).verifiable();
 
-                reportMarkdownConvertor.convert(combinedReportResult, executionEnv);
-            },
-        );
+            reportMarkdownConvertor.convert(combinedReportResult);
+        });
 
-        it.each(executionEnvArray)(
-            'should convert with baseline and title defined and execution env %s',
-            (executionEnv: ExecutionEnvironment) => {
-                const title = 'some title';
-                resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, executionEnv, title, undefined)).verifiable();
+        it('should convert with baseline and title defined', () => {
+            const title = 'some title';
+            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, title, undefined)).verifiable();
 
-                reportMarkdownConvertor.convert(combinedReportResult, executionEnv, title);
-            },
-        );
+            reportMarkdownConvertor.convert(combinedReportResult, title);
+        });
 
-        it.each(executionEnvArray)('report with baseline, execution env %s', (executionEnv: ExecutionEnvironment) => {
+        it('report with baseline', () => {
             const baselineInfo = {
                 baselineFileName: 'some filename',
                 baselineEvaluationStub: {} as BaselineEvaluation,
             };
-            resultMarkdownBuilderMock
-                .setup((o) => o.buildContent(combinedReportResult, executionEnv, undefined, baselineInfo))
-                .verifiable();
+            resultMarkdownBuilderMock.setup((o) => o.buildContent(combinedReportResult, undefined, baselineInfo)).verifiable();
 
-            reportMarkdownConvertor.convert(combinedReportResult, executionEnv, undefined, baselineInfo);
+            reportMarkdownConvertor.convert(combinedReportResult, undefined, baselineInfo);
         });
     });
 

--- a/packages/shared/src/mark-down/report-markdown-convertor.spec.ts
+++ b/packages/shared/src/mark-down/report-markdown-convertor.spec.ts
@@ -12,7 +12,7 @@ describe(ReportMarkdownConvertor, () => {
     let resultMarkdownBuilderMock: IMock<ResultMarkdownBuilder>;
     let reportMarkdownConvertor: ReportMarkdownConvertor;
     let combinedReportResult: CombinedReportParameters;
-    const executionEnvArray = ['ADO', 'github'];
+    const executionEnvArray = ['ADO'];
 
     beforeEach(() => {
         resultMarkdownBuilderMock = Mock.ofType(ResultMarkdownBuilder);

--- a/packages/shared/src/mark-down/report-markdown-convertor.ts
+++ b/packages/shared/src/mark-down/report-markdown-convertor.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import { ExecutionEnvironment, ResultMarkdownBuilder } from './result-markdown-builder';
+import { ResultMarkdownBuilder } from './result-markdown-builder';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 import { BaselineInfo } from '../baseline-info';
 
@@ -10,13 +10,8 @@ import { BaselineInfo } from '../baseline-info';
 export class ReportMarkdownConvertor {
     constructor(@inject(ResultMarkdownBuilder) private readonly checkResultMarkdownBuilder: ResultMarkdownBuilder) {}
 
-    public convert(
-        combinedReportResult: CombinedReportParameters,
-        executionEnvironment: ExecutionEnvironment,
-        title?: string,
-        baselineInfo?: BaselineInfo,
-    ): string {
-        return this.checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnvironment, title, baselineInfo);
+    public convert(combinedReportResult: CombinedReportParameters, title?: string, baselineInfo?: BaselineInfo): string {
+        return this.checkResultMarkdownBuilder.buildContent(combinedReportResult, title, baselineInfo);
     }
 
     public getErrorMarkdown(): string {

--- a/packages/shared/src/mark-down/result-markdown-builder.spec.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import { ExecutionEnvironment, ResultMarkdownBuilder } from './result-markdown-builder';
+import { ResultMarkdownBuilder } from './result-markdown-builder';
 import { CombinedReportParameters } from 'accessibility-insights-report';
 import * as axe from 'axe-core';
 import * as path from 'path';
@@ -15,7 +15,6 @@ describe(ResultMarkdownBuilder, () => {
     let combinedReportResult: CombinedReportParameters;
     let checkResultMarkdownBuilder: ResultMarkdownBuilder;
     let artifactsInfoProviderMock: IMock<ArtifactsInfoProvider>;
-    const executionEnvArray = ['ADO'];
 
     beforeEach(() => {
         artifactsInfoProviderMock = Mock.ofType<ArtifactsInfoProvider>(undefined, MockBehavior.Strict);
@@ -26,23 +25,23 @@ describe(ResultMarkdownBuilder, () => {
         expect(checkResultMarkdownBuilder.buildErrorContent()).toMatchSnapshot();
     });
 
-    it.each(executionEnvArray)('builds content with failures, executionEnv: %s', (executionEnv: ExecutionEnvironment) => {
+    it('builds content with failures', () => {
         setCombinedReportResultWithFailures();
 
-        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnv);
+        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult);
 
         expect(actualContent).toMatchSnapshot();
     });
 
-    it.each(executionEnvArray)('builds content with no failures, executionEnv: %s', (executionEnv: ExecutionEnvironment) => {
+    it('builds content with no failures', () => {
         setCombinedReportResultWithNoFailures();
 
-        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnv);
+        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult);
 
         expect(actualContent).toMatchSnapshot();
     });
 
-    it.each(executionEnvArray)('escapes content for all possible axe rules, executionEnv: %s', (executionEnv: ExecutionEnvironment) => {
+    it('escapes content for all possible axe rules', () => {
         const failedRules = axe.getRules().map((r) => ({
             ruleId: r.ruleId,
             description: r.description,
@@ -67,17 +66,17 @@ describe(ResultMarkdownBuilder, () => {
             },
         } as CombinedReportParameters;
 
-        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnv);
+        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult);
 
         const snapshotFile = path.join(__dirname, '__custom-snapshots__', 'axe-descriptions.snap.md');
         expect(actualContent).toMatchFile(snapshotFile);
     });
 
-    it.each(executionEnvArray)('builds content with title, executionEnv: %s', (executionEnv: ExecutionEnvironment) => {
+    it('builds content with title', () => {
         const title = 'some title';
         setCombinedReportResultWithNoFailures();
 
-        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnv, title);
+        const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, title);
 
         expect(actualContent).toMatchSnapshot();
     });
@@ -92,251 +91,215 @@ describe(ResultMarkdownBuilder, () => {
                 .verifiable(Times.atLeastOnce());
         });
 
-        it.each(executionEnvArray)(
-            'builds content when there are baseline failures and new failures, executionEnv: %s',
-            (executionEnv: ExecutionEnvironment) => {
-                const baselineEvaluation = {
-                    suggestedBaselineUpdate: {},
-                    totalBaselineViolations: 2,
-                    totalNewViolations: 4,
-                    newViolationsByRule: { 'rule id': 3, 'rule id 2': 1 } as CountsByRule,
-                } as BaselineEvaluation;
-                const baselineInfo: BaselineInfo = {
-                    baselineFileName,
-                    baselineEvaluation,
-                };
-                setCombinedReportResultWithFailures();
+        it('builds content when there are baseline failures and new failures', () => {
+            const baselineEvaluation = {
+                suggestedBaselineUpdate: {},
+                totalBaselineViolations: 2,
+                totalNewViolations: 4,
+                newViolationsByRule: { 'rule id': 3, 'rule id 2': 1 } as CountsByRule,
+            } as BaselineEvaluation;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithFailures();
 
-                const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnv, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
-                expect(actualContent).toMatchSnapshot();
-                verifyAllMocks();
-            },
-        );
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
 
-        it.each(executionEnvArray)(
-            'builds content when baseline failures and scanned failures are the same (no new failures, executionEnv: %s)',
-            (executionEnv: ExecutionEnvironment) => {
-                const baselineEvaluation = {
-                    totalBaselineViolations: 6,
-                    totalNewViolations: 0,
-                } as BaselineEvaluation;
-                const baselineInfo: BaselineInfo = {
-                    baselineFileName,
-                    baselineEvaluation,
-                };
-                setCombinedReportResultWithFailures();
+        it('builds content when baseline failures and scanned failures are the same (no new failures)', () => {
+            const baselineEvaluation = {
+                totalBaselineViolations: 6,
+                totalNewViolations: 0,
+            } as BaselineEvaluation;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithFailures();
 
-                const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnv, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
-                expect(actualContent).toMatchSnapshot();
-                verifyAllMocks();
-            },
-        );
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
 
-        it.each(executionEnvArray)(
-            'builds content when some baseline failures have been fixed and some still occur, executionEnv: %s',
-            (executionEnv: ExecutionEnvironment) => {
-                const baselineEvaluation = {
-                    suggestedBaselineUpdate: {},
-                    totalBaselineViolations: 9,
-                    totalNewViolations: 0,
-                    fixedViolationsByRule: { 'rule id': 2, 'rule id 2': 1 } as CountsByRule,
-                    totalFixedViolations: 3,
-                } as BaselineEvaluation;
-                const baselineInfo: BaselineInfo = {
-                    baselineFileName,
-                    baselineEvaluation,
-                };
-                setCombinedReportResultWithFailures();
+        it('builds content when some baseline failures have been fixed and some still occur', () => {
+            const baselineEvaluation = {
+                suggestedBaselineUpdate: {},
+                totalBaselineViolations: 9,
+                totalNewViolations: 0,
+                fixedViolationsByRule: { 'rule id': 2, 'rule id 2': 1 } as CountsByRule,
+                totalFixedViolations: 3,
+            } as BaselineEvaluation;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithFailures();
 
-                const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnv, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
-                expect(actualContent).toMatchSnapshot();
-                verifyAllMocks();
-            },
-        );
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
 
-        it.each(executionEnvArray)(
-            'builds content when some baseline failures have been fixed and some new ones have been introduced, executionEnv: %s',
-            (executionEnv: ExecutionEnvironment) => {
-                const baselineEvaluation = {
-                    suggestedBaselineUpdate: {},
-                    totalBaselineViolations: 9,
-                    fixedViolationsByRule: { 'rule id': 2, 'rule id 2': 1 } as CountsByRule,
-                    totalNewViolations: 1,
-                    newViolationsByRule: { 'rule id': 1 } as CountsByRule,
-                } as BaselineEvaluation;
-                const baselineInfo: BaselineInfo = {
-                    baselineFileName,
-                    baselineEvaluation,
-                };
-                setCombinedReportResultWithFailures();
+        it('builds content when some baseline failures have been fixed and some new ones have been introduced', () => {
+            const baselineEvaluation = {
+                suggestedBaselineUpdate: {},
+                totalBaselineViolations: 9,
+                fixedViolationsByRule: { 'rule id': 2, 'rule id 2': 1 } as CountsByRule,
+                totalNewViolations: 1,
+                newViolationsByRule: { 'rule id': 1 } as CountsByRule,
+            } as BaselineEvaluation;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithFailures();
 
-                const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnv, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
-                expect(actualContent).toMatchSnapshot();
-                verifyAllMocks();
-            },
-        );
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
 
-        it.each(executionEnvArray)(
-            'builds content when there are baseline failures and no additional failures, executionEnv: %s',
-            (executionEnv: ExecutionEnvironment) => {
-                const baselineEvaluation = {
-                    totalBaselineViolations: 1,
-                    totalNewViolations: 0,
-                } as BaselineEvaluation;
-                const baselineInfo: BaselineInfo = {
-                    baselineFileName,
-                    baselineEvaluation,
-                };
-                setCombinedReportResultWithNoFailures();
+        it('builds content when there are baseline failures and no additional failures', () => {
+            const baselineEvaluation = {
+                totalBaselineViolations: 1,
+                totalNewViolations: 0,
+            } as BaselineEvaluation;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithNoFailures();
 
-                const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnv, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
-                expect(actualContent).toMatchSnapshot();
-                verifyAllMocks();
-            },
-        );
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
 
-        it.each(executionEnvArray)(
-            'builds content when there are no baseline failures and no new failures, executionEnv: %s',
-            (executionEnv: ExecutionEnvironment) => {
-                const baselineEvaluation = {
-                    totalBaselineViolations: 0,
-                } as BaselineEvaluation;
-                const baselineInfo: BaselineInfo = {
-                    baselineFileName,
-                    baselineEvaluation,
-                };
-                setCombinedReportResultWithNoFailures();
+        it('builds content when there are no baseline failures and no new failures', () => {
+            const baselineEvaluation = {
+                totalBaselineViolations: 0,
+            } as BaselineEvaluation;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithNoFailures();
 
-                const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnv, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
-                expect(actualContent).toMatchSnapshot();
-                verifyAllMocks();
-            },
-        );
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
 
-        it.each(executionEnvArray)(
-            'builds content when there are new failures and no baseline failures, executionEnv: %s',
-            (executionEnv: ExecutionEnvironment) => {
-                const baselineEvaluation = {
-                    totalBaselineViolations: 0,
-                    totalNewViolations: 6,
-                    newViolationsByRule: { 'rule id': 5, 'rule id 2': 1 } as CountsByRule,
-                } as BaselineEvaluation;
-                const baselineInfo: BaselineInfo = {
-                    baselineFileName,
-                    baselineEvaluation,
-                };
-                setCombinedReportResultWithFailures();
+        it('builds content when there are new failures and no baseline failures', () => {
+            const baselineEvaluation = {
+                totalBaselineViolations: 0,
+                totalNewViolations: 6,
+                newViolationsByRule: { 'rule id': 5, 'rule id 2': 1 } as CountsByRule,
+            } as BaselineEvaluation;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithFailures();
 
-                const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnv, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
-                expect(actualContent).toMatchSnapshot();
-                verifyAllMocks();
-            },
-        );
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
 
-        it.each(executionEnvArray)(
-            'builds content when there are no new failures and no baseline detected, executionEnv: %s',
-            (executionEnv: ExecutionEnvironment) => {
-                const baselineEvaluation: BaselineEvaluation = undefined;
-                const baselineInfo: BaselineInfo = {
-                    baselineFileName,
-                    baselineEvaluation,
-                };
-                setCombinedReportResultWithNoFailures();
+        it('builds content when there are no new failures and no baseline detected', () => {
+            const baselineEvaluation: BaselineEvaluation = undefined;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithNoFailures();
 
-                const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnv, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
-                expect(actualContent).toMatchSnapshot();
-                verifyAllMocks();
-            },
-        );
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
 
-        it.each(executionEnvArray)(
-            'builds content when there are new failures and no baseline detected, executionEnv: %s',
-            (executionEnv: ExecutionEnvironment) => {
-                const baselineEvaluation: BaselineEvaluation = undefined;
-                const baselineInfo: BaselineInfo = {
-                    baselineFileName,
-                    baselineEvaluation,
-                };
-                setCombinedReportResultWithFailures();
+        it('builds content when there are new failures and no baseline detected', () => {
+            const baselineEvaluation: BaselineEvaluation = undefined;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithFailures();
 
-                const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnv, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
-                expect(actualContent).toMatchSnapshot();
-                verifyAllMocks();
-            },
-        );
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
 
-        it.each(executionEnvArray)(
-            'builds content when there is no baseline configured, executionEnv: %s',
-            (executionEnv: ExecutionEnvironment) => {
-                baselineFileName = undefined;
-                const baselineEvaluation: BaselineEvaluation = undefined;
-                const baselineInfo: BaselineInfo = {
-                    baselineFileName,
-                    baselineEvaluation,
-                };
-                setCombinedReportResultWithFailures();
+        it('builds content when there is no baseline configured', () => {
+            baselineFileName = undefined;
+            const baselineEvaluation: BaselineEvaluation = undefined;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithFailures();
 
-                const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnv, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
-                expect(actualContent).toMatchSnapshot();
-                verifyAllMocks();
-            },
-        );
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
 
-        it.each(executionEnvArray)(
-            'builds content when there are no new failures and baseline failures are undefined, executionEnv: %s',
-            (executionEnv: ExecutionEnvironment) => {
-                const baselineEvaluation = {
-                    totalBaselineViolations: undefined,
-                } as BaselineEvaluation;
-                const baselineInfo: BaselineInfo = {
-                    baselineFileName,
-                    baselineEvaluation,
-                };
-                setCombinedReportResultWithNoFailures();
+        it('builds content when there are no new failures and baseline failures are undefined', () => {
+            const baselineEvaluation = {
+                totalBaselineViolations: undefined,
+            } as BaselineEvaluation;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithNoFailures();
 
-                const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnv, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
-                expect(actualContent).toMatchSnapshot();
-                verifyAllMocks();
-            },
-        );
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
     });
 
     describe('uploadOutputArtifact is false', () => {
         const baselineFileName = 'baseline file';
-        it.each(executionEnvArray)(
-            'skips artifact link line when artifactsUrl returns undefined, executionEnv: %s',
-            (executionEnv: ExecutionEnvironment) => {
-                artifactsInfoProviderMock
-                    .setup((aip) => aip.getArtifactsUrl())
-                    .returns(() => undefined)
-                    .verifiable(Times.atLeastOnce());
+        it('skips artifact link line when artifactsUrl returns undefined', () => {
+            artifactsInfoProviderMock
+                .setup((aip) => aip.getArtifactsUrl())
+                .returns(() => undefined)
+                .verifiable(Times.atLeastOnce());
 
-                const baselineEvaluation = {
-                    totalBaselineViolations: 0,
-                } as BaselineEvaluation;
-                const baselineInfo: BaselineInfo = {
-                    baselineFileName,
-                    baselineEvaluation,
-                };
-                setCombinedReportResultWithNoFailures();
+            const baselineEvaluation = {
+                totalBaselineViolations: 0,
+            } as BaselineEvaluation;
+            const baselineInfo: BaselineInfo = {
+                baselineFileName,
+                baselineEvaluation,
+            };
+            setCombinedReportResultWithNoFailures();
 
-                const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, executionEnv, undefined, baselineInfo);
+            const actualContent = checkResultMarkdownBuilder.buildContent(combinedReportResult, undefined, baselineInfo);
 
-                expect(actualContent).toMatchSnapshot();
-                verifyAllMocks();
-            },
-        );
+            expect(actualContent).toMatchSnapshot();
+            verifyAllMocks();
+        });
     });
 
     const setCombinedReportResultWithFailures = (): void => {

--- a/packages/shared/src/mark-down/result-markdown-builder.spec.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.spec.ts
@@ -15,7 +15,7 @@ describe(ResultMarkdownBuilder, () => {
     let combinedReportResult: CombinedReportParameters;
     let checkResultMarkdownBuilder: ResultMarkdownBuilder;
     let artifactsInfoProviderMock: IMock<ArtifactsInfoProvider>;
-    const executionEnvArray = ['ADO', 'github'];
+    const executionEnvArray = ['ADO'];
 
     beforeEach(() => {
         artifactsInfoProviderMock = Mock.ofType<ArtifactsInfoProvider>(undefined, MockBehavior.Strict);

--- a/packages/shared/src/mark-down/result-markdown-builder.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.ts
@@ -10,7 +10,7 @@ import { brand } from '../content/strings';
 import { bold, escaped, footerSeparator, heading, link, listItem, productTitle, sectionSeparator } from './markdown-formatter';
 import { iocTypes } from '../ioc/ioc-types';
 
-export type ExecutionEnvironment = 'github' | 'ADO';
+export type ExecutionEnvironment = 'ADO';
 
 @injectable()
 export class ResultMarkdownBuilder {
@@ -228,8 +228,8 @@ export class ResultMarkdownBuilder {
     };
 
     private getNoFailuresText = (baselineEvaluation: BaselineEvaluation, executionEnvironment: ExecutionEnvironment): string[] => {
-        const checkMark = executionEnvironment == 'github' ? ':white_check_mark:' : '✅';
-        const pointRight = executionEnvironment == 'github' ? ':point_right:' : '👉';
+        const checkMark = executionEnvironment == 'ADO' ? '✅' : ':white_check_mark:';
+        const pointRight = executionEnvironment == 'ADO' ? '👉' : ':point_right:';
         let failureDetailsHeading = `${checkMark} No failures detected`;
         let failureDetailsDescription = `No failures were detected by automatic scanning.`;
         if (this.baselineHasFailures(baselineEvaluation)) {

--- a/packages/shared/src/mark-down/result-markdown-builder.ts
+++ b/packages/shared/src/mark-down/result-markdown-builder.ts
@@ -10,8 +10,6 @@ import { brand } from '../content/strings';
 import { bold, escaped, footerSeparator, heading, link, listItem, productTitle, sectionSeparator } from './markdown-formatter';
 import { iocTypes } from '../ioc/ioc-types';
 
-export type ExecutionEnvironment = 'ADO';
-
 @injectable()
 export class ResultMarkdownBuilder {
     constructor(@inject(iocTypes.ArtifactsInfoProvider) private readonly artifactsInfoProvider: ArtifactsInfoProvider) {}
@@ -27,12 +25,7 @@ export class ResultMarkdownBuilder {
         return this.scanResultDetails(lines.join(''));
     }
 
-    public buildContent(
-        combinedReportResult: CombinedReportParameters,
-        executionEnvironment: ExecutionEnvironment,
-        title?: string,
-        baselineInfo?: BaselineInfo,
-    ): string {
+    public buildContent(combinedReportResult: CombinedReportParameters, title?: string, baselineInfo?: BaselineInfo): string {
         const passedChecks = combinedReportResult.results.resultsByRule.passed.length;
         const inapplicableChecks = combinedReportResult.results.resultsByRule.notApplicable.length;
         const failedChecks = combinedReportResult.results.resultsByRule.failed.length;
@@ -58,7 +51,7 @@ export class ResultMarkdownBuilder {
             lines = [
                 this.headingWithMessage(),
                 this.fixedFailureDetails(baselineInfo),
-                this.failureDetailsBaseline(combinedReportResult, baselineInfo, executionEnvironment),
+                this.failureDetailsBaseline(combinedReportResult, baselineInfo),
                 sectionSeparator(),
                 this.baselineDetails(baselineInfo),
                 this.downloadArtifactsWithLink(combinedReportResult, baselineInfo.baselineEvaluation),
@@ -206,11 +199,7 @@ export class ResultMarkdownBuilder {
         return lines.join('');
     };
 
-    private failureDetailsBaseline = (
-        combinedReportResult: CombinedReportParameters,
-        baselineInfo: BaselineInfo,
-        executionEnvironment: ExecutionEnvironment,
-    ): string => {
+    private failureDetailsBaseline = (combinedReportResult: CombinedReportParameters, baselineInfo: BaselineInfo): string => {
         let lines = [];
         if (
             this.hasFailures(combinedReportResult, baselineInfo.baselineEvaluation) ||
@@ -221,15 +210,15 @@ export class ResultMarkdownBuilder {
             const failureInstancesHeading = this.getFailureInstancesHeading(failureInstances, baselineInfo.baselineEvaluation);
             lines = [sectionSeparator(), bold(failureInstancesHeading), sectionSeparator(), ...failedRulesList];
         } else {
-            lines = [sectionSeparator(), ...this.getNoFailuresText(baselineInfo.baselineEvaluation, executionEnvironment)];
+            lines = [sectionSeparator(), ...this.getNoFailuresText(baselineInfo.baselineEvaluation)];
         }
 
         return lines.join('');
     };
 
-    private getNoFailuresText = (baselineEvaluation: BaselineEvaluation, executionEnvironment: ExecutionEnvironment): string[] => {
-        const checkMark = executionEnvironment == 'ADO' ? '✅' : ':white_check_mark:';
-        const pointRight = executionEnvironment == 'ADO' ? '👉' : ':point_right:';
+    private getNoFailuresText = (baselineEvaluation: BaselineEvaluation): string[] => {
+        const checkMark = '✅';
+        const pointRight = '👉';
         let failureDetailsHeading = `${checkMark} No failures detected`;
         let failureDetailsDescription = `No failures were detected by automatic scanning.`;
         if (this.baselineHasFailures(baselineEvaluation)) {


### PR DESCRIPTION
#### Details

This pull request removes action specific code from the shared package:

- Remove execution environment from markdown reporters

##### Motivation

Feature work

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

We considered keeping the execution environment, but it's only used for the logic of switching the emoji. Since it would be fairly quick to add back, we decided to remove the execution environment for now.


<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] Described how this PR impacts both the ADO extension and the GitHub action
