### PR TITLE
fix: service account authentication and ignore yarn config from environment variables

### DIFF
--- a/packages/ado-extension/src/install-runtime-dependencies.ts
+++ b/packages/ado-extension/src/install-runtime-dependencies.ts
@@ -34,7 +34,7 @@ export function installRuntimeDependencies(): void {
 
     console.log(`Using registry URL: ${registryUrl}`);
 
-    // Ignore environment variables starting with YARN_, Yarn_ or yarn_
+    // Ignore environment variables starting with YARN_, Yarn_, or yarn_
     const filteredEnv = getFilteredEnv();
 
     // Set the Yarn registry URL

--- a/packages/ado-extension/src/install-runtime-dependencies.ts
+++ b/packages/ado-extension/src/install-runtime-dependencies.ts
@@ -34,7 +34,7 @@ export function installRuntimeDependencies(): void {
 
     console.log(`Using registry URL: ${registryUrl}`);
 
-    // Ignore environment variables starting with YARN_, Yarn_, or yarn_
+    // Ignore environment variables starting with YARN_, Yarn_ or yarn_
     const filteredEnv = getFilteredEnv();
 
     // Set the Yarn registry URL

--- a/packages/ado-extension/src/install-runtime-dependencies.ts
+++ b/packages/ado-extension/src/install-runtime-dependencies.ts
@@ -35,7 +35,6 @@ export function installRuntimeDependencies(): void {
     console.log(`Using registry URL: ${registryUrl}`);
 
     // Ignore environment variables starting with YARN_, Yarn_, or yarn_
-    // Filtered environment variables in one step
     const filteredEnv = getFilteredEnv();
 
     // Set the Yarn registry URL

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -30,7 +30,7 @@
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "accessibility-insights-report": "5.1.0",
-        "accessibility-insights-scan": "^3.0.0",
+        "accessibility-insights-scan": "^3.0.1",
         "axe-core": "^4.9.1",
         "express": "^4.20.0",
         "filenamify-url": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,7 +62,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^6.18.1
     "@typescript-eslint/parser": ^6.18.1
     accessibility-insights-report: 5.1.0
-    accessibility-insights-scan: ^3.0.0
+    accessibility-insights-scan: ^3.0.1
     axe-core: ^4.9.1
     eslint: ^8.57.0
     eslint-plugin-security: ^1.7.1
@@ -6026,9 +6026,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"accessibility-insights-scan@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "accessibility-insights-scan@npm:3.0.0"
+"accessibility-insights-scan@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "accessibility-insights-scan@npm:3.0.1"
   dependencies:
     "@apify/log": 2.2.18
     "@axe-core/puppeteer": 4.9.1
@@ -6069,7 +6069,7 @@ __metadata:
     yargs: ^17.6.2
   bin:
     ai-scan: dist/ai-scan-cli.js
-  checksum: 81999b7ece82c32e8d87751e12e606e900159877eddea25bcd59245cbc64f6839805006a8c0b0f8d3c742eab917d2ac3f78148805f4c5f48427f2b36cfeebab7
+  checksum: 60e7285a012fefe2bc36728170b76621a100f66864f47ca210eadfcd42fa1de408290f6377d02da308f59b2c9bc48c347f5011f69313db805fa8695df84cbbd5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Details

This PR adjust the logic to set yarn config before installing runtime dependencies. It filters out environment variables starting with yarn_. This is to make Yarn commands for ado extension independent of any environment setting and if environment variable contains invalid/unrecognized variable starting with yarn_  than it throughs error. For example, environment YARN_MIN_VERSION (This is no valid config in yarn 3) will give below error:
_Unrecognized or legacy configuration settings found: minVersion - run "yarn config -v" to see the list of settings supported in Yarn (in <environment>)_

Also it updates accessibility insights scan package to fix the issue #2182.
##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes #2182 
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
