### PR TITLE
chore: Increase dependabot PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
     prefix: chore
     include: scope
   versioning-strategy: increase
+  open-pull-requests-limit: 10 # Default value of 5 has been problematic
   ignore:
     # axe-core updates require extra validation and synchronization with
     # accessibility-insights-web; we handle them as features, not auto-updates.


### PR DESCRIPTION
#### Details

Increase dependabot PR limit from the default of 5. We've seen cases where our updates get blocked behind dependabot PR's that contain breaking changes. Since we're scheduled to run dependabot once per day, we end up accumulating updates without realizing it.

##### Motivation

Updates shouldn't hide in the dependabot queue.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes 
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
