### PR TITLE
Breaking Change: Update node version to 20.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: 20.x
         
     - name: Install dependencies
       run: yarn install --immutable
@@ -49,7 +49,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: 20.x
     
     - name: Install dependencies
       run: yarn install --immutable

--- a/packages/ado-extension/src/ado-extension-metadata.spec.ts
+++ b/packages/ado-extension/src/ado-extension-metadata.spec.ts
@@ -76,12 +76,12 @@ describe(AdoExtensionMetadataProvider, () => {
             throw readFileError;
         };
 
-        expect(() => testSubject.readMetadata()).toThrowError(readFileError);
+        expect(() => testSubject.readMetadata()).toThrow(readFileError);
     });
 
     it('throws an error if ado-extension-metadata.json is malformatted', () => {
         mockFs.readFileSync = () => '{ "extensionName": "Oops it had some stray "quotes"" }';
 
-        expect(() => testSubject.readMetadata()).toThrowError(/Unexpected token/);
+        expect(() => testSubject.readMetadata()).toThrow("Expected ',' or '}' after property value in JSON at position 44");
     });
 });

--- a/packages/ado-extension/task.json
+++ b/packages/ado-extension/task.json
@@ -228,7 +228,7 @@
         }
     ],
     "execution": {
-        "Node16": {
+        "Node20_1": {
             "target": "index.js"
         }
     },

--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -45,8 +45,8 @@ jobs:
       steps:
           - task: NodeTool@0
             inputs:
-                versionSpec: '16.x'
-                displayName: Use Node 16.x
+                versionSpec: '20.x'
+                displayName: Use Node 20.x
 
           # reused by all "url" cases
           - script: npx serve "$(System.DefaultWorkingDirectory)/dev/website-root" -l 5858 &

--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -41,8 +41,8 @@ extends:
                     steps:
                         - task: NodeTool@0
                           inputs:
-                              versionSpec: '16.x'
-                          displayName: Use Node 16.x
+                              versionSpec: '20.x'
+                          displayName: Use Node 20.x
 
                         - script: yarn install --immutable
                           displayName: Install dependencies
@@ -120,8 +120,8 @@ extends:
                     steps:
                         - task: NodeTool@0
                           inputs:
-                              versionSpec: '16.x'
-                          displayName: Use Node 16.x
+                              versionSpec: '20.x'
+                          displayName: Use Node 20.x
 
                         - script: yarn install --immutable
                           displayName: Install dependencies


### PR DESCRIPTION
#### Details
Node 16 left support in October 2023. Updating the code node version to node 20.x.x version. As lot of other packages are using or going to use Node 20.x.x.

##### Motivation

Get on a supported version that we expect to last for a while

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
