### PR TITLE
chore(deps): Bump ip from 1.1.9 to 2.0.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12171,9 +12171,9 @@ __metadata:
   linkType: hard
 
 "ip@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "ip@npm:2.0.0"
-  checksum: cfcfac6b873b701996d71ec82a7dd27ba92450afdb421e356f44044ed688df04567344c36cbacea7d01b1c39a4c732dc012570ebe9bebfb06f27314bca625349
+  version: 2.0.1
+  resolution: "ip@npm:2.0.1"
+  checksum: d765c9fd212b8a99023a4cde6a558a054c298d640fec1020567494d257afd78ca77e37126b1a3ef0e053646ced79a816bf50621d38d5e768cdde0431fa3b0d35
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Details
Bumps [ip](https://github.com/indutny/node-ip) from 1.1.9 to 2.0.1.

<!-- Usually a sentence or two describing what the PR changes -->

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
https://github.com/microsoft/accessibility-insights-action/security/dependabot/56
There is a dependabot security alert for ip. But dependabot is unable to create a PR for upgraded version.
Creating Manual PR for that.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [na] Addresses an existing issue: Fixes #0000
- [na] Added relevant unit test for your changes. (`yarn test`)
- [na] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
