### PR TITLE
feat(faq-update): point helpMarkdown to new FAQ link

### DIFF
--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -4,7 +4,7 @@
     "name": "accessibility-insights",
     "friendlyName": "Accessibility Insights Azure DevOps Task",
     "description": "Scan for accessibility issues in an Azure DevOps pipeline",
-    "helpMarkDown": "Learn [how to add Accessibility Insights Azure DevOps Task](https://aka.ms/ado-extension-usage) to your pipeline. For authenticated sites, learn [how to setup authentication](https://aka.ms/AI-action-auth)",
+    "helpMarkDown": "For help with configuring and troubleshooting this task, see https://aka.ms/accessibility-insights-faq#azure-devops-extension",
     "category": "Test",
     "author": "Accessibility Insights",
     "version": {


### PR DESCRIPTION
#### Details

This points the top-level  `helpMarkdown` in the `task.json` file to the new FAQ link.  This snippet is displayed at the top of the task whenever it is run.

Here is a run with my test extension displaying the new behavior: https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=42652&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=7384d774-f7ca-599c-ee57-ab2c05be9247

##### Motivation

This allows us to point users to a single place for both configuration and troubleshooting questions.

##### Context

We'll also be updating the eng.ms documentation to link back to setup documentation. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran prechecking (`yarn precheckin`)
