### PR TITLE
fix: improve accuracy of log message default `chromePath` behavior

### DIFF
--- a/packages/shared/src/scanner/scanner.spec.ts
+++ b/packages/shared/src/scanner/scanner.spec.ts
@@ -393,7 +393,7 @@ describe(Scanner, () => {
                 .verifiable(Times.once());
             loggerMock.setup((lm) => lm.logDebug(`Starting accessibility scanning of URL ${scanArguments.url}`)).verifiable(Times.once());
             loggerMock
-                .setup((lm) => lm.logDebug(`Chrome app executable: ${scanArguments.chromePath ?? 'system default'}`))
+                .setup((lm) => lm.logDebug(`Chrome app executable: ${scanArguments.chromePath ?? 'default (bundled with task)'}`))
                 .verifiable(Times.once());
             loggerMock
                 .setup((lm) => lm.logInfo(`Report output directory does not exist. Creating directory ${reportOutDir}`))

--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -111,7 +111,7 @@ export class Scanner {
 
             this.logger.logStartGroup(`Scanning URL ${scanArguments.url}`);
             this.logger.logDebug(`Starting accessibility scanning of URL ${scanArguments.url}`);
-            this.logger.logDebug(`Chrome app executable: ${scanArguments.chromePath ?? 'system default'}`);
+            this.logger.logDebug(`Chrome app executable: ${scanArguments.chromePath ?? 'default (Puppeteer-bundled)'}`);
 
             const crawlerParameters = this.crawlerParametersBuilder.build(scanArguments);
 

--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -111,7 +111,7 @@ export class Scanner {
 
             this.logger.logStartGroup(`Scanning URL ${scanArguments.url}`);
             this.logger.logDebug(`Starting accessibility scanning of URL ${scanArguments.url}`);
-            this.logger.logDebug(`Chrome app executable: ${scanArguments.chromePath ?? 'default (Puppeteer-bundled)'}`);
+            this.logger.logDebug(`Chrome app executable: ${scanArguments.chromePath ?? 'default (bundled with task)'}`);
 
             const crawlerParameters = this.crawlerParametersBuilder.build(scanArguments);
 


### PR DESCRIPTION
#### Details

This PR improves the log message we emit when the task is using a default (unset) `chromePath`. Previously, the log message said this would result in using the "system default", which is misleading; what we actually use (both in practice and as-documented) in that case is the version of Chromium bundled with Puppeteer.

##### Motivation

See second bullet point in https://github.com/microsoft/accessibility-insights-service/issues/2426#issuecomment-1528125055

##### Context

https://github.com/microsoft/accessibility-insights-service/issues/2426

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
