### PR TITLE
feat(crawl-hash-urls): Updated ADO task validation pipeline for new parameter

### DIFF
--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -26,9 +26,17 @@ jobs:
             inputs:
                 versionSpec: '16.x'
                 displayName: Use Node 16.x
-          # reused by all "url" cases
+
+          - script: yarn install --immutable
+            displayName: 'yarn install'
+    
+          # reused by all "url" cases except hash routing
           - script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &
             displayName: 'Start /dev/website-root test server at http://localhost:5858'
+
+            # reused by all "url" cases with hash routing
+          - script: yarn workspace test-website-hashroute start &
+            displayName: 'Start /packages/test-website-hashroute test server'
 
           # Please keep all "should succeed" cases together as a block before and "should fail" cases.
           # Do not specify a condition so that the pipeline will fail if any of these fail.
@@ -136,6 +144,25 @@ jobs:
             condition: succeededOrFailed()
             continueOnError: true
 
+          # Below cases are for keepUrlFragment parameter validation
+          - task: ${{ parameters.taskUnderTest }}
+            displayName: '[should crawl] case keepUrlFragment-1: crawl to hash routed page'
+            inputs:
+                url: 'http://localhost:3000/'
+                keepUrlFragment: 'true'
+                outputArtifactName: 'accessibility-reports-case-keepUrlFragment-1'
+            condition: succeededOrFailed()
+            continueOnError: true
+
+          - task: ${{ parameters.taskUnderTest }}
+            displayName: '[should not crawl] case keepUrlFragment-2: do not crawl to hash routed page'
+            inputs:
+                url: 'http://localhost:3000/'
+                keepUrlFragment: 'false'
+                outputArtifactName: 'accessibility-reports-case-keepUrlFragment-2'
+            condition: succeededOrFailed()
+            continueOnError: true
+
     - job: validate_artifacts
       dependsOn: run_tests
       displayName: 'Validate artifacts'
@@ -160,6 +187,8 @@ jobs:
                     echo artifacts/accessibility-reports-case-fail-5/index.html >> expected-index-html-files.txt
                     echo artifacts/accessibility-reports-case-fail-6/index.html >> expected-index-html-files.txt
                     echo artifacts/accessibility-reports-case-fail-7/index.html >> expected-index-html-files.txt
+                    echo artifacts/accessibility-reports-case-keepUrlFragment-1/index.html >> expected-index-html-files.txt
+                    echo artifacts/accessibility-reports-case-keepUrlFragment-2/index.html >> expected-index-html-files.txt
                     echo artifacts/accessibility-reports-case-succeed-1/index.html >> expected-index-html-files.txt
                     echo artifacts/accessibility-reports-case-succeed-2/index.html >> expected-index-html-files.txt
                     echo artifacts/accessibility-reports/index.html >> expected-index-html-files.txt
@@ -191,4 +220,29 @@ jobs:
                     echo Comparing actual-baseline-files.txt to expected-baseline-files.txt
                     # Note: diff will return 0 if the files are identical, 1 if they differ, and 2 if an error occurs
                     diff actual-baseline-files.txt expected-baseline-files.txt
+                workingDirectory: '$(Pipeline.Workspace)'
+
+          - task: CmdLine@2
+            displayName: 'Validate keepUrlFragment from index.html file'
+            # Below validation is based on number of URLs scanned by crawler in index.html file
+            # with keepUrlFragment as false, only 1 Url should be scanned
+            # with keepUrlFragment as true, 5 Urls should be scanned
+            inputs:
+                script: |
+                    cd artifacts/accessibility-reports-case-keepUrlFragment-1
+                    grep -r --include='*.html' '5</span> total URLs scanned' > accessibility-reports-case-keepUrlFragment-1.txt
+                    if [ -s "accessibility-reports-case-keepUrlFragment-1.txt" ]; then
+                    echo test-passed > expected-result.txt
+                    echo keepUrlFragment-1-test-passed
+                    fi
+
+                    cd ../accessibility-reports-case-keepUrlFragment-2
+                    grep -r --include='*.html' '5</span> total URLs scanned' > accessibility-reports-case-keepUrlFragment-2.txt
+                    if [ ! -s "accessibility-reports-case-keepUrlFragment-2.txt" ]; then
+                    echo test-passed > expected-result.txt
+                    echo keepUrlFragment-2-test-passed
+                    fi
+
+                    cd ..
+                    diff accessibility-reports-case-keepUrlFragment-1/expected-result.txt accessibility-reports-case-keepUrlFragment-2/expected-result.txt
                 workingDirectory: '$(Pipeline.Workspace)'

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -141,7 +141,7 @@ jobs:
           - task: ${{ parameters.taskUnderTest }}
             displayName: '[should crawl] case keepUrlFragment-1: crawl to hash routed page'
             inputs:
