### PR TITLE
feat(private npm registry): Updated ADO task validation pipeline for private registry parameter

### DIFF
--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -49,7 +49,7 @@ jobs:
                 baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/up-to-date-5858.baseline'
 
           - task: ${{ parameters.taskUnderTest }}
-            displayName: '[should succeed] case case succeed-3: use same org artifact feed registry URL'
+            displayName: '[should succeed] case succeed-3: use same org artifact feed registry URL'
             inputs:
                 url: 'https://accessibilityinsights.io/'
                 maxUrls: 1

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -13,6 +13,27 @@ parameters:
       type: string
 
 jobs:
+    - job: run_registry_url_tests
+      displayName: 'Run registry URL tests'
+      steps:
+          - task: ${{ parameters.taskUnderTest }}
+            displayName: '[should fail] case fail: use different org artifact feed registry URL without credentials'
+            inputs:
+                url: 'https://accessibilityinsights.io/'
+                maxUrls: 1
+                npmRegistryUrl: $(outsideOrgArtifactURL)
+                outputArtifactName: 'no-artifact-will-be-created-here'
+            condition: succeededOrFailed()
+            continueOnError: true
+
+          - task: ${{ parameters.taskUnderTest }}
+            displayName: '[should succeed] case succeed: use same org artifact feed registry URL'
+            inputs:
+                url: 'https://accessibilityinsights.io/'
+                maxUrls: 1
+                npmRegistryUrl: $(sameOrgArtifactURL)
+                outputArtifactName: 'accessibility-reports-case-same-org-registry-url'
+
     - job: run_tests
       displayName: 'Run tests'
       templateContext:
@@ -47,13 +68,6 @@ jobs:
                 url: 'http://localhost:5858'
                 outputArtifactName: 'accessibility-reports-case-succeed-2'
                 baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/up-to-date-5858.baseline'
-
-          - task: ${{ parameters.taskUnderTest }}
-            displayName: '[should succeed] case succeed-3: use same org artifact feed registry URL'
-            inputs:
-                url: 'https://accessibilityinsights.io/'
-                maxUrls: 1
-                npmRegistryUrl: $(sameOrgArtifactURL)
 
           # Please keep all "should fail" cases together as a block after all "should succeed" cases
           # Each case will need to have continueOnError: true. Each case but the first will also need
@@ -144,15 +158,6 @@ jobs:
             condition: succeededOrFailed()
             continueOnError: true
 
-          - task: ${{ parameters.taskUnderTest }}
-            displayName: '[should fail] case fail-11: use different org artifact feed registry URL without credentials'
-            inputs:
-                url: 'https://accessibilityinsights.io/'
-                maxUrls: 1
-                npmRegistryUrl: $(outsideOrgArtifactURL)
-            condition: succeededOrFailed()
-            continueOnError: true
-
           # Below cases are for keepUrlFragment parameter validation
           - task: ${{ parameters.taskUnderTest }}
             displayName: '[should crawl] case keepUrlFragment-1: crawl to hash routed page'
@@ -182,7 +187,9 @@ jobs:
             continueOnError: true
 
     - job: validate_artifacts
-      dependsOn: run_tests
+      dependsOn:
+          - run_tests
+          - run_registry_url_tests
       displayName: 'Validate artifacts'
       #pool:
       #    name: a11y-ado-auth
@@ -207,6 +214,7 @@ jobs:
                     echo artifacts/accessibility-reports-case-fail-7/index.html >> expected-index-html-files.txt
                     echo artifacts/accessibility-reports-case-keepUrlFragment-1/index.html >> expected-index-html-files.txt
                     echo artifacts/accessibility-reports-case-keepUrlFragment-2/index.html >> expected-index-html-files.txt
+                    echo artifacts/accessibility-reports-case-same-org-registry-url/index.html >> expected-index-html-files.txt
                     echo artifacts/accessibility-reports-case-succeed-1/index.html >> expected-index-html-files.txt
                     echo artifacts/accessibility-reports-case-succeed-2/index.html >> expected-index-html-files.txt
                     echo artifacts/accessibility-reports/index.html >> expected-index-html-files.txt

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -48,6 +48,14 @@ jobs:
                 outputArtifactName: 'accessibility-reports-case-succeed-2'
                 baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/up-to-date-5858.baseline'
 
+          # Below are succeed cases for private registry parameter validation
+          - task: ${{ parameters.taskUnderTest }}
+            displayName: '[should succeed] case case succeed-3: use same org artifact feed registry URL'
+            inputs:
+                url: 'https://accessibilityinsights.io/'
+                maxUrls: 1
+                npmRegistryUrl: $(sameOrgArtifactURL)
+
           # Please keep all "should fail" cases together as a block after all "should succeed" cases
           # Each case will need to have continueOnError: true. Each case but the first will also need
           # a condition: succeededOrFailed() so that the pipeline will run correctly.
@@ -137,6 +145,16 @@ jobs:
             condition: succeededOrFailed()
             continueOnError: true
 
+          # Below is succeed fail case for private registry parameter validation          
+          - task: ${{ parameters.taskUnderTest }}
+            displayName: '[should fail] case fail-11: use different org artifact feed registry URL without credentials'
+            inputs:
+                url: 'https://accessibilityinsights.io/'
+                maxUrls: 1
+                npmRegistryUrl: $(outsideArtifactURL)
+            condition: succeededOrFailed()
+            continueOnError: true
+
           # Below cases are for keepUrlFragment parameter validation
           - task: ${{ parameters.taskUnderTest }}
             displayName: '[should crawl] case keepUrlFragment-1: crawl to hash routed page'
@@ -148,6 +166,7 @@ jobs:
                 maxUrls: 10
                 keepUrlFragment: 'true'
                 outputArtifactName: 'accessibility-reports-case-keepUrlFragment-1'
+                scanTimeout: 180000
             condition: succeededOrFailed()
             continueOnError: true
 

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -48,7 +48,6 @@ jobs:
                 outputArtifactName: 'accessibility-reports-case-succeed-2'
                 baselineFile: '$(System.DefaultWorkingDirectory)/dev/website-baselines/up-to-date-5858.baseline'
 
-          # Below are succeed cases for private registry parameter validation
           - task: ${{ parameters.taskUnderTest }}
             displayName: '[should succeed] case case succeed-3: use same org artifact feed registry URL'
             inputs:
@@ -145,13 +144,12 @@ jobs:
             condition: succeededOrFailed()
             continueOnError: true
 
-          # Below is succeed fail case for private registry parameter validation          
           - task: ${{ parameters.taskUnderTest }}
             displayName: '[should fail] case fail-11: use different org artifact feed registry URL without credentials'
             inputs:
                 url: 'https://accessibilityinsights.io/'
                 maxUrls: 1
-                npmRegistryUrl: $(outsideArtifactURL)
+                npmRegistryUrl: $(outsideOrgArtifactURL)
             condition: succeededOrFailed()
             continueOnError: true
 


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Added the new task in validation pipeline to validate the new parameter "npmRegistryUrl" functionality in pipeline

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
[Feature 2207295](https://dev.azure.com/mseng/1ES/_workitems/edit/2207295): Enable option to use private npm registry Url in a11y ado extension

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [na] Addresses an existing issue: Fixes #0000
- [na] Added relevant unit test for your changes. (`yarn test`)
- [na] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
