### PR TITLE
Chore: Remove inline snapshots

### DIFF
--- a/packages/ado-extension/e2e/__snapshots__/ado-extension.test.ts.snap
+++ b/packages/ado-extension/e2e/__snapshots__/ado-extension.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Sample task tests returns expected scan summary and footer (ignoring user agent) 1`] = `
+"-------------------
+Scan summary
+URLs: 1 with failures, 0 passed, 0 not scannable
+Rules: 5 with failures, 14 passed, 36 not applicable
+
+-------------------
+This scan used axe-core 4.7.2"
+`;

--- a/packages/ado-extension/e2e/ado-extension.test.ts
+++ b/packages/ado-extension/e2e/ado-extension.test.ts
@@ -15,15 +15,7 @@ describe('Sample task tests', () => {
             url: 'https://www.washington.edu/accesscomputing/AU/before.html',
         };
         const testSubject = runTestWithInputs(inputs);
-        expect(filterStdOut(testSubject.stdout)).toMatchInlineSnapshot(`
-            "-------------------
-            Scan summary
-            URLs: 1 with failures, 0 passed, 0 not scannable
-            Rules: 5 with failures, 14 passed, 36 not applicable
-
-            -------------------
-            This scan used axe-core 4.7.2"
-        `);
+        expect(filterStdOut(testSubject.stdout)).toMatchSnapshot();
 
         expect(
             testSubject.stdOutContainedRegex(new RegExp('This scan used axe-core 4.* with a display resolution of 1920x1080.$')),

--- a/packages/shared/src/logger/__snapshots__/recording-test-logger.spec.ts.snap
+++ b/packages/shared/src/logger/__snapshots__/recording-test-logger.spec.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RecordingTestLogger records different log calls in order with readable snapshotting 1`] = `
+[
+  "[info] message 1 (info)",
+  "[debug] message 2 (debug)",
+  "[info] message 3 (info)",
+  {
+    "message": "[info] message 4 (info w/props)",
+    "properties": {
+      "key": "val",
+    },
+  },
+  {
+    "exception": [Error: message 5 (exception)],
+  },
+  {
+    "exception": [ErrorWithCause: message 6 (exceptionAny)],
+  },
+  "[warning] message 7 (warning)",
+  "[error] message 8 (error)",
+  "[group] message 9 (start group)",
+  "[endgroup] ",
+]
+`;

--- a/packages/shared/src/logger/recording-test-logger.spec.ts
+++ b/packages/shared/src/logger/recording-test-logger.spec.ts
@@ -19,28 +19,6 @@ describe(RecordingTestLogger, () => {
         testSubject.logStartGroup('message 9 (start group)');
         testSubject.logEndGroup();
 
-        expect(testSubject.recordedLogs()).toMatchInlineSnapshot(`
-            [
-              "[info] message 1 (info)",
-              "[debug] message 2 (debug)",
-              "[info] message 3 (info)",
-              {
-                "message": "[info] message 4 (info w/props)",
-                "properties": {
-                  "key": "val",
-                },
-              },
-              {
-                "exception": [Error: message 5 (exception)],
-              },
-              {
-                "exception": [ErrorWithCause: message 6 (exceptionAny)],
-              },
-              "[warning] message 7 (warning)",
-              "[error] message 8 (error)",
-              "[group] message 9 (start group)",
-              "[endgroup] ",
-            ]
-        `);
+        expect(testSubject.recordedLogs()).toMatchSnapshot();
     });
 });

