### PR TITLE
fix: Resolved issue in pipeline validation for CreateReleaseTag

### DIFF
--- a/pipelines/prod-release.yaml
+++ b/pipelines/prod-release.yaml
@@ -64,6 +64,8 @@ extends:
                     value: v${{ parameters.prodVersionOverride }}-sources-ado
               jobs:
                   - job: 'CreateReleaseTag'
+                    templateContext:
+                        type: releaseJob
                     steps:
                         - task: 1ES.DownloadPipelineArtifact@1
                           inputs:

--- a/pipelines/prod-release.yaml
+++ b/pipelines/prod-release.yaml
@@ -73,7 +73,7 @@ extends:
                               source: 'specific'
                               runVersion: 'specific'
                               project: $(resources.pipeline.accessibility-insights-action-ci.projectID)
-                              pipeline: $(resources.pipeline.accessibility-insights-action-ci.pipelineID)
+                              definition: $(resources.pipeline.accessibility-insights-action-ci.pipelineID)
                               runId: $(resources.pipeline.accessibility-insights-action-ci.runID)
                               artifactName: ado-extension-drop
                               targetPath: '$(System.DefaultWorkingDirectory)/ado-extension-drop'

--- a/pipelines/prod-release.yaml
+++ b/pipelines/prod-release.yaml
@@ -66,6 +66,7 @@ extends:
                   - job: 'CreateReleaseTag'
                     templateContext:
                         type: releaseJob
+                        isProduction: true
                     steps:
                         - task: 1ES.DownloadPipelineArtifact@1
                           inputs:


### PR DESCRIPTION
#### Details

Resolved issue in pipeline validation for CreateReleaseTag.

Pipeline was failing at validation as 1ES.DownloadPipelineArtifact@1 task is allowed only in release job, so added the job type as releaseJob ([1ES pipeline template Inputs | 1ES On EngHub](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/inputs))

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
