### PR TITLE
chore: Pin e2e scenarios that were previously omitted

### DIFF
--- a/packages/ado-extension/e2e/ado-extension.test.ts
+++ b/packages/ado-extension/e2e/ado-extension.test.ts
@@ -95,7 +95,35 @@ describe('Sample task tests', () => {
         inputs = {
             staticSiteDir: path.join(__dirname, '..', '..', '..', 'dev', 'website-root'),
             staticSitePort: '39983',
+            inputUrls: 'http://localhost:39983/unlinked/index.html',
+        };
+        const testSubject = runTestWithInputs(inputs);
+
+        expect(testSubject.warningIssues.length).toEqual(0);
+        expect(testSubject.errorIssues.length).toEqual(1);
+        expect(testSubject.stdOutContained('Processing page http://localhost:39983/unlinked/')).toBeTruthy();
+        expect(testSubject.stdOutContained('Rules: 4 with failures, 13 passed, 39 not applicable')).toBeTruthy();
+    });
+
+    it('scans folders that are passed in as inputUrls (without trailing slash)', () => {
+        inputs = {
+            staticSiteDir: path.join(__dirname, '..', '..', '..', 'dev', 'website-root'),
+            staticSitePort: '39983',
             inputUrls: 'http://localhost:39983/unlinked',
+        };
+        const testSubject = runTestWithInputs(inputs);
+
+        expect(testSubject.warningIssues.length).toEqual(0);
+        expect(testSubject.errorIssues.length).toEqual(1);
+        expect(testSubject.stdOutContained('Processing page http://localhost:39983/unlinked/')).toBeTruthy();
+        expect(testSubject.stdOutContained('Rules: 4 with failures, 13 passed, 39 not applicable')).toBeTruthy();
+    });
+
+    it('scans folders that are passed in as inputUrls (with trailing slash)', () => {
+        inputs = {
+            staticSiteDir: path.join(__dirname, '..', '..', '..', 'dev', 'website-root'),
+            staticSitePort: '39983',
+            inputUrls: 'http://localhost:39983/unlinked/',
         };
         const testSubject = runTestWithInputs(inputs);
 


### PR DESCRIPTION
#### Details

Add e2e scenarios to pin existing crawling behavior. The gaps were noticed when considering moving to ai-scan 2.x

##### Motivation

Detect future crawling changes

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
This adds 2 tests with identical checks as an existing test. I thought about using the `it.each` construct for the existing test, but it seemed better to have 3 simple tests than one that is harder to read

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
