### PR TITLE
feat(oncall-vendor-transition): Increase Dependabot limit and move scheduled runs to 08:30 UTC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
     prefix: chore
     include: scope
   versioning-strategy: increase
-  open-pull-requests-limit: 20  # Default value of 5 has been problematic
+  open-pull-requests-limit: 10  # Default value of 5 has been problematic
   ignore:
     # axe-core updates require extra validation and synchronization with
     # accessibility-insights-web; we handle them as features, not auto-updates.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "11:00"
-    timezone: "America/Los_Angeles" # Pacific Time
+    time: "8:30"  # UTC
   labels:
   - "category: engineering"
   - dependencies
@@ -16,7 +15,7 @@ updates:
     prefix: chore
     include: scope
   versioning-strategy: increase
-  open-pull-requests-limit: 10 # Default value of 5 has been problematic
+  open-pull-requests-limit: 20  # Default value of 5 has been problematic
   ignore:
     # axe-core updates require extra validation and synchronization with
     # accessibility-insights-web; we handle them as features, not auto-updates.
@@ -41,8 +40,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "11:00"
-    timezone: "America/Los_Angeles" # Pacific Time
+    time: "8:30"  # UTC
   labels:
   - "category: engineering"
   - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "8:30"  # UTC
+    time: "08:30"  # UTC
   labels:
   - "category: engineering"
   - dependencies
@@ -40,7 +40,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "8:30"  # UTC
+    time: "08:30"  # UTC
   labels:
   - "category: engineering"
   - dependencies


### PR DESCRIPTION
#### Details
* Dependabot for our repos is scheduled to run at fairly different times that are inconvenient for some geographies. This PR moves this repo's dependabot time to 08:30 UTC (14:00 IST, 01:30 PDT, 00:30 PST).
* Web-based projects have many dependencies, and a low Dependabot PR limit causes us to need to run Dependabot manually multiple times to update all dependencies. This PR increases the limit.

##### Motivation
Part of [Feature 2083093](https://mseng.visualstudio.com/1ES/_queries/edit/2083093) (internal access required to view).

#### Pull request checklist
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
