### PR TITLE
fix: update github service connection for create release tag in yaml pipeline

### DIFF
--- a/pipelines/prod-release.yaml
+++ b/pipelines/prod-release.yaml
@@ -58,7 +58,7 @@ stages:
                       tag: '$(tag)'
                       action: edit
                       tagSource: userSpecifiedTag
-                      gitHubConnection: 'ada-cat-github-repo-access'
+                      gitHubConnection: 'a11y-insights-ada-cat-github-oauth'
                       isPreRelease: true
                       isDraft: true
                       target: $(resources.pipeline.accessibility-insights-action-ci.sourceCommit)


### PR DESCRIPTION
#### Details

Updated git hub service connection name for creating release tag from mseng ADO.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