--- a/packages/shared/src/progress-reporter/__snapshots__/all-progress-reporter.spec.ts.snap
+++ b/packages/shared/src/progress-reporter/__snapshots__/all-progress-reporter.spec.ts.snap
@@ -6,6 +6,12 @@ exports[`AllProgressReporter complete should rethrow an AggregateError if multip
     error from failingReporter"
 `;
 
+exports[`AllProgressReporter didScanSucceed should rethrow an AggregateError if multiple reporters throw 1`] = `
+"Multiple progress reporters encountered Errors
+    error from failingReporter
+    error from failingReporter"
+`;
+
 exports[`AllProgressReporter failRun should rethrow an AggregateError if multiple reporters throw 1`] = `
 "Multiple progress reporters encountered Errors
     error from failingReporter

--- a/packages/shared/src/progress-reporter/__snapshots__/all-progress-reporter.spec.ts.snap
+++ b/packages/shared/src/progress-reporter/__snapshots__/all-progress-reporter.spec.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AllProgressReporter start should rethrow an AggregateError if multiple reporters throw 1`] = `
+"Multiple progress reporters encountered Errors
+    error from failingReporter
+    error from failingReporter"
+`;

--- a/packages/shared/src/progress-reporter/__snapshots__/all-progress-reporter.spec.ts.snap
+++ b/packages/shared/src/progress-reporter/__snapshots__/all-progress-reporter.spec.ts.snap
@@ -6,6 +6,12 @@ exports[`AllProgressReporter complete should rethrow an AggregateError if multip
     error from failingReporter"
 `;
 
+exports[`AllProgressReporter failRun should rethrow an AggregateError if multiple reporters throw 1`] = `
+"Multiple progress reporters encountered Errors
+    error from failingReporter
+    error from failingReporter"
+`;
+
 exports[`AllProgressReporter start should rethrow an AggregateError if multiple reporters throw 1`] = `
 "Multiple progress reporters encountered Errors
     error from failingReporter

--- a/packages/shared/src/progress-reporter/__snapshots__/all-progress-reporter.spec.ts.snap
+++ b/packages/shared/src/progress-reporter/__snapshots__/all-progress-reporter.spec.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AllProgressReporter complete should rethrow an AggregateError if multiple reporters throw 1`] = `
+"Multiple progress reporters encountered Errors
+    error from failingReporter
+    error from failingReporter"
+`;
+
 exports[`AllProgressReporter start should rethrow an AggregateError if multiple reporters throw 1`] = `
 "Multiple progress reporters encountered Errors
     error from failingReporter

--- a/packages/shared/src/progress-reporter/all-progress-reporter.spec.ts
+++ b/packages/shared/src/progress-reporter/all-progress-reporter.spec.ts
@@ -67,11 +67,7 @@ describe(AllProgressReporter, () => {
         it('should rethrow an AggregateError if multiple reporters throw', async () => {
             const testSubject = new AllProgressReporter([failingReporter, failingReporter]);
 
-            await expect(testSubject.start()).rejects.toThrowErrorMatchingInlineSnapshot(`
-                        "Multiple progress reporters encountered Errors
-                            error from failingReporter
-                            error from failingReporter"
-                    `);
+            await expect(testSubject.start()).rejects.toThrowErrorMatchingSnapshot();
         });
     });
 

--- a/packages/shared/src/progress-reporter/all-progress-reporter.spec.ts
+++ b/packages/shared/src/progress-reporter/all-progress-reporter.spec.ts
@@ -146,11 +146,7 @@ describe(AllProgressReporter, () => {
             testSubject = new AllProgressReporter([failingReporter, failingReporter]);
 
             // The error from the first reporter should be rethrown, but we should still see the call to the second reporter
-            await expect(testSubject.failRun()).rejects.toThrowErrorMatchingInlineSnapshot(`
-                    "Multiple progress reporters encountered Errors
-                        error from failingReporter
-                        error from failingReporter"
-                `);
+            await expect(testSubject.failRun()).rejects.toThrowErrorMatchingSnapshot();
         });
     });
 

--- a/packages/shared/src/progress-reporter/all-progress-reporter.spec.ts
+++ b/packages/shared/src/progress-reporter/all-progress-reporter.spec.ts
@@ -180,11 +180,7 @@ describe(AllProgressReporter, () => {
             testSubject = new AllProgressReporter([failingReporter, failingReporter]);
 
             // The error from the first reporter should be rethrown, but we should still see the call to the second reporter
-            await expect(testSubject.didScanSucceed()).rejects.toThrowErrorMatchingInlineSnapshot(`
-                    "Multiple progress reporters encountered Errors
-                        error from failingReporter
-                        error from failingReporter"
-                `);
+            await expect(testSubject.didScanSucceed()).rejects.toThrowErrorMatchingSnapshot();
         });
 
         it('should return true if all reporters return true', async () => {

--- a/packages/shared/src/progress-reporter/all-progress-reporter.spec.ts
+++ b/packages/shared/src/progress-reporter/all-progress-reporter.spec.ts
@@ -112,11 +112,7 @@ describe(AllProgressReporter, () => {
         it('should rethrow an AggregateError if multiple reporters throw', async () => {
             testSubject = new AllProgressReporter([failingReporter, failingReporter]);
 
-            await expect(testSubject.completeRun(axeResultsStub)).rejects.toThrowErrorMatchingInlineSnapshot(`
-                        "Multiple progress reporters encountered Errors
-                            error from failingReporter
-                            error from failingReporter"
-                    `);
+            await expect(testSubject.completeRun(axeResultsStub)).rejects.toThrowErrorMatchingSnapshot();
         });
     });
 

--- a/packages/shared/src/utils/__snapshots__/aggregate-error.spec.ts.snap
+++ b/packages/shared/src/utils/__snapshots__/aggregate-error.spec.ts.snap
@@ -5,3 +5,12 @@ exports[`AggregateError uses the pinned message format 1`] = `
     first error
     second error"
 `;
+
+exports[`AggregateError uses the pinned stack format 1`] = `
+"AggregateError: Multiple errors occurred
+    Error: first error
+        at <normalized first location>
+    Error: second error
+        at <normalized second location>
+    at <normalized location>"
+`;

--- a/packages/shared/src/utils/__snapshots__/aggregate-error.spec.ts.snap
+++ b/packages/shared/src/utils/__snapshots__/aggregate-error.spec.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AggregateError uses the pinned message format 1`] = `
+"Multiple errors occurred
+    first error
+    second error"
+`;

