### PR TITLE
Draft: Run Attack Surface Analyzer in pipeline, save report as artifact

### DIFF
--- a/pipelines/ado-extension-canary-validation.yaml
+++ b/pipelines/ado-extension-canary-validation.yaml
@@ -26,8 +26,8 @@ extends:
     parameters:
         pool:
             name: a11y-ado-auth
-            image: windows-2022-secure
-            os: windows
+            image: ubuntu-22.04-secure
+            os: linux
         sdl:
             sourceAnalysisPool:
                 name: a11y-ado-auth

--- a/pipelines/ado-extension-canary-validation.yaml
+++ b/pipelines/ado-extension-canary-validation.yaml
@@ -26,8 +26,8 @@ extends:
     parameters:
         pool:
             name: a11y-ado-auth
-            image: ubuntu-22.04-secure
-            os: linux
+            image: windows-2022-secure
+            os: windows
         sdl:
             sourceAnalysisPool:
                 name: a11y-ado-auth

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -39,7 +39,7 @@ jobs:
           - script: dotnet tool install -g Microsoft.CST.AttackSurfaceAnalyzer.CLI
             displayName: 'Install AttackSurfaceAnalyzer'
 
-          - script: asa collect -cdFktpPsuw --debug --verbose --runid SDL
+          - script: asa collect -dFkpPsuw --debug --verbose --runid SDL
             displayName: 'Start AttackSurfaceAnalyzer'
 
           # Please keep all "should succeed" cases together as a block before and "should fail" cases.
@@ -52,7 +52,7 @@ jobs:
                 outputArtifactName: accessibility-reports-case-succeed-1
                 scanTimeout: 180000
 
-          - script: asa collect -cdFktpPsuw --debug --verbose --match-run-id SDL
+          - script: asa collect -dFkpPsuw --debug --verbose --match-run-id SDL
             displayName: 'Stop AttackSurfaceAnalyzer'
 
           - script: asa export-collect --outputsarif --outputpath SDL.sarif --debug --verbose

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -55,7 +55,7 @@ jobs:
           - script: asa collect -cdFktpPsuw --debug --verbose --match-run-id SDL
             displayName: 'Stop AttackSurfaceAnalyzer'
 
-          - script: asa export-collect --exportsarif --outputpath SDL.sarif --debug --verbose
+          - script: asa export-collect --outputsarif --outputpath SDL.sarif --debug --verbose
             displayName: 'Export AttackSurfaceAnalyzer results'
 
           - task: ${{ parameters.taskUnderTest }}

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -39,6 +39,9 @@ jobs:
           - script: dotnet tool install -g Microsoft.CST.AttackSurfaceAnalyzer.CLI
             displayName: 'Install AttackSurfaceAnalyzer'
 
+          - script: asa
+            displayName: 'Run AttackSurfaceAnalyzer'
+
           # Please keep all "should succeed" cases together as a block before and "should fail" cases.
           # Do not specify a condition so that the pipeline will fail if any of these fail.
           - task: ${{ parameters.taskUnderTest }}

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -21,6 +21,10 @@ jobs:
                 targetPath: '$(System.DefaultWorkingDirectory)/_accessibility-reports-case-fail-6'
                 artifactName: 'accessibility-reports-case-fail-6'
                 condition: succeededOrFailed()
+              - output: pipelineArtifact
+                targetPath: '$(System.DefaultWorkingDirectory)/ASA'
+                artifactName: 'ASA'
+                condition: succeededOrFailed()
       steps:
           - task: NodeTool@0
             inputs:
@@ -51,12 +55,6 @@ jobs:
                 failOnAccessibilityError: false
                 outputArtifactName: accessibility-reports-case-succeed-1
                 scanTimeout: 180000
-
-          - script: asa collect -dFkpPsuw --debug --verbose --match-run-id SDL
-            displayName: 'Stop AttackSurfaceAnalyzer'
-
-          - script: asa export-collect --outputsarif --outputpath SDL.sarif --debug --verbose
-            displayName: 'Export AttackSurfaceAnalyzer results'
 
           - task: ${{ parameters.taskUnderTest }}
             displayName: '[should succeed] case succeed-2: up-to-date baseline'
@@ -153,6 +151,12 @@ jobs:
                 siteDir: '$(System.DefaultWorkingDirectory)/dev/website-root'
             condition: succeededOrFailed()
             continueOnError: true
+
+          - script: asa collect -dFkpPsuw --debug --verbose --match-run-id SDL
+            displayName: 'Stop AttackSurfaceAnalyzer'
+
+          - script: mkdir $(System.DefaultWorkingDirectory)/ASA && asa export-collect --outputsarif --outputpath $(System.DefaultWorkingDirectory)/ASA --debug --verbose
+            displayName: 'Export AttackSurfaceAnalyzer results'
 
     - job: validate_artifacts
       dependsOn: run_tests

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -30,6 +30,15 @@ jobs:
           - script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &
             displayName: 'Start /dev/website-root test server at http://localhost:5858'
 
+          - task: UseDotNet@2
+            displayName: 'Install .NET 6'
+            inputs:
+                packageType: 'sdk'
+                version: '6.0'
+
+          - script: dotnet tool install -g Microsoft.CST.AttackSurfaceAnalyzer.CLI
+            displayName: 'Install AttackSurfaceAnalyzer'
+
           # Please keep all "should succeed" cases together as a block before and "should fail" cases.
           # Do not specify a condition so that the pipeline will fail if any of these fail.
           - task: ${{ parameters.taskUnderTest }}

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -39,8 +39,8 @@ jobs:
           - script: dotnet tool install -g Microsoft.CST.AttackSurfaceAnalyzer.CLI
             displayName: 'Install AttackSurfaceAnalyzer'
 
-          - script: asa
-            displayName: 'Run AttackSurfaceAnalyzer'
+          - script: asa collect -cdFktpPsuw --debug --verbose --runid SDL
+            displayName: 'Start AttackSurfaceAnalyzer'
 
           # Please keep all "should succeed" cases together as a block before and "should fail" cases.
           # Do not specify a condition so that the pipeline will fail if any of these fail.
@@ -51,6 +51,12 @@ jobs:
                 failOnAccessibilityError: false
                 outputArtifactName: accessibility-reports-case-succeed-1
                 scanTimeout: 180000
+
+          - script: asa collect -cdFktpPsuw --debug --verbose --match-run-id SDL
+            displayName: 'Stop AttackSurfaceAnalyzer'
+
+          - script: asa export-collect --exportsarif --outputpath SDL.sarif --debug --verbose
+            displayName: 'Export AttackSurfaceAnalyzer results'
 
           - task: ${{ parameters.taskUnderTest }}
             displayName: '[should succeed] case succeed-2: up-to-date baseline'

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -31,10 +31,10 @@ jobs:
             displayName: 'Start /dev/website-root test server at http://localhost:5858'
 
           - task: UseDotNet@2
-            displayName: 'Install .NET 6'
+            displayName: 'Install .NET 6.x'
             inputs:
                 packageType: 'sdk'
-                version: '6.0'
+                version: '6.x'
 
           - script: dotnet tool install -g Microsoft.CST.AttackSurfaceAnalyzer.CLI
             displayName: 'Install AttackSurfaceAnalyzer'


### PR DESCRIPTION
#### Details

PR to have a captured version of the changes to run the Attack Surface Analyzer in the pipeline. This is a recently added SDL requirement and since the extension runs in a pipeline, it seems to make sense to validate it there.

##### Motivation

Saving this for future reference

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
