### PR TITLE
fix: avoid error when outputDir is contained in a non-existent directory

### DIFF
--- a/packages/shared/src/scanner/scanner.spec.ts
+++ b/packages/shared/src/scanner/scanner.spec.ts
@@ -405,7 +405,7 @@ describe(Scanner, () => {
                 .returns(() => false)
                 .verifiable();
             // eslint-disable-next-line security/detect-non-literal-fs-filename
-            fsMock.setup((fsm) => fsm.mkdirSync(reportOutDir)).verifiable();
+            fsMock.setup((fsm) => fsm.mkdirSync(reportOutDir, { recursive: true })).verifiable();
 
             const crawlerParams: CrawlerRunOptions = {
                 baseUrl: scanArguments.url,

--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -194,7 +194,7 @@ export class Scanner {
         if (!this.fileSystemObj.existsSync(outDirectory)) {
             this.logger.logInfo(`Report output directory does not exist. Creating directory ${outDirectory}`);
             // eslint-disable-next-line security/detect-non-literal-fs-filename
-            this.fileSystemObj.mkdirSync(outDirectory);
+            this.fileSystemObj.mkdirSync(outDirectory, { recursive: true });
         }
     }
 


### PR DESCRIPTION
#### Details

This PR adds a `{ recursive: true }` option to the point where we create the `outputDir`, such that it will no longer be an error to specify an outputDir with an ancestor that doesn't exist yet.

##### Motivation

Addresses #1609 

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes #1609
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
