### PR TITLE
Added null handling in scanner.ts

### DIFF
--- a/packages/shared/src/scanner/scanner.ts
+++ b/packages/shared/src/scanner/scanner.ts
@@ -174,15 +174,15 @@ export class Scanner {
         scanEnded: Date,
     ): CombinedReportParameters {
         const scanResultData = {
-            baseUrl: combinedScanResult.scanMetadata.baseUrl ?? 'n/a',
-            basePageTitle: combinedScanResult.scanMetadata.basePageTitle,
+            baseUrl: combinedScanResult?.scanMetadata?.baseUrl ?? 'n/a',
+            basePageTitle: combinedScanResult?.scanMetadata?.basePageTitle ?? 'n/a',
             scanEngineName: toolName,
             axeCoreVersion: this.axeInfo.version,
-            browserUserAgent: combinedScanResult.scanMetadata.userAgent,
-            urlCount: combinedScanResult.urlCount,
+            browserUserAgent: combinedScanResult?.scanMetadata?.userAgent ?? 'n/a',
+            urlCount: combinedScanResult?.urlCount ?? 0,
             scanStarted,
             scanEnded,
-            browserResolution: combinedScanResult.scanMetadata.browserResolution,
+            browserResolution: combinedScanResult?.scanMetadata?.browserResolution? ?? 'n/a',
         };
 
         return this.combinedReportDataConverter.convertCrawlingResults(combinedScanResult.combinedAxeResults, scanResultData);


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Null pointer exception when reading the scan results:

##[error][Exception]ErrorWithCause: An error occurred while scanning website page http://localhost:9009/
    at Logger.trackExceptionAny (/__w/_tasks/accessibility-insights_4811a442-2fd3-5aa8-ba1a-14cb7e24c113/2.0.6/index.js:189664:29)
    at Scanner.<anonymous> (/__w/_tasks/accessibility-insights_4811a442-2fd3-5aa8-ba1a-14cb7e24c113/2.0.6/index.js:190823:29)
    at Generator.next (<anonymous>)
    at fulfilled (/__w/_tasks/accessibility-insights_4811a442-2fd3-5aa8-ba1a-14cb7e24c113/2.0.6/index.js:190741:58)
caused by: TypeError: Cannot read property 'baseUrl' of undefined
    at Scanner.getCombinedReportParameters (/__w/_tasks/accessibility-insights_4811a442-2fd3-5aa8-ba1a-14cb7e24c113/2.0.6/index.js:190837:60)
    at Scanner.<anonymous> (/__w/_tasks/accessibility-insights_4811a442-2fd3-5aa8-ba1a-14cb7e24c113/2.0.6/index.js:190815:55)
    at Generator.next (<anonymous>)
    at fulfilled (/__w/_tasks/accessibility-insights_4811a442-2fd3-5aa8-ba1a-14cb7e24c113/2.0.6/index.js:190741:58)
Accessibility scanning of URL http://localhost:9009/ completed

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Addresses #2014

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [] Ran precheckin (`yarn precheckin`)