--- a/packages/shared/src/utils/aggregate-error.spec.ts
+++ b/packages/shared/src/utils/aggregate-error.spec.ts
@@ -50,14 +50,7 @@ describe(AggregateError, () => {
             .replace(/^(    at) .*\n/gm, '') // This removes all stack lines except the last one (which won't have the \n)
             .replace(/^(    at) .*$/gm, '$1 <normalized location>'); // This normalizes the path/location in the last stack line
 
-        expect(stackWithLocationsCollapsed).toMatchInlineSnapshot(`
-            "AggregateError: Multiple errors occurred
-                Error: first error
-                    at <normalized first location>
-                Error: second error
-                    at <normalized second location>
-                at <normalized location>"
-        `);
+        expect(stackWithLocationsCollapsed).toMatchSnapshot();
     });
 
     it('uses the name "AggregateError"', () => {

--- a/packages/shared/src/utils/aggregate-error.spec.ts
+++ b/packages/shared/src/utils/aggregate-error.spec.ts
@@ -41,11 +41,7 @@ describe(AggregateError, () => {
     });
 
     it('uses the pinned message format', () => {
-        expect(testSubject.message).toMatchInlineSnapshot(`
-            "Multiple errors occurred
-                first error
-                second error"
-        `);
+        expect(testSubject.message).toMatchSnapshot();
     });
 
     it('uses the pinned stack format', () => {


### PR DESCRIPTION
#### Details

Due to https://github.com/jestjs/jest/issues/14305, our inline snapshots are causing problems when using `yarn test -u`. We discussed this internally and decided that the simplest approach was to convert the inline snapshots to traditional snapshots. For most cases, this was just removing "Inline" from the method name and removing the string that provided the snapshot. A small number of test cases were checking multiple inline snapshots in the same test, so the approach there was to build an array of the things that were previously checked individually, then having a single snapshot for the test case.

I ran `yarn test -u` and `yarn format:fix` after making all of the changes, just to make sure that we're ready for future changes.

It will probably be easiest to review this one commit at a time--each of the 32 commits represents the conversion of a single test case.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
