### PR TITLE
fix: update to ai-scan 1.7.0/puppeteer 19.8.5

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -30,7 +30,7 @@
         "@types/react": "^16.14",
         "@types/react-dom": "^16.9",
         "accessibility-insights-report": "4.6.4",
-        "accessibility-insights-scan": "1.6.0",
+        "accessibility-insights-scan": "1.7.0",
         "axe-core": "4.6.3",
         "express": "^4.18.2",
         "filenamify-url": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,7 +55,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.58.0
     "@typescript-eslint/parser": ^5.57.1
     accessibility-insights-report: 4.6.4
-    accessibility-insights-scan: 1.6.0
+    accessibility-insights-scan: 1.7.0
     axe-core: 4.6.3
     eslint: ^8.38.0
     eslint-plugin-security: ^1.7.1
@@ -1823,6 +1823,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@puppeteer/browsers@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@puppeteer/browsers@npm:0.4.0"
+  dependencies:
+    debug: 4.3.4
+    extract-zip: 2.0.1
+    https-proxy-agent: 5.0.1
+    progress: 2.0.3
+    proxy-from-env: 1.1.0
+    tar-fs: 2.1.1
+    unbzip2-stream: 1.4.3
+    yargs: 17.7.1
+  peerDependencies:
+    typescript: ">= 4.7.4"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    browsers: lib/cjs/main-cli.js
+  checksum: d21fce3daa739f156a2539cc1893adad7572c4253ff5a9e3785745c614ff30306b69f327c4e21c50c96cffbaa4d858037e4e72fb291065bc83caf0997f186a05
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.25.16":
   version: 0.25.21
   resolution: "@sinclair/typebox@npm:0.25.21"
@@ -2842,9 +2865,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"accessibility-insights-scan@npm:1.6.0":
-  version: 1.6.0
-  resolution: "accessibility-insights-scan@npm:1.6.0"
+"accessibility-insights-scan@npm:1.7.0":
+  version: 1.7.0
+  resolution: "accessibility-insights-scan@npm:1.7.0"
   dependencies:
     "@axe-core/puppeteer": ^4.5.0
     "@medv/finder": ^2.1.0
@@ -2864,17 +2887,17 @@ __metadata:
     filenamify-url: ^2.1.2
     got: ^11.8.5
     inversify: ^6.0.1
-    json5: ^2.2.3
+    json5: ">=2.2.3"
     leveldown: ^6.1.1
     levelup: ^5.1.1
     lodash: ^4.17.21
     moment: ^2.29.4
     normalize-path: ^3.0.0
     normalize-url: 6.1.0
-    puppeteer: 18.1.0
-    puppeteer-extra: ^3.3.4
-    puppeteer-extra-plugin: ^3.2.2
-    puppeteer-extra-plugin-stealth: ^2.11.1
+    puppeteer: ^19.8.5
+    puppeteer-extra: ^3.3.6
+    puppeteer-extra-plugin: ^3.2.3
+    puppeteer-extra-plugin-stealth: ^2.11.2
     raw-body: ^2.5.1
     reflect-metadata: ^0.1.13
     serialize-error: ^8.1.0
@@ -2884,7 +2907,7 @@ __metadata:
     yargs: ^17.6.2
   bin:
     ai-scan: dist/ai-scan-cli.js
-  checksum: 3102131de49e5066d4d19429fb88f59a705b1ebac44a0fed6501c270afefcfee580612ee16a4502046477296c8df864fc54018e7828d439f599ed1aab0b548d8
+  checksum: 8f1034f4b52e07de218587dcefc4d270cbf4652061fa24466b872ab7be3d673db865b62063f11b9e9e8b4d1f09133ae3fa617a3c8a32ca82e08e804036716da2
   languageName: node
   linkType: hard
 
@@ -3983,6 +4006,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chromium-bidi@npm:0.4.6":
+  version: 0.4.6
+  resolution: "chromium-bidi@npm:0.4.6"
+  dependencies:
+    mitt: 3.0.0
+  peerDependencies:
+    devtools-protocol: "*"
+  checksum: 1d6365896bca4592ddd95233a784e4743d2c8c692d065327a416a09acddc3d05e300c360b859d7049f91924be326d801e6fe9860ace4541325b25f4ec6b94b97
+  languageName: node
+  linkType: hard
+
 "ci-info@npm:^3.2.0":
   version: 3.2.0
   resolution: "ci-info@npm:3.2.0"
