### PR TITLE
chore: clean up yarn resolutions using versioned specifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,12 +72,10 @@
         "webpack-cli": "^5.0.1"
     },
     "resolutions": {
-        "y18n": ">=5.0.5",
-        "hosted-git-info": ">=3.0.8",
-        "http-signature": ">=1.3.1",
-        "ansi-regex": "^5.0.1",
-        "tar": ">=6.1.9",
-        "node-fetch": "2.6.7",
-        "mockery": "^2.1.0"
+        "y18n@^4.0.0": "^5.0.5",
+        "hosted-git-info@^2.1.4": "^3.0.8",
+        "http-signature@~1.2.0": "^1.3.1",
+        "ansi-regex@^2.0.0": "^5.0.1",
+        "ansi-regex@^4.1.0": "^5.0.1"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2896,7 +2896,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^5.0.1":
+"ansi-regex@npm:^5.0.0, ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
   checksum: 2aa4bb54caf2d622f1afdad09441695af2a83aa3fe8b8afa581d205e57ed4261c183c4d3877cee25794443fde5876417d859c108078ab788d6af7e4fe52eb66b
@@ -6173,12 +6173,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hosted-git-info@npm:>=3.0.8":
-  version: 6.1.1
-  resolution: "hosted-git-info@npm:6.1.1"
+"hosted-git-info@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "hosted-git-info@npm:3.0.8"
   dependencies:
-    lru-cache: ^7.5.1
-  checksum: fcd3ca2eaa05f3201425ccbb8aa47f88cdda4a3a6d79453f8e269f7171356278bd1db08f059d8439eb5eaa91c6a8a20800fc49cca6e9e4e899b202a332d5ba6b
+    lru-cache: ^6.0.0
+  checksum: 5af7a69581acb84206a7b8e009f4680c36396814e92c8a83973dfb3b87e44e44d1f7b8eaf3e4a953686482770ecb78406a4ce4666bfdfe447762434127871d8d
+  languageName: node
+  linkType: hard
+
+"hosted-git-info@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "hosted-git-info@npm:4.1.0"
+  dependencies:
+    lru-cache: ^6.0.0
+  checksum: c3f87b3c2f7eb8c2748c8f49c0c2517c9a95f35d26f4bf54b2a8cba05d2e668f3753548b6ea366b18ec8dadb4e12066e19fa382a01496b0ffa0497eb23cbe461
   languageName: node
   linkType: hard
 
@@ -6276,7 +6285,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-signature@npm:>=1.3.1":
+"http-signature@npm:^1.3.1":
   version: 1.3.6
   resolution: "http-signature@npm:1.3.6"
   dependencies:
@@ -7930,13 +7939,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^7.5.1":
-  version: 7.10.2
-  resolution: "lru-cache@npm:7.10.2"
-  checksum: b8f98064c981ce98e2a3b82903726dd28d842f54b7f53e1d6029c6836546243d4157b8495a405c062209715c612050150bdf30b5fa8200d5a3559fb0fd4072c1
-  languageName: node
-  linkType: hard
-
 "lru-cache@npm:^7.7.1":
   version: 7.12.0
   resolution: "lru-cache@npm:7.12.0"
@@ -8525,6 +8527,20 @@ __metadata:
     encoding:
       optional: true
   checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.1":
+  version: 2.6.9
+  resolution: "node-fetch@npm:2.6.9"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: acb04f9ce7224965b2b59e71b33c639794d8991efd73855b0b250921382b38331ffc9d61bce502571f6cc6e11a8905ca9b1b6d4aeb586ab093e2756a1fd190d0
   languageName: node
   linkType: hard
 
@@ -10880,7 +10896,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:>=6.1.9":
+"tar@npm:^6.1.0, tar@npm:^6.1.11, tar@npm:^6.1.2":
   version: 6.1.13
   resolution: "tar@npm:6.1.13"
   dependencies:
@@ -11931,7 +11947,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"y18n@npm:>=5.0.5":
+"y18n@npm:^5.0.5":
   version: 5.0.8
   resolution: "y18n@npm:5.0.8"
   checksum: 54f0fb95621ee60898a38c572c515659e51cc9d9f787fb109cef6fde4befbe1c4602dc999d30110feee37456ad0f1660fa2edcfde6a9a740f86a290999550d30


### PR DESCRIPTION
#### Details

This PR cleans up the repo's use of yarn resolutions:

* Removes a few obsolete resolutions
* Updates remaining resolutions to take advantage of yarn v3's versioned specifiers

In practice, the actual delta of packages we resolve to is:

* `hosted-git-info` is downgraded, but not past the version boundary containing security fixes we want to maintain (3.0.8). This is intentional, to avoid accidentally picking up breaking changes unnecessarily
    * one `lru-cache` version is collapsed away (as a follow-on effect of the `hosted-git-info` downgrade)
* `node-fetch` is upgraded slightly (`2.6.7` to `2.6.9`) in one path that wasn't intended to be impacted by its resolution

##### Motivation

* Removing obsolete resolutions removes some existing tech debt
* Using versioned specifiers avoids issues where we accidentally force changes upon compliant dependency references that we don't mean to touch. For example, this was happening (benignly) in multiple cases in this PR:
    *  `hosted-git-info` was being forced to `>=3.0.8` with the intent of forcing the transitive reference on `^2.1.4` to pick up a fix from 3.0.8, but this was additionally having the unintentional effect of forcing a perfectly fine dependency on `^4.0.1` to pick up a few versions' worth of breaking changes in `6.1.1`. With this update, we now force a version change only for the too-old `hosted-git-info` dependency, and only up to the major version level we've specifically validated is compatible for our usage
    * `node-fetch` was being forced to `2.6.7`, with the intent of forcing a transitive reference on `2.6.1` to pick up a fix from `2.6.7`, but this was additionally having the unintentional effect of forcing a valid dependency on `^2.6.7` to `2.6.7` instead of the latest version (`2.6.9`). In this case, the fix was just to remove the resolution since we no longer have a transitive dependency on `2.6.1`, but if that transitive dependency still existed, updating the resolution to `"node-fetch@2.6.1": "^2.6.7"` would similarly avoid impacting the undesired package.

##### Context

This pattern (`"dependency-name@^original.version.number": "^new.version.number"`) is what I suggest we start using generally going forward; it avoids most of the problems with blanket resolutions mentioned in the Motivation section.

The main downside of this pattern compared to the non-version-based ones is that if a dependency chain updates in a way where we'd still want to keep a resolution, but against a different starting version number, the version-based resolution would stop applying where the version-free resolution wouldn't. I think this is a good tradeoff because:
* This case is relatively rare - usually, if we're doing a resolution, it's because of a security update, and the next update of that dependency chain is almost always to just pick up the security update we're doing a resolution for
* If it did come up, it would be caught very quickly by component governance, whereas the issues that might arise from the version-free resolution wouldn't

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
