### PR TITLE
chore: Bump nanoid to 3.3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
         "path-to-regexp": "^1.9.0",
         "express": "^4.21.0",
         "serve-static": "^1.16.0",
-        "send": "^0.19.0"
+        "send": "^0.19.0",
+        "nanoid": "^3.3.8"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15216,21 +15216,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.4":
-  version: 3.3.6
-  resolution: "nanoid@npm:3.3.6"
+"nanoid@npm:^3.3.8":
+  version: 3.3.8
+  resolution: "nanoid@npm:3.3.8"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 7d0eda657002738aa5206107bd0580aead6c95c460ef1bdd0b1a87a9c7ae6277ac2e9b945306aaa5b32c6dcb7feaf462d0f552e7f8b5718abfc6ead5c94a71b3
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.7":
-  version: 3.3.7
-  resolution: "nanoid@npm:3.3.7"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: d36c427e530713e4ac6567d488b489a36582ef89da1d6d4e3b87eded11eb10d7042a877958c6f104929809b2ab0bafa17652b076cdf84324aa75b30b722204f2
+  checksum: dfe0adbc0c77e9655b550c333075f51bb28cfc7568afbf3237249904f9c86c9aaaed1f113f0fddddba75673ee31c758c30c43d4414f014a52a7a626efc5958c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Bump nanoid from 3.3.6 to 3.3.8 to fix CG Alert.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
CVE-2024-55565

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes [2237408](https://dev.azure.com/mseng/1ES/_workitems/edit/2237408)
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
