### PR TITLE
feat(decommission-gh-action): Remove gh-action from build pipeline

### DIFF
--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -124,7 +124,7 @@ jobs:
           - task: ComponentGovernanceComponentDetection@0
             displayName: 'dependency detection (Component Governance)'
             inputs:
-                ignoreDirectories: 'drop,dist,extension,node_modules'
+                ignoreDirectories: 'dist,extension,node_modules'
 
           - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
             displayName: 'generate NOTICE.html file'
@@ -134,19 +134,7 @@ jobs:
                 outputformat: html
 
           - task: CopyFiles@2
-            displayName: 'Copy Files to: gh-drop'
-            inputs:
-                Contents: |
-                    $(System.DefaultWorkingDirectory)/NOTICE.html
-                    $(System.DefaultWorkingDirectory)/packages/gh-action/dist/index.js
-                    $(System.DefaultWorkingDirectory)/packages/gh-action/dist/package.json
-                    $(System.DefaultWorkingDirectory)/packages/gh-action/dist/yarn.lock
-                    $(System.DefaultWorkingDirectory)/packages/gh-action/action.yml
-
-                TargetFolder: '$(System.DefaultWorkingDirectory)/drop'
-
-          - task: CopyFiles@2
-            displayName: 'Copy Notices.html to: ado-drop'
+            displayName: 'Copy Notices.html to: ado-extension'
             inputs:
                 Contents: |
                     $(System.DefaultWorkingDirectory)/NOTICE.html
@@ -162,23 +150,9 @@ jobs:
                 # About
                               
                 This release was generated from this source tree [$(Build.SourceVersion)](https://github.com/microsoft/accessibility-insights-action/tree/$(Build.SourceVersion)).
-                ' > '$(System.DefaultWorkingDirectory)/drop/RELEASE_COMMIT.md'
+                ' > '$(System.DefaultWorkingDirectory)/packages/ado-extension/dist/RELEASE_COMMIT.md'
 
-            displayName: 'Generate Release README Info'
-
-          - task: CopyFiles@2
-            displayName: 'Copy ReadMe to: ado-drop'
-            inputs:
-                Contents: |
-                    $(System.DefaultWorkingDirectory)/drop/RELEASE_COMMIT.md
-
-                TargetFolder: '$(System.DefaultWorkingDirectory)/packages/ado-extension/dist'
-
-          - task: PublishBuildArtifacts@1
-            inputs:
-                pathtoPublish: '$(System.DefaultWorkingDirectory)/drop'
-                artifactName: 'drop'
-            displayName: publish drop
+            displayName: 'Generate Release README Info to: ado-extension'
 
           - task: PublishBuildArtifacts@1
             inputs:

--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -124,7 +124,7 @@ jobs:
           - task: ComponentGovernanceComponentDetection@0
             displayName: 'dependency detection (Component Governance)'
             inputs:
-                ignoreDirectories: 'dist,extension,node_modules'
+                ignoreDirectories: 'drop,dist,extension,node_modules'
 
           - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
             displayName: 'generate NOTICE.html file'


### PR DESCRIPTION
#### Details

This pull request will remove the GitHub action from the build pipeline.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

From what I understand, the gh-action was placed in an artifact at `drop/packages/gh-action/`, while the extension lives in an artifact at `ado-extension-drop/pkg/`. This PR will remove the `drop/` directory at the root since that appears to be for the action only. The REALEASE_COMMIT.md was saved in `ado-extension-drop/drop`, but I moved that up a directory into `ado-extension-drop` to simplify the directory structure.

- Example of artifact before this PR: https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=40217&view=artifacts&pathAsName=false&type=publishedArtifacts
- Example of artifact with this PR: https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=40411&view=artifacts&pathAsName=false&type=publishedArtifacts


<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Described how this PR impacts both the ADO extension and the GitHub action
