### PR TITLE
chore: Remove unneeded condition

### DIFF
--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -54,7 +54,6 @@ jobs:
             inputs:
                 staticSiteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
                 # intentionally omits artifactName; should go to default accessibility-reports
-            condition: succeededOrFailed()
             continueOnError: true
 
           - task: ${{ parameters.taskUnderTest }}


### PR DESCRIPTION
#### Details

When #1874 rearranged the validation tests, an unnecessary condition was left in place. it's unnecessary because the run should fail if either of the 2 previous test steps fail. Leaving the condition in place doesn't impact the overall result (thanks to the validation job), but it's both slower and inconsistent with the comment on lines 50 and 51.

Validation run is at https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=48628&view=results

##### Motivation

Avoid maintaining unnecessary stuff

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
