### PR TITLE
chore(deps): added react-router-dom to ignore list of dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,11 @@ updates:
   - dependency-name: "applicationinsights"
     versions:
     - ">= 2.7.3"
+    # react-router-dom is used for test website for testing Urls with hash fragments.
+    # the feature used in test website is not supported from v6. https://github.com/remix-run/react-router/issues/11076
+  - dependency-name: "react-router-dom"
+    versions:
+    - ">= 5.3.4"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
#### Details

react-router-dom is used for test website for testing Urls with hash fragments.
The feature hashType="noslash" used in test website is not supported from v6. Please refer https://github.com/remix-run/react-router/issues/11076 for more details. As per this, this feature is not going to be supported in future version so we have to stick with v5 only

Also closed out dependabot PR https://github.com/microsoft/accessibility-insights-action/pull/2024

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
