### PR TITLE
chore: Temporarily disable fabricbot auto merge

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -3,21 +3,6 @@
   "tasks": [
     {
       "taskType": "trigger",
-      "capabilityId": "AutoMerge",
-      "subCapability": "AutoMerge",
-      "version": "1.0",
-      "config": {
-        "taskName": "auto-merge",
-        "label": "pr: auto-merge",
-        "minMinutesOpen": "1",
-        "mergeType": "squash",
-        "deleteBranches": true,
-        "requireAllStatuses": true
-      },
-      "id": "rm57lnlY4P3UWpNJCGGRE"
-    },
-    {
-      "taskType": "trigger",
       "capabilityId": "IssueResponder",
       "subCapability": "IssuesOnlyResponder",
       "version": "1.0",


### PR DESCRIPTION
#### Details

Per suggestion from the FabricBot team, this pull request will temporarily disable the auto merge trigger pending further guidance.


##### Motivation

For the past few weeks, FabricBot has been triggering auto-merge and not respecting the label trigger.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