@@ -4363,6 +4397,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cosmiconfig@npm:8.1.3":
+  version: 8.1.3
+  resolution: "cosmiconfig@npm:8.1.3"
+  dependencies:
+    import-fresh: ^3.2.1
+    js-yaml: ^4.1.0
+    parse-json: ^5.0.0
+    path-type: ^4.0.0
+  checksum: b3d277bc3a8a9e649bf4c3fc9740f4c52bf07387481302aa79839f595045368903bf26ea24a8f7f7b8b180bf46037b027c5cb63b1391ab099f3f78814a147b2b
+  languageName: node
+  linkType: hard
+
 "cosmiconfig@npm:^7.0.1":
   version: 7.0.1
   resolution: "cosmiconfig@npm:7.0.1"
@@ -4669,17 +4715,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"devtools-protocol@npm:0.0.1045489":
-  version: 0.0.1045489
-  resolution: "devtools-protocol@npm:0.0.1045489"
-  checksum: 670b2ecc8e890358b08da3095b4c927ffc5ef846a39e1526ff99aecaa623b339450dfe308e421e64bf94308441832b8e9497ebda97fb02266fef3f455286742f
-  languageName: node
-  linkType: hard
-
 "devtools-protocol@npm:0.0.1056733":
   version: 0.0.1056733
   resolution: "devtools-protocol@npm:0.0.1056733"
   checksum: d81b474d656d5cdfa0ec6afb8725e8707ba8b38ad7fc68abe05e5accdef1967a6bc1a1545744c8b69cb22ec5d3b3e5225d4bc0313b6a017c94a32a43f3d2c3d3
+  languageName: node
+  linkType: hard
+
+"devtools-protocol@npm:0.0.1107588":
+  version: 0.0.1107588
+  resolution: "devtools-protocol@npm:0.0.1107588"
+  checksum: 9064fd643f39ae0adabb8f425b746899ff24371d89a5047d38752653259e6afcb6bcb2d9759ff727eb5885cfc0f9ba8eb384850a2af00694135622e88080e3e5
   languageName: node
   linkType: hard
 
@@ -7691,7 +7737,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.1.2, json5@npm:^2.2.1, json5@npm:^2.2.3":
+"json5@npm:>=2.2.3, json5@npm:^2.1.2, json5@npm:^2.2.1, json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:
@@ -8479,6 +8525,13 @@ __metadata:
     minipass: ^3.0.0
     yallist: ^4.0.0
   checksum: f1fdeac0b07cf8f30fcf12f4b586795b97be856edea22b5e9072707be51fc95d41487faec3f265b42973a304fe3a64acd91a44a3826a963e37b37bafde0212c3
+  languageName: node
+  linkType: hard
+
+"mitt@npm:3.0.0":
+  version: 3.0.0
+  resolution: "mitt@npm:3.0.0"
+  checksum: f7be5049d27d18b1dbe9408452d66376fa60ae4a79fe9319869d1b90ae8cbaedadc7e9dab30b32d781411256d468be5538996bb7368941c09009ef6bbfa6bfc7
   languageName: node
   linkType: hard
 
@@ -9597,13 +9650,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"puppeteer-extra-plugin-stealth@npm:^2.11.1":
-  version: 2.11.1
-  resolution: "puppeteer-extra-plugin-stealth@npm:2.11.1"
+"puppeteer-core@npm:19.8.5":
+  version: 19.8.5
+  resolution: "puppeteer-core@npm:19.8.5"
+  dependencies:
+    "@puppeteer/browsers": 0.4.0
+    chromium-bidi: 0.4.6
+    cross-fetch: 3.1.5
+    debug: 4.3.4
+    devtools-protocol: 0.0.1107588
+    extract-zip: 2.0.1
+    https-proxy-agent: 5.0.1
+    proxy-from-env: 1.1.0
+    tar-fs: 2.1.1
+    unbzip2-stream: 1.4.3
+    ws: 8.13.0
+  peerDependencies:
+    typescript: ">= 4.7.4"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 6bad7a7279403be6b6799876e2ebafb3713d965ec4befe78207b19e05c4a06ff296b90f7f04007f32a80a41a1bf96930a86524cba27915f0b76112261d30833f
+  languageName: node
+  linkType: hard
+
+"puppeteer-extra-plugin-stealth@npm:^2.11.2":
+  version: 2.11.2
+  resolution: "puppeteer-extra-plugin-stealth@npm:2.11.2"
   dependencies:
     debug: ^4.1.1
