### PR TITLE
fix: updated service connection name for market place in yaml pipeline

### DIFF
--- a/pipelines/package-vsix-file.yaml
+++ b/pipelines/package-vsix-file.yaml
@@ -40,7 +40,7 @@ steps:
       name: QueryVersion
       inputs:
           connectTo: 'VsTeam'
-          connectedServiceName: 'vs-marketplace'
+          connectedServiceName: 'a11y-insights-vs-marketplace'
           publisherId: '$(PublisherID)'
           extensionId: '$(ExtensionID)'
           versionAction: 'Patch'

--- a/pipelines/publish-vsix-file.yaml
+++ b/pipelines/publish-vsix-file.yaml
@@ -23,7 +23,7 @@ steps:
     - task: PublishAzureDevOpsExtension@3
       inputs:
           connectTo: 'VsTeam'
-          connectedServiceName: 'vs-marketplace'
+          connectedServiceName: 'a11y-insights-vs-marketplace'
           fileType: 'vsix'
           vsixFile: '${{ parameters.environment }}-vsix/${{ parameters.environment }}.vsix'
           publisherId: '$(PublisherID)'


### PR DESCRIPTION
#### Details

Update new service connection name for publishing ADO extension to market place. New service connection name is created in mseng ADO as we have to migrate our pipelines to this ADO.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
