### PR TITLE
chore: Upgraded package version for CGAlert

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "socks": "^2.8.3",
         "ws": "^8.17.1",
         "path-to-regexp": "^1.9.0",
-        "express": "^4.20.0",
+        "express": "^4.21.0",
         "serve-static": "^1.16.0",
         "send": "^0.19.0"
     }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -32,7 +32,7 @@
         "accessibility-insights-report": "5.1.0",
         "accessibility-insights-scan": "^3.0.1",
         "axe-core": "^4.9.1",
-        "express": "^4.20.0",
+        "express": "^4.21.0",
         "filenamify-url": "^3.1.0",
         "get-port": "^7.1.0",
         "inversify": "6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,7 +66,7 @@ __metadata:
     axe-core: ^4.9.1
     eslint: ^8.57.0
     eslint-plugin-security: ^1.7.1
-    express: ^4.20.0
+    express: ^4.21.0
     filenamify-url: ^3.1.0
     fork-ts-checker-webpack-plugin: ^9.0.2
     get-port: ^7.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -8236,10 +8236,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:0.6.0":
-  version: 0.6.0
-  resolution: "cookie@npm:0.6.0"
-  checksum: f56a7d32a07db5458e79c726b77e3c2eff655c36792f2b6c58d351fb5f61531e5b1ab7f46987150136e366c65213cbe31729e02a3eaed630c3bf7334635fb410
+"cookie@npm:0.7.1":
+  version: 0.7.1
+  resolution: "cookie@npm:0.7.1"
+  checksum: cec5e425549b3650eb5c3498a9ba3cde0b9cd419e3b36e4b92739d30b4d89e0b678b98c1ddc209ce7cf958cd3215671fd6ac47aec21f10c2a0cc68abd399d8a7
   languageName: node
   linkType: hard
 
@@ -10323,16 +10323,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:^4.20.0":
-  version: 4.21.0
-  resolution: "express@npm:4.21.0"
+"express@npm:^4.21.0":
+  version: 4.21.1
+  resolution: "express@npm:4.21.1"
   dependencies:
     accepts: ~1.3.8
     array-flatten: 1.1.1
     body-parser: 1.20.3
     content-disposition: 0.5.4
     content-type: ~1.0.4
-    cookie: 0.6.0
+    cookie: 0.7.1
     cookie-signature: 1.0.6
     debug: 2.6.9
     depd: 2.0.0
@@ -10358,7 +10358,7 @@ __metadata:
     type-is: ~1.6.18
     utils-merge: 1.0.1
     vary: ~1.1.2
-  checksum: 1c5212993f665809c249bf00ab550b989d1365a5b9171cdfaa26d93ee2ef10cd8add520861ec8d5da74b3194d8374e1d9d53e85ef69b89fd9c4196b87045a5d4
+  checksum: 5ac2b26d8aeddda5564fc0907227d29c100f90c0ead2ead9d474dc5108e8fb306c2de2083c4e3ba326e0906466f2b73417dbac16961f4075ff9f03785fd940fe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Details

Upgrade express from 4.20.0 to 4.21.0 to fix the vulnerability.

##### Motivation

[CG Work Items](https://dev.azure.com/mseng/1ES/_queries/query/894c54da-1edd-4c5c-ae4d-38903314430c/)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
