### PR TITLE
fix: changed validation pattern for keepURLFragment cases in validation pipeline

### DIFF
--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -169,7 +169,7 @@ jobs:
                 maxUrls: 10
                 keepUrlFragment: 'true'
                 outputArtifactName: 'accessibility-reports-case-keepUrlFragment-1'
-                scanTimeout: 180000
+                scanTimeout: 300000
             condition: succeededOrFailed()
             continueOnError: true
 
@@ -183,6 +183,7 @@ jobs:
                 maxUrls: 10
                 keepUrlFragment: 'false'
                 outputArtifactName: 'accessibility-reports-case-keepUrlFragment-2'
+                scanTimeout: 300000
             condition: succeededOrFailed()
             continueOnError: true
 

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -251,21 +251,21 @@ jobs:
 
           - task: CmdLine@2
             displayName: 'Validate keepUrlFragment from index.html file'
-            # Below validation is based on number of URLs scanned by crawler in index.html file
-            # with keepUrlFragment as false, only 1 Url should be scanned
-            # with keepUrlFragment as true, 10 Urls should be scanned
+            # Below validation is based on hash URLs pattern scanned by crawler in index.html file
+            # with keepUrlFragment as false, azure portal URL with #view should not be present
+            # with keepUrlFragment as true, azure portal URL with #view should be present
             inputs:
                 script: |
                     cd artifacts/accessibility-reports-case-keepUrlFragment-1
-                    grep -r --include='*.html' '10</span> total URLs scanned' > accessibility-reports-case-keepUrlFragment-1.txt
+                    grep -r --include='*.html' 'https://ms.portal.azure.com/#view' > accessibility-reports-case-keepUrlFragment-1.txt
                     if [ -s "accessibility-reports-case-keepUrlFragment-1.txt" ]; then
                         echo test-passed > expected-result.txt
                         echo keepUrlFragment-1-test-passed
                     fi
 
                     cd ../accessibility-reports-case-keepUrlFragment-2
-                    grep -r --include='*.html' '1</span> total URLs scanned' > accessibility-reports-case-keepUrlFragment-2.txt
-                    if [ -s "accessibility-reports-case-keepUrlFragment-2.txt" ]; then
+                    grep -r --include='*.html' 'https://ms.portal.azure.com/#view' > accessibility-reports-case-keepUrlFragment-2.txt
+                    if [ ! -s "accessibility-reports-case-keepUrlFragment-2.txt" ]; then
                         echo test-passed > expected-result.txt
                         echo keepUrlFragment-2-test-passed
                     fi


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Validation Pipeline for ado-extension is failing as Azure Portal URL used for hash fragment validation is now having extra non hash fragment URLs coming along with home page when keepUrlFragment is false, so changed the validation from number of URLs scanned to hash URLs pattern scanned by crawler in index.html file
- with keepUrlFragment as false, azure portal URL with #view should not be present
- with keepUrlFragment as true, azure portal URL with #view should be present

Also increased the timeout to 5min for keepUrlFragment cases in the validation pipeline to prevent failures due to timeout.

##### Motivation

[20241018.4](https://dev.azure.com/mseng/1ES/_build/results?buildId=29215119) build failure

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [na] Addresses an existing issue: Fixes #0000
- [na] Added relevant unit test for your changes. (`yarn test`)
- [na] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
