### PR TITLE
chore: Classify azure-pipelines-task-lib as a devdependency

### DIFF
--- a/packages/ado-extension/package.json
+++ b/packages/ado-extension/package.json
@@ -30,12 +30,12 @@
     "dependencies": {
         "@accessibility-insights-action/shared": "workspace:*",
         "applicationinsights": "^2.5.1",
-        "azure-pipelines-task-lib": "^4.3.1",
         "reflect-metadata": "^0.1.13"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.1",
         "@typescript-eslint/parser": "^5.59.1",
+        "azure-pipelines-task-lib": "^4.3.1",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
         "eslint": "^8.38.0",
         "eslint-plugin-security": "^1.7.1",


### PR DESCRIPTION
#### Details

[CVE-2022-37614](https://nvd.nist.gov/vuln/detail/CVE-2022-37614) was recently flagged against our repo. It comes from `mockery`, which is consumed by `azure-pipelines-task-lib`, which appears to be used purely for local E2E tests. I've confirmed this opinion with both @ThanyaLeif and @katydecorah, so we shouldn't need to distribute `azure-pipelines-task-lib` as part of the dist folder. E2E tests work locally. 

##### Motivation

Ensure that we don't ship more than we need, minimize potential downstream impact of the CVE.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Corroborates dismissal of CG [#328](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_workitems/edit/328)
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
