### PR TITLE
fix: add .net core sdk 2.1.x installation to package-vsix-file.yml

### DIFF
--- a/pipelines/package-vsix-file.yaml
+++ b/pipelines/package-vsix-file.yaml
@@ -80,6 +80,12 @@ steps:
           patternManifest: 'ado-extension.json'
           outputPath: '$(Build.ArtifactStagingDirectory)/${{ parameters.environment }}.vsix'
 
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core sdk 2.1.x'
+      inputs:
+          packageType: 'sdk'
+          version: '2.1.x'
+
     - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
       condition: and(succeeded(), eq('${{ parameters.shouldSign }}', 'true'))
       displayName: 'ESRP: Sign VSIX file '


### PR DESCRIPTION
#### Details

This adds an installation step for a package that was missing in the release pipeline VM, causing the ESRP signing to fail as demonstrated in [this pipeline run](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=42108&view=logs&j=396ea3d1-819f-56b8-6471-9a0868242726&t=7ac2f2c6-f908-505b-7eb0-4caa111ca6d9).

I dug around and found various people working around this issue by installing the missing .NET package using the `UseDotNet@2` task. To verify that it would work as expected, I pushed this branch and ran the pipeline using the yaml file from this branch. It succeeded, as you can see in [this successful pipeline run](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=42112&view=logs&j=c5b65442-1d8a-52e7-0754-df15d10797ab&t=e187e7d8-7fdb-5260-b74e-b39e0b1ac439).

##### Motivation

Fixing the release pipeline

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran prechecking (`yarn precheckin`)
