### PR TITLE
chore: Restore canary signing

### DIFF
--- a/pipelines/canary-release.yaml
+++ b/pipelines/canary-release.yaml
@@ -37,7 +37,7 @@ stages:
             parameters:
                 ${{ if eq(parameters.variableGroupName, 'ado-extension-canary') }}:
                     environment: ado-extension-canary
-                    shouldSign: false
+                    shouldSign: true
                     visibility: preview
                 ${{ if ne(parameters.variableGroupName, 'ado-extension-canary') }}:
                     environment: ado-extension-test


### PR DESCRIPTION
#### Details

Canary signing has flip-flopped. In #1823, it apparently broke our Canary validation pipeline. #1871 reverted it, but the pipeline was actually working before #1871 merged, suggesting that something else was causing the problem. So this is setting the signing flag back to true since we want that behavior and the empirical data suggests that we can.

##### Motivation

Signing the Canary build is a good early warning of expired secrets

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