-    puppeteer-extra-plugin: ^3.2.2
-    puppeteer-extra-plugin-user-preferences: ^2.4.0
+    puppeteer-extra-plugin: ^3.2.3
+    puppeteer-extra-plugin-user-preferences: ^2.4.1
   peerDependencies:
     playwright-extra: "*"
     puppeteer-extra: "*"
@@ -9612,17 +9689,17 @@ __metadata:
       optional: true
     puppeteer-extra:
       optional: true
-  checksum: 8d5c3c8f650113dd35e9dd8c93617528921b6d5b0331e60006324db4080c56268b0f1a3d7af036cf6741fbdd4587f5d4400545e7d225242a0cce698cd3e51295
+  checksum: 13ab2b906c1cd1a75bb346074e6ed75dd33da426e9b7d2e111dee6d497ae9ff42f44c2e5b0d48a04b545e862f9d27d8ecf61fa1863201afc8a9410121ed65a4b
   languageName: node
   linkType: hard
 
-"puppeteer-extra-plugin-user-data-dir@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "puppeteer-extra-plugin-user-data-dir@npm:2.4.0"
+"puppeteer-extra-plugin-user-data-dir@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "puppeteer-extra-plugin-user-data-dir@npm:2.4.1"
   dependencies:
     debug: ^4.1.1
     fs-extra: ^10.0.0
-    puppeteer-extra-plugin: ^3.2.2
+    puppeteer-extra-plugin: ^3.2.3
     rimraf: ^3.0.2
   peerDependencies:
     playwright-extra: "*"
@@ -9632,18 +9709,18 @@ __metadata:
       optional: true
     puppeteer-extra:
       optional: true
-  checksum: ba414fcf75768b85f8785815bb1bef948615225c3b663e01bf7b72dc7c425987e2db402f564c48dbae8af77a19179bcca9ada8e51f947b5850d2b4e9f52e5696
+  checksum: f360b3bb22eeb899b23b6e2a38412ddfeda4b2333e08f77452732e16f094f33725272ee81150428e2c20b39d4d88edc87584d8344bd761c9ef8ae5d681968399
   languageName: node
   linkType: hard
 
-"puppeteer-extra-plugin-user-preferences@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "puppeteer-extra-plugin-user-preferences@npm:2.4.0"
+"puppeteer-extra-plugin-user-preferences@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "puppeteer-extra-plugin-user-preferences@npm:2.4.1"
   dependencies:
     debug: ^4.1.1
     deepmerge: ^4.2.2
-    puppeteer-extra-plugin: ^3.2.2
-    puppeteer-extra-plugin-user-data-dir: ^2.4.0
+    puppeteer-extra-plugin: ^3.2.3
+    puppeteer-extra-plugin-user-data-dir: ^2.4.1
   peerDependencies:
     playwright-extra: "*"
     puppeteer-extra: "*"
@@ -9652,13 +9729,13 @@ __metadata:
       optional: true
     puppeteer-extra:
       optional: true
-  checksum: f8c2359b1ddce3d7b8f543b2a8708688e74da5b7d705f79d2599d485d0fc88b4465303348a7e6977bc1705817f4d40f2db3b1b532776cc602a700487f3d80ba3
+  checksum: e0e50145d1d32626a8bb75afeb0dc238d63c05a8d264e12bb249b06aa34f7c116f6ec531335e964ea715837759dacd505d2fa8f6c9d478e983303eb2cb701ec9
   languageName: node
   linkType: hard
 
-"puppeteer-extra-plugin@npm:^3.2.2":
-  version: 3.2.2
-  resolution: "puppeteer-extra-plugin@npm:3.2.2"
+"puppeteer-extra-plugin@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "puppeteer-extra-plugin@npm:3.2.3"
   dependencies:
     "@types/debug": ^4.1.0
     debug: ^4.1.1
@@ -9671,13 +9748,13 @@ __metadata:
       optional: true
     puppeteer-extra:
       optional: true
-  checksum: 9ace2300d9c0089e7dbef6ea46bca8e0cb3ea8dcaec621c093569fdad000da4947854970d5d22edd175b3631480fdd899e4de6f1b0e9050f7e6a07eebbe8d538
+  checksum: 18c2780a151e023ed145cd7768a6cf2dba1c124bce920de5f7815dcd872550288554161b1474037e8819969b1adfad41bdc09a9aadfd155338abc6d22699b7ed
   languageName: node
   linkType: hard
 
