### PR TITLE
fix: updated variable group and service connection names in yaml pipelines

### DIFF
--- a/pipelines/Create ESRP service connection.yml
+++ b/pipelines/Create ESRP service connection.yml
@@ -14,7 +14,7 @@ name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
     - name: Codeql.SkipTaskAutoInjection
       value: true
-    - group: esrp-signing-certificate
+    - group: a11y-insights-esrp-signing-certificate
 
 resources:
     repositories:
@@ -55,7 +55,7 @@ extends:
                               script: |-
                                   # This script grabs the latest ESRP client secret & cert
                                   # from the PME KeyVault and creates a new service
-                                  # connection called 'ESRP (staging)' with those values.
+                                  # connection called 'a11y-insights-esrp-code-signing (staging)' with those values.
                                   # This script does not actually rotate the certificates.
                                   # You still need to JIT into the PME KV and create a new
                                   # version of the certificate. Once you've done that,
@@ -86,7 +86,7 @@ extends:
                                      },
                                      "description":"ESRP service connection used for all signing requests",
                                      "groupScopeId":null,
-                                     "name":"ESRP (staging)",
+                                     "name":"a11y-insights-esrp-code-signing (staging)",
                                      "operationStatus":null,
                                      "readersGroup":null,
                                      "type":"PRSS",

--- a/pipelines/ado-extension-canary-validation.yaml
+++ b/pipelines/ado-extension-canary-validation.yaml
@@ -6,7 +6,7 @@ trigger: none
 pr: none
 
 variables:
-    - group: 'ado-auth-example-secrets'
+    - group: 'a11y-insights-ado-auth-example-secrets'
 
 resources:
     pipelines:

--- a/pipelines/ado-extension-prod-validation.yaml
+++ b/pipelines/ado-extension-prod-validation.yaml
@@ -6,7 +6,7 @@ trigger: none
 pr: none
 
 variables:
-    - group: 'ado-auth-example-secrets'
+    - group: 'a11y-insights-ado-auth-example-secrets'
 
 resources:
     pipelines:

--- a/pipelines/ado-extension-staging-validation.yaml
+++ b/pipelines/ado-extension-staging-validation.yaml
@@ -6,7 +6,7 @@ trigger: none
 pr: none
 
 variables:
-    - group: 'ado-auth-example-secrets'
+    - group: 'a11y-insights-ado-auth-example-secrets'
 
 resources:
     pipelines:

--- a/pipelines/canary-release.yaml
+++ b/pipelines/canary-release.yaml
@@ -5,7 +5,7 @@ parameters:
     - name: variableGroupName
       displayName: Deployment variable group. Should contain variables named extensionId, extensionName, publisherId, and (optionally) appInsightsConnectionString.
       type: string
-      default: 'ado-extension-canary'
+      default: 'a11y-insights-ado-extension-canary'
     - name: versionOverride
       displayName: Override extension version (for non-patch version upgrades, specify version number)
       type: string
@@ -35,11 +35,11 @@ stages:
       jobs:
           - template: release-template.yaml
             parameters:
-                ${{ if eq(parameters.variableGroupName, 'ado-extension-canary') }}:
-                    environment: ado-extension-canary
+                ${{ if eq(parameters.variableGroupName, 'a11y-insights-ado-extension-canary') }}:
+                    environment: a11y-insghts-ado-extension-canary
                     shouldSign: true
                     visibility: preview
-                ${{ if ne(parameters.variableGroupName, 'ado-extension-canary') }}:
-                    environment: ado-extension-test
+                ${{ if ne(parameters.variableGroupName, 'a11y-insights-ado-extension-canary') }}:
+                    environment: a11y-insghts-ado-extension-test
                     shouldSign: false
                     visibility: private

--- a/pipelines/package-vsix-file.yaml
+++ b/pipelines/package-vsix-file.yaml
@@ -90,7 +90,7 @@ steps:
       condition: and(succeeded(), eq('${{ parameters.shouldSign }}', 'true'))
       displayName: 'ESRP: Sign VSIX file '
       inputs:
-          ConnectedServiceName: 'ESRP Code Signing'
+          ConnectedServiceName: 'a11y-insights-esrp-code-signing'
           FolderPath: '$(Build.ArtifactStagingDirectory)'
           Pattern: '${{ parameters.environment }}.vsix'
           signConfigType: inlineSignParams

--- a/pipelines/prod-release.yaml
+++ b/pipelines/prod-release.yaml
@@ -24,14 +24,14 @@ resources:
 stages:
     - stage: package_publish_staging
       variables:
-          - group: ado-extension-staging
+          - group: a11y-insights-ado-extension-staging
           - ${{ if ne(parameters.stagingVersionOverride, 'increment') }}:
                 - name: extensionVersionOverride
                   value: ${{ parameters.stagingVersionOverride }}
       jobs:
           - template: release-template.yaml
             parameters:
-                environment: ado-extension-staging
+                environment: a11y-insights-ado-extension-staging
                 shouldSign: true
                 visibility: preview
 
@@ -66,12 +66,12 @@ stages:
 
     - stage: package_publish_prod
       variables:
-          - group: ado-extension-prod
+          - group: a11y-insights-ado-extension-prod
           - name: extensionVersionOverride
             value: ${{ parameters.prodVersionOverride }}
       jobs:
           - template: release-template.yaml
             parameters:
-                environment: ado-extension-prod
+                environment: a11y-insights-ado-extension-prod
                 shouldSign: true
                 visibility: preview


### PR DESCRIPTION
#### Details

Created new variable groups, service connections and environments in mseng ADO. As this is common ADO for different team so appended a11y-insights in all the names to distinguish them for our team.
##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
