### PR TITLE
feat(telemetry-and-inputs): add failOnAccessibilityError telemetry

### DIFF
--- a/packages/shared/src/scanner/scanner.spec.ts
+++ b/packages/shared/src/scanner/scanner.spec.ts
@@ -249,9 +249,11 @@ describe(Scanner, () => {
 
             inputValidatorMock.setup((m) => m.validate()).returns(() => true);
 
-            telemetryClientMock.setup((m) => m.trackEvent({ name: 'ScanStart' }));
-            telemetryClientMock.setup((m) => m.trackEvent({ name: 'Inputs' }));
-            telemetryClientMock.setup((m) => m.flush());
+            telemetryClientMock.setup((m) => m.trackEvent({ name: 'ScanStart' })).verifiable();
+            telemetryClientMock
+                .setup((m) => m.trackEvent({ name: 'Inputs', properties: { failOnAccessibilityError: false } }))
+                .verifiable();
+            telemetryClientMock.setup((m) => m.flush()).verifiable();
 
             await scanner.scan();
 
@@ -265,10 +267,12 @@ describe(Scanner, () => {
 
             inputValidatorMock.setup((m) => m.validate()).returns(() => true);
 
-            telemetryClientMock.setup((m) => m.trackEvent({ name: 'ScanStart' }));
-            telemetryClientMock.setup((m) => m.trackEvent({ name: 'Inputs' }));
-            telemetryClientMock.setup((m) => m.trackEvent({ name: 'AuthUsed' }));
-            telemetryClientMock.setup((m) => m.flush());
+            telemetryClientMock.setup((m) => m.trackEvent({ name: 'ScanStart' })).verifiable();
+            telemetryClientMock
+                .setup((m) => m.trackEvent({ name: 'Inputs', properties: { failOnAccessibilityError: false } }))
+                .verifiable();
+            telemetryClientMock.setup((m) => m.trackEvent({ name: 'AuthUsed' })).verifiable();
+            telemetryClientMock.setup((m) => m.flush()).verifiable();
 
             await scanner.scan();
 
@@ -287,6 +291,10 @@ describe(Scanner, () => {
             taskConfigMock
                 .setup((m) => m.getReportOutDir())
                 .returns(() => reportOutDir)
+                .verifiable(Times.once());
+            taskConfigMock
+                .setup((m) => m.getFailOnAccessibilityError())
+                .returns(() => false)
                 .verifiable(Times.once());
             progressReporterMock.setup((p) => p.start()).verifiable(Times.once());
             progressReporterMock

--- a/packages/shared/src/scanner/scanner.spec.ts
+++ b/packages/shared/src/scanner/scanner.spec.ts
@@ -250,6 +250,7 @@ describe(Scanner, () => {
             inputValidatorMock.setup((m) => m.validate()).returns(() => true);
 
             telemetryClientMock.setup((m) => m.trackEvent({ name: 'ScanStart' }));
+            telemetryClientMock.setup((m) => m.trackEvent({ name: 'Inputs' }));
             telemetryClientMock.setup((m) => m.flush());
 
             await scanner.scan();
@@ -265,6 +266,7 @@ describe(Scanner, () => {
             inputValidatorMock.setup((m) => m.validate()).returns(() => true);
 
             telemetryClientMock.setup((m) => m.trackEvent({ name: 'ScanStart' }));
+            telemetryClientMock.setup((m) => m.trackEvent({ name: 'Inputs' }));
             telemetryClientMock.setup((m) => m.trackEvent({ name: 'AuthUsed' }));
             telemetryClientMock.setup((m) => m.flush());
 

--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -97,6 +97,10 @@ export class Scanner {
             scanArguments = this.crawlArgumentHandler.processScanArguments(localServerUrl);
 
             this.telemetryClient.trackEvent({ name: 'ScanStart' });
+            this.telemetryClient.trackEvent({
+                name: 'Inputs',
+                properties: { failOnAccessibilityError: this.taskConfig.getFailOnAccessibilityError() },
+            });
 
             if (scanArguments.serviceAccountName !== undefined) {
                 this.telemetryClient.trackEvent({ name: 'AuthUsed' });

--- a/packages/shared/src/task-config.ts
+++ b/packages/shared/src/task-config.ts
@@ -28,4 +28,5 @@ export abstract class TaskConfig {
     abstract getServiceAccountName(): string | undefined;
     abstract getServiceAccountPassword(): string | undefined;
     abstract getAuthType(): string | undefined;
+    abstract getFailOnAccessibilityError(): boolean;
 }

--- a/packages/shared/src/telemetry/telemetry-event.ts
+++ b/packages/shared/src/telemetry/telemetry-event.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export type TelemetryEventName = 'ScanStart' | 'ScanCompleted' | 'AuthUsed' | 'ErrorFound';
+export type TelemetryEventName = 'ScanStart' | 'ScanCompleted' | 'AuthUsed' | 'ErrorFound' | 'Inputs';
 
 export type TelemetryEvent = {
     name: TelemetryEventName;


### PR DESCRIPTION
#### Details

This adds telemetry tracking of usage of the `failOnAccessibilityError` input.

##### Motivation

To allow for visibility into compliance of failing pull requests if accessibility errors are found and no baseline is in place. If `failOnAccessibilityError` is set to `true`, the extension will always return as successful even if there are errors, rendering the extension mostly useless.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran prechecking (`yarn precheckin`)
