### PR TITLE
chore: Sign Canary build in validation pipeline

### DIFF
--- a/pipelines/canary-release.yaml
+++ b/pipelines/canary-release.yaml
@@ -37,7 +37,7 @@ stages:
             parameters:
                 ${{ if eq(parameters.variableGroupName, 'ado-extension-canary') }}:
                     environment: ado-extension-canary
-                    shouldSign: false
+                    shouldSign: true
                     visibility: preview
                 ${{ if ne(parameters.variableGroupName, 'ado-extension-canary') }}:
                     environment: ado-extension-test


### PR DESCRIPTION
#### Details

This change adds signing of the Canary release of the ADO extension. While signing is required only for the Production release, signing the Canary release provides with an early warning of potential signing problems (like the one that we had earlier this year when our secret expired without our realizing it).

Signing takes about 2 minutes, so the release pipeline total time will go from about 2 minutes to about 4 minutes. None of our processes rely on the pipeline speed, so this seems like an acceptable change.

Test build using this change: https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=47432&view=results

##### Motivation

Avoid surprises when we need a production release

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
I considered making the signing variable default to false for Canary, then we could set it to true when validating secret rotation, but signing all Canary releases was a simpler process and a better overall signal.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
