### PR TITLE
chore: Revert #1823

### DIFF
--- a/pipelines/canary-release.yaml
+++ b/pipelines/canary-release.yaml
@@ -37,7 +37,7 @@ stages:
             parameters:
                 ${{ if eq(parameters.variableGroupName, 'ado-extension-canary') }}:
                     environment: ado-extension-canary
-                    shouldSign: true
+                    shouldSign: false
                     visibility: preview
                 ${{ if ne(parameters.variableGroupName, 'ado-extension-canary') }}:
                     environment: ado-extension-test


### PR DESCRIPTION
#### Details

When running in the Canary validation pipeline, the ADO extension is throwing an error that it can't locate `applicationinsights.json` in the `node_modules` folder. I've been able to prove that `applicationinsights,json` was present in Canary release 3.5.2 and earlier, but is absent in Canary release 3.5.3 and newer. There were 2 changes between the 2 releases: #1804 (bump the `@types/lodash` version) and #1823 (sign the Canary package). Of the two changes, it seems much more likely that signing the package was the cause of the change. It's also the simpler change to revert, so we'll give it a try.

##### Motivation

Hopefully fix issue in Canary validation pipeline

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
If this fixes the problem, we'll also want to revert #1866, which was the assumed (but later disproven) source of the Canary pipeline problem.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