-                url: 'https://ms.portal.azure.com/#browse/all'
+                url: 'https://ms.portal.azure.com/#home'
                 serviceAccountName: $(a11yinsscan-service-acct-username)
                 serviceAccountPassword: $(a11yinsscan-service-acct-password)
                 authType: 'AAD'
@@ -154,7 +154,7 @@ jobs:
           - task: ${{ parameters.taskUnderTest }}
             displayName: '[should not crawl] case keepUrlFragment-2: do not crawl to hash routed page'
             inputs:
-                url: 'https://ms.portal.azure.com/#browse/all'
+                url: 'https://ms.portal.azure.com/#home'
                 serviceAccountName: $(a11yinsscan-service-acct-username)
                 serviceAccountPassword: $(a11yinsscan-service-acct-password)
                 authType: 'AAD'

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -27,16 +27,9 @@ jobs:
                 versionSpec: '16.x'
                 displayName: Use Node 16.x
 
-          - script: yarn install --immutable
-            displayName: 'yarn install'
-
-          # reused by all "url" cases except hash routing
+          # reused by all "url" cases
           - script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &
             displayName: 'Start /dev/website-root test server at http://localhost:5858'
-
-          # reused by all "url" cases with hash routing
-          - script: yarn workspace test-website-hashroute start &
-            displayName: 'Start /packages/test-website-hashroute test server'
 
           # Please keep all "should succeed" cases together as a block before and "should fail" cases.
           # Do not specify a condition so that the pipeline will fail if any of these fail.
@@ -148,7 +141,11 @@ jobs:
           - task: ${{ parameters.taskUnderTest }}
             displayName: '[should crawl] case keepUrlFragment-1: crawl to hash routed page'
             inputs:
-                url: 'http://localhost:3000/'
+                url: 'https://portal.azure.com'
+                serviceAccountName: $(a11yinsscan-service-acct-username)
+                serviceAccountPassword: $(a11yinsscan-service-acct-password)
+                authType: 'AAD'
+                maxUrls: 10
                 keepUrlFragment: 'true'
                 outputArtifactName: 'accessibility-reports-case-keepUrlFragment-1'
             condition: succeededOrFailed()
@@ -157,7 +154,11 @@ jobs:
           - task: ${{ parameters.taskUnderTest }}
             displayName: '[should not crawl] case keepUrlFragment-2: do not crawl to hash routed page'
             inputs:
-                url: 'http://localhost:3000/'
+                url: 'https://portal.azure.com'
+                serviceAccountName: $(a11yinsscan-service-acct-username)
+                serviceAccountPassword: $(a11yinsscan-service-acct-password)
+                authType: 'AAD'
+                maxUrls: 10
                 keepUrlFragment: 'false'
                 outputArtifactName: 'accessibility-reports-case-keepUrlFragment-2'
             condition: succeededOrFailed()
@@ -226,11 +227,11 @@ jobs:
             displayName: 'Validate keepUrlFragment from index.html file'
             # Below validation is based on number of URLs scanned by crawler in index.html file
             # with keepUrlFragment as false, only 1 Url should be scanned
-            # with keepUrlFragment as true, 5 Urls should be scanned
+            # with keepUrlFragment as true, 10 Urls should be scanned
             inputs:
                 script: |
                     cd artifacts/accessibility-reports-case-keepUrlFragment-1
-                    grep -r --include='*.html' '5</span> total URLs scanned' > accessibility-reports-case-keepUrlFragment-1.txt
+                    grep -r --include='*.html' '10</span> total URLs scanned' > accessibility-reports-case-keepUrlFragment-1.txt
                     if [ -s "accessibility-reports-case-keepUrlFragment-1.txt" ]; then
                         echo test-passed > expected-result.txt
                         echo keepUrlFragment-1-test-passed

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -29,7 +29,7 @@ jobs:
 
           - script: yarn install --immutable
             displayName: 'yarn install'
-    
+
           # reused by all "url" cases except hash routing
           - script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &
             displayName: 'Start /dev/website-root test server at http://localhost:5858'

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -34,7 +34,7 @@ jobs:
           - script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &
             displayName: 'Start /dev/website-root test server at http://localhost:5858'
 
