### PR TITLE
fix: skip codecov publish report step in ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,5 @@ jobs:
       env:
         NODE_OPTIONS: --max_old_space_size=4096
 
-
     - name: Run e2e tests
       run: yarn test:e2e --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,6 @@ jobs:
       env:
         NODE_OPTIONS: --max_old_space_size=4096
 
-    # - name: Publish code coverage to codecov
-    #   run: yarn publish-code-coverage -t ${{ secrets.CODECOV_TOKEN }}
 
     - name: Run e2e tests
       run: yarn test:e2e --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,8 @@ jobs:
       env:
         NODE_OPTIONS: --max_old_space_size=4096
 
-    - name: Publish code coverage to codecov
-      if: false
-      run: yarn publish-code-coverage -t ${{ secrets.CODECOV_TOKEN }}
+    # - name: Publish code coverage to codecov
+    #   run: yarn publish-code-coverage -t ${{ secrets.CODECOV_TOKEN }}
 
     - name: Run e2e tests
       run: yarn test:e2e --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
         NODE_OPTIONS: --max_old_space_size=4096
 
     - name: Publish code coverage to codecov
+      if: false
       run: yarn publish-code-coverage -t ${{ secrets.CODECOV_TOKEN }}
 
     - name: Run e2e tests

--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -64,9 +64,6 @@ extends:
                           env:
                               NODE_OPTIONS: --max_old_space_size=4096
 
-                        # - script: yarn publish-code-coverage -t $(CODECOV_TOKEN)
-                        #   displayName: Publish code coverage to codecov
-
                         - script: yarn test:e2e --verbose
                           displayName: Run e2e tests
 

--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -64,8 +64,8 @@ extends:
                           env:
                               NODE_OPTIONS: --max_old_space_size=4096
 
-                        - script: yarn publish-code-coverage -t $(CODECOV_TOKEN)
-                          displayName: Publish code coverage to codecov
+                        # - script: yarn publish-code-coverage -t $(CODECOV_TOKEN)
+                        #   displayName: Publish code coverage to codecov
 
                         - script: yarn test:e2e --verbose
                           displayName: Run e2e tests


### PR DESCRIPTION
#### Details

Disable the code coverage command in the CI workflow. As Codecov package is deprecated.
Commented out the codecov command from build yml files


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
