### PR TITLE
fix: changing validation pattern for keepurlfragment cases

### DIFF
--- a/pipelines/ado-extension-validation-template.yaml
+++ b/pipelines/ado-extension-validation-template.yaml
@@ -252,19 +252,20 @@ jobs:
           - task: CmdLine@2
             displayName: 'Validate keepUrlFragment from index.html file'
             # Below validation is based on hash URLs pattern scanned by crawler in index.html file
-            # with keepUrlFragment as false, azure portal URL with #view should not be present
-            # with keepUrlFragment as true, azure portal URL with #view should be present
+            # with keepUrlFragment as false, azure portal URL with # routed page should not be present
+            # with keepUrlFragment as true, azure portal URL with # routed page should be present
+            # Note: https://ms.portal.azure.com/#home is default routed page it will be present in both case so excluding #home routing for validation
             inputs:
                 script: |
                     cd artifacts/accessibility-reports-case-keepUrlFragment-1
-                    grep -r --include='*.html' 'https://ms.portal.azure.com/#view' > accessibility-reports-case-keepUrlFragment-1.txt
+                    grep -r --include='*.html' -P 'https://ms.portal.azure.com/#(?!home)' > accessibility-reports-case-keepUrlFragment-1.txt
                     if [ -s "accessibility-reports-case-keepUrlFragment-1.txt" ]; then
                         echo test-passed > expected-result.txt
                         echo keepUrlFragment-1-test-passed
                     fi
 
                     cd ../accessibility-reports-case-keepUrlFragment-2
-                    grep -r --include='*.html' 'https://ms.portal.azure.com/#view' > accessibility-reports-case-keepUrlFragment-2.txt
+                    grep -r --include='*.html' -P 'https://ms.portal.azure.com/#(?!home)' > accessibility-reports-case-keepUrlFragment-2.txt
                     if [ ! -s "accessibility-reports-case-keepUrlFragment-2.txt" ]; then
                         echo test-passed > expected-result.txt
                         echo keepUrlFragment-2-test-passed


### PR DESCRIPTION
#### Details

Issues in #view pages used for validation are fixed or not scanned by crawler due to maxUrl parameter.
To avoid these issues in future changing validation pattern to check any # url except #home to be present in file.
"https://ms.portal.azure.com/#home" is default routed page it will be present in both case so excluding #home routing for validation.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
