### PR TITLE
fix: Add NodeTool to validation pipelines

### DIFF
--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -16,6 +16,10 @@ variables:
     - group: 'ado-auth-example-secrets'
 
 steps:
+    - task: NodeTool@0
+      inputs:
+          versionSpec: '16.x'
+          displayName: Use node 16.x
     # reused by all "url" cases
     - script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &
       displayName: 'Start /dev/website-root test server at http://localhost:5858'

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -19,7 +19,7 @@ steps:
     - task: NodeTool@0
       inputs:
           versionSpec: '16.x'
-          displayName: Use node 16.x
+          displayName: Use Node 16.x
     # reused by all "url" cases
     - script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &
       displayName: 'Start /dev/website-root test server at http://localhost:5858'


### PR DESCRIPTION
#### Details

This pull request adds NodeTool to make sure the validation pipeline use Node 16.x. I noticed the canary validation pipelines started failing yesterday with a Node version error; ubuntu-latest appears to be shipping with Node v18. 

##### Motivation

Fix validation pipelines.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
