### PR TITLE
fix: Run current canary release

### DIFF
--- a/pipelines/ado-extension-canary-validation.yaml
+++ b/pipelines/ado-extension-canary-validation.yaml
@@ -18,4 +18,4 @@ pool: a11y-ado-auth
 extends:
     template: ado-extension-validation-template.yaml
     parameters:
-        taskUnderTest: accessibility-insights.canary.task.accessibility-insights@1
+        taskUnderTest: accessibility-insights.canary.task.accessibility-insights@3

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -32,6 +32,7 @@ steps:
           staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
           failOnAccessibilityError: false
           outputArtifactName: accessibility-reports-case-succeed-1
+          scanTimeout: 180000
 
     - task: ${{ parameters.taskUnderTest }}
       displayName: '[should succeed] case succeed-2: up-to-date baseline'


### PR DESCRIPTION
#### Details

On August 30th, our Canary releases were (probably unintentionally) bumped from 1.X to 3.X. The validation pipeline didn't update, so our Canary validations have been running the wrong version for several weeks. This change gets us back in sync with the Canary releases and increases the scanning timeout since the new crawler is a little slower than the old one was.

Also, we're not in a shippable state because of a problem with telemetry initialization that we'll fix separately.

##### Motivation

Canary pipeline needs to be reliable

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
There are 3 things this doesn't address and that we might want to do in the future:
- Should we restore Canary as v1.X? This will require cleaning up the existing 3.X versions, resetting the canary prototype, and maybe adding a guard against another unintended change of the Canary version
- Since the new scanner is slower, should we increase the default timeout? Customers who have overridden their timeout may need to increase them further, so this only goes so far ☹️ 
- An update to ApplicationInsights introduced an error. We'll need to address this after the pipeline is restored to a functional state

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