-            # reused by all "url" cases with hash routing
+          # reused by all "url" cases with hash routing
           - script: yarn workspace test-website-hashroute start &
             displayName: 'Start /packages/test-website-hashroute test server'
 
@@ -232,17 +232,18 @@ jobs:
                     cd artifacts/accessibility-reports-case-keepUrlFragment-1
                     grep -r --include='*.html' '5</span> total URLs scanned' > accessibility-reports-case-keepUrlFragment-1.txt
                     if [ -s "accessibility-reports-case-keepUrlFragment-1.txt" ]; then
-                    echo test-passed > expected-result.txt
-                    echo keepUrlFragment-1-test-passed
+                        echo test-passed > expected-result.txt
+                        echo keepUrlFragment-1-test-passed
                     fi
 
                     cd ../accessibility-reports-case-keepUrlFragment-2
                     grep -r --include='*.html' '1</span> total URLs scanned' > accessibility-reports-case-keepUrlFragment-2.txt
                     if [ -s "accessibility-reports-case-keepUrlFragment-2.txt" ]; then
-                    echo test-passed > expected-result.txt
-                    echo keepUrlFragment-2-test-passed
+                        echo test-passed > expected-result.txt
+                        echo keepUrlFragment-2-test-passed
                     fi
 
                     cd ..
+                    # Note: diff will succeed if both files are present and identical, and fail if any of the file is missing or they differ
                     diff accessibility-reports-case-keepUrlFragment-1/expected-result.txt accessibility-reports-case-keepUrlFragment-2/expected-result.txt
                 workingDirectory: '$(Pipeline.Workspace)'

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -237,8 +237,8 @@ jobs:
                     fi
 
                     cd ../accessibility-reports-case-keepUrlFragment-2
-                    grep -r --include='*.html' '5</span> total URLs scanned' > accessibility-reports-case-keepUrlFragment-2.txt
-                    if [ ! -s "accessibility-reports-case-keepUrlFragment-2.txt" ]; then
+                    grep -r --include='*.html' '1</span> total URLs scanned' > accessibility-reports-case-keepUrlFragment-2.txt
+                    if [ -s "accessibility-reports-case-keepUrlFragment-2.txt" ]; then
                     echo test-passed > expected-result.txt
                     echo keepUrlFragment-2-test-passed
                     fi

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -141,7 +141,7 @@ jobs:
           - task: ${{ parameters.taskUnderTest }}
             displayName: '[should crawl] case keepUrlFragment-1: crawl to hash routed page'
             inputs:
-                url: 'https://portal.azure.com'
+                url: 'https://ms.portal.azure.com/#browse/all'
                 serviceAccountName: $(a11yinsscan-service-acct-username)
                 serviceAccountPassword: $(a11yinsscan-service-acct-password)
                 authType: 'AAD'
@@ -154,7 +154,7 @@ jobs:
           - task: ${{ parameters.taskUnderTest }}
             displayName: '[should not crawl] case keepUrlFragment-2: do not crawl to hash routed page'
             inputs:
-                url: 'https://portal.azure.com'
+                url: 'https://ms.portal.azure.com/#browse/all'
                 serviceAccountName: $(a11yinsscan-service-acct-username)
                 serviceAccountPassword: $(a11yinsscan-service-acct-password)
                 authType: 'AAD'

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -141,7 +141,7 @@ jobs:
           - task: ${{ parameters.taskUnderTest }}
             displayName: '[should crawl] case keepUrlFragment-1: crawl to hash routed page'
             inputs:
-                url: 'https://ms.portal.azure.com/#home'
+                url: 'https://ms.portal.azure.com/'
                 serviceAccountName: $(a11yinsscan-service-acct-username)
                 serviceAccountPassword: $(a11yinsscan-service-acct-password)
                 authType: 'AAD'
@@ -154,7 +154,7 @@ jobs:
           - task: ${{ parameters.taskUnderTest }}
             displayName: '[should not crawl] case keepUrlFragment-2: do not crawl to hash routed page'
             inputs:
-                url: 'https://ms.portal.azure.com/#home'
+                url: 'https://ms.portal.azure.com/'
                 serviceAccountName: $(a11yinsscan-service-acct-username)
                 serviceAccountPassword: $(a11yinsscan-service-acct-password)
                 authType: 'AAD'


### PR DESCRIPTION
#### Details

Added the new task in validation pipeline to validate the new parameter "keepUrlFragment" functionality in pipeline

##### Motivation

[Feature 2114928](https://dev.azure.com/mseng/1ES/_workitems/edit/2114928): ADO Extension should be able to crawl hash-routing SPA apps

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
