### PR TITLE
chore: Bump http-cache-semantics transitive dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6358,7 +6358,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-cache-semantics@npm:^4.0.0, http-cache-semantics@npm:^4.1.0":
+"http-cache-semantics@npm:^4.0.0, http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
   checksum: 83ac0bc60b17a3a36f9953e7be55e5c8f41acc61b22583060e8dedc9dd5e3607c823a88d0926f9150e571f90946835c7fe150732801010845c72cd8bbff1a236
@@ -8087,7 +8087,7 @@ __metadata:
   dependencies:
     agentkeepalive: ^4.2.1
     cacache: ^16.1.0
-    http-cache-semantics: ^4.1.0
+    http-cache-semantics: ^4.1.1
     http-proxy-agent: ^5.0.0
     https-proxy-agent: ^5.0.0
     is-lambda: ^1.0.1


### PR DESCRIPTION
#### Details

Pin to a higher version of http-cache-semantics transitive dependency to ensure we get security fixes (see https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_workitems/edit/312)

##### Motivation

Keep dependencies up to date

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
