### PR TITLE
feat(telemetry-and-inputs): add snapshot input and snapshot artifact upload

### DIFF
--- a/docs/ado-extension-inputs.md
+++ b/docs/ado-extension-inputs.md
@@ -56,4 +56,6 @@ or
 
 -   `outputDir` (string). Directory to write the scan output to. Its contents will be uploaded as a pipeline artifact unless `uploadOutputArtifact` is set to `false`. If unspecified, output will be written to a generated temporary directory.
 
+-   `snapshot` (boolean). Save snapshots of scanned pages as artifacts. These snapshots will show you exactly what the scanner sees when scanning the page. This requires `uploadOutputArtifact` to not be set to `false`.
+
 -   `chromePath` (string). Path to Chrome executable. By default, the task downloads a version of Chrome that is tested to work with this task.

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -170,6 +170,22 @@ export class ADOTaskConfig extends TaskConfig {
         return this.adoTaskObj.getInput('authType');
     }
 
+    public getDebug(): boolean {
+        return this.adoTaskObj.getBoolInput('debug');
+    }
+
+    public getSnapshot(): boolean {
+        return this.adoTaskObj.getBoolInput('snapshot');
+    }
+
+    public getSimulate(): boolean {
+        return this.adoTaskObj.getBoolInput('simulate');
+    }
+
+    public getSelectors(): string | undefined {
+        return this.adoTaskObj.getInput('selectors');
+    }
+
     public getInputName(key: TaskInputKey): string {
         const keyToName = {
             HostingMode: 'hostingMode',

--- a/packages/ado-extension/src/task-config/ado-task-config.ts
+++ b/packages/ado-extension/src/task-config/ado-task-config.ts
@@ -170,20 +170,8 @@ export class ADOTaskConfig extends TaskConfig {
         return this.adoTaskObj.getInput('authType');
     }
 
-    public getDebug(): boolean {
-        return this.adoTaskObj.getBoolInput('debug');
-    }
-
     public getSnapshot(): boolean {
         return this.adoTaskObj.getBoolInput('snapshot');
-    }
-
-    public getSimulate(): boolean {
-        return this.adoTaskObj.getBoolInput('simulate');
-    }
-
-    public getSelectors(): string | undefined {
-        return this.adoTaskObj.getInput('selectors');
     }
 
     public getInputName(key: TaskInputKey): string {

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -186,19 +186,20 @@
             "groupName": "outputOptions"
         },
         {
+            "name": "snapshot",
+            "type": "boolean",
+            "label": "Snapshot",
+            "required": false,
+            "helpMarkDown": "Save snapshots of scanned pages as artifacts. These snapshots will show you exactly what the scanner sees when scanning the page. This requires `uploadOutputArtifact` to not be set to `false`.",
+            "groupName": "outputOptions"
+        },
+        {
             "name": "chromePath",
             "type": "string",
             "label": "Chrome path",
             "required": false,
             "helpMarkDown": "Path to Chrome executable. By default, the task downloads a version of Chrome that is tested to work with this task.",
             "groupName": "advancedOptions"
-        },
-        {
-            "name": "snapshot",
-            "type": "boolean",
-            "label": "Snapshot",
-            "required": false,
-            "helpMarkDown": "Save snapshot of the crawled page. Enabled by default if simulation option is selected, otherwise false."
         }
     ],
     "execution": {

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -192,6 +192,34 @@
             "required": false,
             "helpMarkDown": "Path to Chrome executable. By default, the task downloads a version of Chrome that is tested to work with this task.",
             "groupName": "advancedOptions"
+        },
+        {
+            "name": "debug",
+            "type": "boolean",
+            "label": "Debug mode",
+            "required": false,
+            "helpMarkDown": "Enables crawler engine debug mode."
+        },
+        {
+            "name": "snapshot",
+            "type": "boolean",
+            "label": "Snapshot",
+            "required": false,
+            "helpMarkDown": "Save snapshot of the crawled page. Enabled by default if simulation option is selected, otherwise false."
+        },
+        {
+            "name": "simulate",
+            "type": "boolean",
+            "label": "Simulate",
+            "required": false,
+            "helpMarkDown": "Simulate user click on elements that match to the specified selectors."
+        },
+        {
+            "name": "selectors",
+            "type": "string",
+            "label": "Selectors",
+            "required": false,
+            "helpMarkDown": "List of CSS selectors to match against, separated by space. Default selector is 'button'."
         }
     ],
     "execution": {

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -194,32 +194,11 @@
             "groupName": "advancedOptions"
         },
         {
-            "name": "debug",
-            "type": "boolean",
-            "label": "Debug mode",
-            "required": false,
-            "helpMarkDown": "Enables crawler engine debug mode."
-        },
-        {
             "name": "snapshot",
             "type": "boolean",
             "label": "Snapshot",
             "required": false,
             "helpMarkDown": "Save snapshot of the crawled page. Enabled by default if simulation option is selected, otherwise false."
-        },
-        {
-            "name": "simulate",
-            "type": "boolean",
-            "label": "Simulate",
-            "required": false,
-            "helpMarkDown": "Simulate user click on elements that match to the specified selectors."
-        },
-        {
-            "name": "selectors",
-            "type": "string",
-            "label": "Selectors",
-            "required": false,
-            "helpMarkDown": "List of CSS selectors to match against, separated by space. Default selector is 'button'."
         }
     ],
     "execution": {

--- a/packages/shared/src/scanner/crawl-argument-handler.spec.ts
+++ b/packages/shared/src/scanner/crawl-argument-handler.spec.ts
@@ -54,6 +54,7 @@ describe(CrawlArgumentHandler, () => {
             serviceAccountName: undefined,
             serviceAccountPassword: undefined,
             authType: undefined,
+            snapshot: undefined,
         };
 
         validateMock.setup((m) => m(expectedArgs));
@@ -84,6 +85,7 @@ describe(CrawlArgumentHandler, () => {
             serviceAccountName: undefined,
             serviceAccountPassword: undefined,
             authType: undefined,
+            snapshot: undefined,
         };
 
         validateMock.setup((m) => m(expectedArgs));
@@ -112,6 +114,7 @@ describe(CrawlArgumentHandler, () => {
             serviceAccountName: undefined,
             serviceAccountPassword: undefined,
             authType: undefined,
+            snapshot: undefined,
         };
 
         validateMock.setup((m) => m(expectedArgs));
@@ -138,6 +141,7 @@ describe(CrawlArgumentHandler, () => {
             serviceAccountName: undefined,
             serviceAccountPassword: undefined,
             authType: undefined,
+            snapshot: undefined,
         };
 
         validateMock.setup((m) => m(expectedArgs));
@@ -166,5 +170,6 @@ describe(CrawlArgumentHandler, () => {
         taskConfigMock.setup((m) => m.getServiceAccountName()).returns((_) => undefined);
         taskConfigMock.setup((m) => m.getServiceAccountPassword()).returns((_) => undefined);
         taskConfigMock.setup((m) => m.getAuthType()).returns((_) => undefined);
+        taskConfigMock.setup((m) => m.getSnapshot()).returns((_) => undefined);
     }
 });

--- a/packages/shared/src/scanner/crawl-argument-handler.ts
+++ b/packages/shared/src/scanner/crawl-argument-handler.ts
@@ -37,7 +37,6 @@ export class CrawlArgumentHandler {
         const inputFile = this.taskConfig.getInputFile() || undefined;
         const inputUrlsArg = this.taskConfig.getInputUrls() || undefined;
         const discoveryPatternsArg = this.taskConfig.getDiscoveryPatterns() || undefined;
-        const selectorsArg = this.taskConfig.getSelectors() || undefined;
 
         const args = {
             inputFile,
@@ -56,10 +55,7 @@ export class CrawlArgumentHandler {
             serviceAccountName: this.taskConfig.getServiceAccountName() || undefined,
             serviceAccountPassword: this.taskConfig.getServiceAccountPassword() || undefined,
             authType: this.taskConfig.getAuthType() || undefined,
-            debug: this.taskConfig.getDebug() || undefined,
             snapshot: this.taskConfig.getSnapshot() || undefined,
-            simulate: this.taskConfig.getSimulate() || undefined,
-            selectors: selectorsArg?.split(/\s+/),
         };
 
         return args;

--- a/packages/shared/src/scanner/crawl-argument-handler.ts
+++ b/packages/shared/src/scanner/crawl-argument-handler.ts
@@ -37,6 +37,7 @@ export class CrawlArgumentHandler {
         const inputFile = this.taskConfig.getInputFile() || undefined;
         const inputUrlsArg = this.taskConfig.getInputUrls() || undefined;
         const discoveryPatternsArg = this.taskConfig.getDiscoveryPatterns() || undefined;
+        const selectorsArg = this.taskConfig.getSelectors() || undefined;
 
         const args = {
             inputFile,
@@ -55,6 +56,10 @@ export class CrawlArgumentHandler {
             serviceAccountName: this.taskConfig.getServiceAccountName() || undefined,
             serviceAccountPassword: this.taskConfig.getServiceAccountPassword() || undefined,
             authType: this.taskConfig.getAuthType() || undefined,
+            debug: this.taskConfig.getDebug() || undefined,
+            snapshot: this.taskConfig.getSnapshot() || undefined,
+            simulate: this.taskConfig.getSimulate() || undefined,
+            selectors: selectorsArg?.split(/\s+/),
         };
 
         return args;

--- a/packages/shared/src/task-config.ts
+++ b/packages/shared/src/task-config.ts
@@ -29,4 +29,8 @@ export abstract class TaskConfig {
     abstract getServiceAccountPassword(): string | undefined;
     abstract getAuthType(): string | undefined;
     abstract getFailOnAccessibilityError(): boolean;
+    abstract getDebug(): boolean | undefined;
+    abstract getSnapshot(): boolean | undefined;
+    abstract getSimulate(): boolean | undefined;
+    abstract getSelectors(): string | undefined;
 }

--- a/packages/shared/src/task-config.ts
+++ b/packages/shared/src/task-config.ts
@@ -29,8 +29,5 @@ export abstract class TaskConfig {
     abstract getServiceAccountPassword(): string | undefined;
     abstract getAuthType(): string | undefined;
     abstract getFailOnAccessibilityError(): boolean;
-    abstract getDebug(): boolean | undefined;
     abstract getSnapshot(): boolean | undefined;
-    abstract getSimulate(): boolean | undefined;
-    abstract getSelectors(): string | undefined;
 }


### PR DESCRIPTION
#### Details

This adds the snapshot input available in the accessibility-insights-scan package to the ADO Extension. The snapshot input takes a snapshot of every page scanned and uploads it to a separate artifact folder using the existing artifact name and appending `-snapshots`.

Here is an [example run from my test extension](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=41619&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=7384d774-f7ca-599c-ee57-ab2c05be9247)

Here is a [direct link to the artifacts for that run](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=41619&view=artifacts&pathAsName=false&type=publishedArtifacts)

##### Motivation

Feature work, this will allow users to see what the scanner is seeing when pages are being scanned. This will help in debugging unexpected scan results.

##### Context

There were a few approaches for the uploads that I considered. When there are a lot of snapshots there will end up being a fairly large stream of upload information in the logs as it uploads them one by one, as you can see in the example run linked above.

There is an alternative that I considered that cuts down on the noise but has other drawbacks.  We could delete all additional files in the key_value_stores working directory (json/diagnostic files output by the scanner), and then upload the entire directory at once. I decided to match on the screenshot instead and upload them each separately in case we ever want to use those files for anything in the future.

It also didn't feel like the noise at the bottom was much of a problem, as the UI defaults to showing the top of the log, which is where the key information will still reside.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran prechecking (`yarn precheckin`)
