### PR TITLE
fix: Fix Dependency Confusion vulnerability

### DIFF
--- a/packages/ado-extension/package.json
+++ b/packages/ado-extension/package.json
@@ -16,7 +16,7 @@
         "watch:test": "jest --watch",
         "test:e2e": "npm-run-all --race --parallel test:e2e:serve-hashroute \"test:e2e:run-tests\" --",
         "test:e2e:run-tests": "jest --rootDir e2e --coverage false",
-        "test:e2e:serve-hashroute": "yarn workspace test-website-hashroute start",
+        "test:e2e:serve-hashroute": "yarn workspace @accessibility-insights-action/test-website-hashroute start",
         "docs": "node scripts/documentation.js && prettier --write \"../../docs/ado-extension-inputs.md\""
     },
     "repository": {

--- a/packages/test-website-hashroute/package.json
+++ b/packages/test-website-hashroute/package.json
@@ -1,12 +1,11 @@
 {
-    "name": "test-website-hashroute",
+    "name": "@accessibility-insights-action/test-website-hashroute",
     "version": "0.1.0",
     "private": true,
     "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^5.3.4",
-        "test-website-hashroute": "file:"
+        "react-router-dom": "^5.3.4"
     },
     "devDependencies": {
         "react-scripts": "5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,6 +94,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@accessibility-insights-action/test-website-hashroute@workspace:packages/test-website-hashroute":
+  version: 0.0.0-use.local
+  resolution: "@accessibility-insights-action/test-website-hashroute@workspace:packages/test-website-hashroute"
+  dependencies:
+    react: ^18.3.1
+    react-dom: ^18.3.1
+    react-router-dom: ^5.3.4
+    react-scripts: 5.0.1
+  languageName: unknown
+  linkType: soft
+
 "@alloc/quick-lru@npm:^5.2.0":
   version: 5.2.0
   resolution: "@alloc/quick-lru@npm:5.2.0"
@@ -19963,18 +19974,6 @@ __metadata:
   checksum: 3b34a3d77165a2cb82b34014b3aba93b1c4637a5011807557dc2f3da826c59975a5ccad765721c4648b39817e3472789f9b0fa98fc854c5c1c7a1e632aacdc28
   languageName: node
   linkType: hard
-
-"test-website-hashroute@file:, test-website-hashroute@workspace:packages/test-website-hashroute":
-  version: 0.0.0-use.local
-  resolution: "test-website-hashroute@workspace:packages/test-website-hashroute"
-  dependencies:
-    react: ^18.3.1
-    react-dom: ^18.3.1
-    react-router-dom: ^5.3.4
-    react-scripts: 5.0.1
-    test-website-hashroute: "file:"
-  languageName: unknown
-  linkType: soft
 
 "text-table@npm:^0.2.0":
   version: 0.2.0


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Removing self-dependency for test-website-hashroute package as it could lead to Dependency Confusion vulnerability.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Addresses [MSRC93697 - accessibility-insights-action - Dependency Confusion vulnerability](https://portal.microsofticm.com/imp/v5/incidents/details/31000000281764/summary)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes [MSRC93697 - accessibility-insights-action - Dependency Confusion vulnerability](https://portal.microsofticm.com/imp/v5/incidents/details/31000000281764/summary)
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
