### PR TITLE
feat(onboard-1es-pt): Add back NodeTool tasks back to CI pipeline

### DIFF
--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -39,6 +39,11 @@ extends:
                   - job: BuildAndCheckCodeStyling
                     displayName: Build and check code styling
                     steps:
+                        - task: NodeTool@0
+                          inputs:
+                              versionSpec: '16.x'
+                              displayName: Use Node 16.x
+
                         - script: yarn install --immutable
                           displayName: Install dependencies
 
@@ -116,6 +121,11 @@ extends:
                               targetPath: $(System.DefaultWorkingDirectory)/packages/ado-extension/dist
                               artifactName: ado-extension-drop
                     steps:
+                        - task: NodeTool@0
+                          inputs:
+                              versionSpec: '16.x'
+                          displayName: Use Node 16.x
+
                         - script: yarn install --immutable
                           displayName: Install dependencies
 

--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -42,7 +42,7 @@ extends:
                         - task: NodeTool@0
                           inputs:
                               versionSpec: '16.x'
-                              displayName: Use Node 16.x
+                          displayName: Use Node 16.x
 
                         - script: yarn install --immutable
                           displayName: Install dependencies


### PR DESCRIPTION
#### Details

As I was investigating the run times before and after 1ES PT migration for the CI template, I noticed that the yarn install step was taking 3+ minutes due to a node-gyp issue. Adding back Node 16 to the pipeline resolves the node-gyp error and makes the yarn install steps run significantly faster.

##### Motivation

Improvements to https://github.com/microsoft/accessibility-insights-action/pull/1610, https://dev.azure.com/mseng/1ES/_workitems/edit/2033962

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