-"puppeteer-extra@npm:^3.3.4":
-  version: 3.3.4
-  resolution: "puppeteer-extra@npm:3.3.4"
+"puppeteer-extra@npm:^3.3.6":
+  version: 3.3.6
+  resolution: "puppeteer-extra@npm:3.3.6"
   dependencies:
     "@types/debug": ^4.1.0
     debug: ^4.1.1
@@ -9693,26 +9770,21 @@ __metadata:
       optional: true
     puppeteer-core:
       optional: true
-  checksum: dfbeceba086606c5f74305b207b78b0a7248b6667385210d6462af1fa01b6fe50c631449c3a343005ed712aa37e44f10539abc29429cac86baa76351d0c3d10b
+  checksum: d3097a16957dbc7c23e960429020b4c32b3d56d54e80103781ce8cc17b3eebda4554caad454744ff212ff69c19653cc0d4978d6f35381ffdfd1db1cedd0c61a6
   languageName: node
   linkType: hard
 
-"puppeteer@npm:18.1.0":
-  version: 18.1.0
-  resolution: "puppeteer@npm:18.1.0"
+"puppeteer@npm:^19.8.5":
+  version: 19.8.5
+  resolution: "puppeteer@npm:19.8.5"
   dependencies:
-    cross-fetch: 3.1.5
-    debug: 4.3.4
-    devtools-protocol: 0.0.1045489
-    extract-zip: 2.0.1
+    "@puppeteer/browsers": 0.4.0
+    cosmiconfig: 8.1.3
     https-proxy-agent: 5.0.1
     progress: 2.0.3
     proxy-from-env: 1.1.0
-    rimraf: 3.0.2
-    tar-fs: 2.1.1
-    unbzip2-stream: 1.4.3
-    ws: 8.9.0
-  checksum: b805067a1cb5d33afeb5359b268c2d2f8915ee066f653622a045b4fc9a14e5fbfb13894d67903183d023e87e2f8302d78d3fcc75d9ad2973fb8e49daf3261402
+    puppeteer-core: 19.8.5
+  checksum: 3e83eff1ab650e50f708b38beadac51ba68be9a5f1b4c6227996e92d87873b99e8cc20304e72a68acd1501bdbfa222f81db0d0b20c37196a9b73523e1fcf987b
   languageName: node
   linkType: hard
 
@@ -12063,18 +12135,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.9.0":
-  version: 8.9.0
-  resolution: "ws@npm:8.9.0"
+"ws@npm:8.13.0":
+  version: 8.13.0
+  resolution: "ws@npm:8.13.0"
   peerDependencies:
     bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
+    utf-8-validate: ">=5.0.2"
   peerDependenciesMeta:
     bufferutil:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 23aa0f021b2eb65c108ec4c3e08c0d81ba01f82b500432dfe327fd6be36079c1d81fdb0eac6464d2a0eb49904d34a9ab8c59619d673fa07b8346f83aeb0cbf12
+  checksum: 53e991bbf928faf5dc6efac9b8eb9ab6497c69feeb94f963d648b7a3530a720b19ec2e0ec037344257e05a4f35bd9ad04d9de6f289615ffb133282031b18c61c
   languageName: node
   linkType: hard
 
@@ -12189,6 +12261,21 @@ __metadata:
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
   checksum: ed2d96a616a9e3e1cc7d204c62ecc61f7aaab633dcbfab2c6df50f7f87b393993fe6640d017759fe112d0cb1e0119f2b4150a87305cc873fd90831c6a58ccf1c
+  languageName: node
+  linkType: hard
+
+"yargs@npm:17.7.1":
+  version: 17.7.1
+  resolution: "yargs@npm:17.7.1"
+  dependencies:
+    cliui: ^8.0.1
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.3
+    y18n: ^5.0.5
+    yargs-parser: ^21.1.1
+  checksum: 3d8a43c336a4942bc68080768664aca85c7bd406f018bad362fd255c41c8f4e650277f42fd65d543fce99e084124ddafee7bbfc1a5c6a8fda4cec78609dcf8d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Details

This PR updates to version 1.7.0 of `accessibility-insights-scan`. The major change in this version is bumping Puppeteer from `18.1.0` to `19.8.5`, which updates the version of Chromium by about 2 years and notably includes the fix for https://github.com/puppeteer/puppeteer/issues/9965, which we have an active customer support thread requesting.

##### Motivation

Address customer support issue

##### Context

See internal support thread entitled "RE: Support For Adding Accessibility Insights To CI Deployment ."

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
