### PR TITLE
feat: Update report and AI-scan package dependency for axe core and n…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
     "eslint.validate": ["typescript", "javascript"],
     "eslint.workingDirectories": [{ "pattern": "./packages/*/" }],
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": "true"
+        "source.fixAll.eslint": true
     },
     "shellformat.effectLanguages": ["shellscript"],
     "files.exclude": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
     "eslint.validate": ["typescript", "javascript"],
     "eslint.workingDirectories": [{ "pattern": "./packages/*/" }],
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
     "shellformat.effectLanguages": ["shellscript"],
     "files.exclude": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
     "eslint.validate": ["typescript", "javascript"],
     "eslint.workingDirectories": [{ "pattern": "./packages/*/" }],
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": "explicit"
+        "source.fixAll.eslint": "true"
     },
     "shellformat.effectLanguages": ["shellscript"],
     "files.exclude": {

--- a/packages/ado-extension/e2e/__snapshots__/ado-extension.test.ts.snap
+++ b/packages/ado-extension/e2e/__snapshots__/ado-extension.test.ts.snap
@@ -4,8 +4,8 @@ exports[`Sample task tests returns expected scan summary and footer (ignoring us
 "-------------------
 Scan summary
 URLs: 1 with failures, 0 passed, 0 not scannable
-Rules: 5 with failures, 14 passed, 36 not applicable
+Rules: 5 with failures, 13 passed, 36 not applicable
 
 -------------------
-This scan used axe-core 4.9.1"
+This scan used axe-core 4.10.2"
 `;

--- a/packages/ado-extension/e2e/ado-extension.test.ts
+++ b/packages/ado-extension/e2e/ado-extension.test.ts
@@ -23,7 +23,7 @@ describe('Sample task tests', () => {
         expect(testSubject.stdOutContained("##[debug][Telemetry] tracking a 'ScanCompleted' event"));
 
         function filterStdOut(stdout: string) {
-            const logs = stdout.match(/-------------------(.|\n)*This scan used axe-core 4\.9\.1/);
+            const logs = stdout.match(/-------------------(.|\n)*This scan used axe-core 4\.10\.2/);
             return logs ? logs[0] : '';
         }
     });
@@ -41,7 +41,7 @@ describe('Sample task tests', () => {
                 'Accessibility scanning of URL https://www.washington.edu/accesscomputing/AU/before.html completed',
             ),
         ).toBeTruthy();
-        expect(testSubject.stdOutContained('Rules: 5 with failures, 14 passed, 36 not applicable')).toBeTruthy();
+        expect(testSubject.stdOutContained('Rules: 5 with failures, 13 passed, 36 not applicable')).toBeTruthy();
     });
 
     it('should succeed with staticSiteDir inputs', () => {
@@ -54,7 +54,7 @@ describe('Sample task tests', () => {
         expect(testSubject.warningIssues.length).toEqual(0);
         expect(testSubject.errorIssues.length).toEqual(1);
         expect(testSubject.stdOutContained('Accessibility scanning of URL http://localhost:39983/ completed')).toBeTruthy();
-        expect(testSubject.stdOutContained('Rules: 4 with failures, 13 passed, 39 not applicable')).toBeTruthy();
+        expect(testSubject.stdOutContained('Rules: 4 with failures, 12 passed, 39 not applicable')).toBeTruthy();
     });
 
     it('limits the number of pages crawled and scanned when maxUrls input is set', () => {
@@ -108,7 +108,7 @@ describe('Sample task tests', () => {
         expect(
             testSubject.stdOutContainedRegex(new RegExp('Processing loaded page.*{"url":"http://localhost:39983/unlinked/index.html"}')),
         ).toBeTruthy();
-        expect(testSubject.stdOutContained('Rules: 4 with failures, 13 passed, 39 not applicable')).toBeTruthy();
+        expect(testSubject.stdOutContained('Rules: 4 with failures, 12 passed, 39 not applicable')).toBeTruthy();
     });
 
     it('scans folders that are passed in as inputUrls (without a trailing slash)', () => {
@@ -124,7 +124,7 @@ describe('Sample task tests', () => {
         expect(
             testSubject.stdOutContainedRegex(new RegExp('Processing loaded page.*{"url":"http://localhost:39983/unlinked/"}')),
         ).toBeTruthy();
-        expect(testSubject.stdOutContained('Rules: 4 with failures, 13 passed, 39 not applicable')).toBeTruthy();
+        expect(testSubject.stdOutContained('Rules: 4 with failures, 12 passed, 39 not applicable')).toBeTruthy();
     });
 
     it('scans folders that are passed in as inputUrls (with a trailing slash)', () => {
@@ -140,7 +140,7 @@ describe('Sample task tests', () => {
         expect(
             testSubject.stdOutContainedRegex(new RegExp('Processing loaded page.*{"url":"http://localhost:39983/unlinked/"}')),
         ).toBeTruthy();
-        expect(testSubject.stdOutContained('Rules: 4 with failures, 13 passed, 39 not applicable')).toBeTruthy();
+        expect(testSubject.stdOutContained('Rules: 4 with failures, 12 passed, 39 not applicable')).toBeTruthy();
     });
 
     it('should fail if both URL and staticSiteDir are defined', () => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -29,9 +29,9 @@
     "dependencies": {
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
-        "accessibility-insights-report": "5.1.0",
-        "accessibility-insights-scan": "^3.0.1",
-        "axe-core": "^4.9.1",
+        "accessibility-insights-report": "6.0.0",
+        "accessibility-insights-scan": "^3.1.0",
+        "axe-core": "^4.10.2",
         "express": "^4.21.0",
         "filenamify-url": "^3.1.0",
         "get-port": "^7.1.0",

--- a/packages/shared/src/console-output/__custom-snapshots__/axe-descriptions.snap.md
+++ b/packages/shared/src/console-output/__custom-snapshots__/axe-descriptions.snap.md
@@ -1,111 +1,112 @@
 Accessibility Insights
 * URLs: 1 URL(s) failed, 1 URL(s) passed, and 1 were not scannable
-* Rules: 103 check(s) failed, 1 check(s) passed, and 2 were not applicable
+* Rules: 104 check(s) failed, 1 check(s) passed, and 2 were not applicable
 * Download the Accessibility Insights artifact to view the detailed results of these checks
 Failed instances
-* 1 × accesskeys:  Ensures every accesskey attribute value is unique
-* 1 × area-alt:  Ensures <area> elements of image maps have alternate text
-* 1 × aria-allowed-attr:  Ensures an element's role supports its ARIA attributes
-* 1 × aria-allowed-role:  Ensures role attribute has an appropriate value for the element
+* 1 × accesskeys:  Ensure every accesskey attribute value is unique
+* 1 × area-alt:  Ensure <area> elements of image maps have alternative text
+* 1 × aria-allowed-attr:  Ensure an element's role supports its ARIA attributes
+* 1 × aria-allowed-role:  Ensure role attribute has an appropriate value for the element
 * 1 × aria-braille-equivalent:  Ensure aria-braillelabel and aria-brailleroledescription have a non-braille equivalent
-* 1 × aria-command-name:  Ensures every ARIA button, link and menuitem has an accessible name
-* 1 × aria-conditional-attr:  Ensures ARIA attributes are used as described in the specification of the element's role
-* 1 × aria-deprecated-role:  Ensures elements do not use deprecated roles
-* 1 × aria-dialog-name:  Ensures every ARIA dialog and alertdialog node has an accessible name
-* 1 × aria-hidden-body:  Ensures aria-hidden="true" is not present on the document body.
-* 1 × aria-hidden-focus:  Ensures aria-hidden elements are not focusable nor contain focusable elements
-* 1 × aria-input-field-name:  Ensures every ARIA input field has an accessible name
-* 1 × aria-meter-name:  Ensures every ARIA meter node has an accessible name
-* 1 × aria-progressbar-name:  Ensures every ARIA progressbar node has an accessible name
-* 1 × aria-prohibited-attr:  Ensures ARIA attributes are not prohibited for an element's role
-* 1 × aria-required-attr:  Ensures elements with ARIA roles have all required ARIA attributes
-* 1 × aria-required-children:  Ensures elements with an ARIA role that require child roles contain them
-* 1 × aria-required-parent:  Ensures elements with an ARIA role that require parent roles are contained by them
+* 1 × aria-command-name:  Ensure every ARIA button, link and menuitem has an accessible name
+* 1 × aria-conditional-attr:  Ensure ARIA attributes are used as described in the specification of the element's role
+* 1 × aria-deprecated-role:  Ensure elements do not use deprecated roles
+* 1 × aria-dialog-name:  Ensure every ARIA dialog and alertdialog node has an accessible name
+* 1 × aria-hidden-body:  Ensure aria-hidden="true" is not present on the document body.
+* 1 × aria-hidden-focus:  Ensure aria-hidden elements are not focusable nor contain focusable elements
+* 1 × aria-input-field-name:  Ensure every ARIA input field has an accessible name
+* 1 × aria-meter-name:  Ensure every ARIA meter node has an accessible name
+* 1 × aria-progressbar-name:  Ensure every ARIA progressbar node has an accessible name
+* 1 × aria-prohibited-attr:  Ensure ARIA attributes are not prohibited for an element's role
+* 1 × aria-required-attr:  Ensure elements with ARIA roles have all required ARIA attributes
+* 1 × aria-required-children:  Ensure elements with an ARIA role that require child roles contain them
+* 1 × aria-required-parent:  Ensure elements with an ARIA role that require parent roles are contained by them
 * 1 × aria-roledescription:  Ensure aria-roledescription is only used on elements with an implicit or explicit role
-* 1 × aria-roles:  Ensures all elements with a role attribute use a valid value
-* 1 × aria-text:  Ensures role="text" is used on elements with no focusable descendants
-* 1 × aria-toggle-field-name:  Ensures every ARIA toggle field has an accessible name
-* 1 × aria-tooltip-name:  Ensures every ARIA tooltip node has an accessible name
-* 1 × aria-treeitem-name:  Ensures every ARIA treeitem node has an accessible name
-* 1 × aria-valid-attr-value:  Ensures all ARIA attributes have valid values
-* 1 × aria-valid-attr:  Ensures attributes that begin with aria- are valid ARIA attributes
-* 1 × audio-caption:  Ensures <audio> elements have captions
+* 1 × aria-roles:  Ensure all elements with a role attribute use a valid value
+* 1 × aria-text:  Ensure role="text" is used on elements with no focusable descendants
+* 1 × aria-toggle-field-name:  Ensure every ARIA toggle field has an accessible name
+* 1 × aria-tooltip-name:  Ensure every ARIA tooltip node has an accessible name
+* 1 × aria-treeitem-name:  Ensure every ARIA treeitem node has an accessible name
+* 1 × aria-valid-attr-value:  Ensure all ARIA attributes have valid values
+* 1 × aria-valid-attr:  Ensure attributes that begin with aria- are valid ARIA attributes
+* 1 × audio-caption:  Ensure <audio> elements have captions
 * 1 × autocomplete-valid:  Ensure the autocomplete attribute is correct and suitable for the form field
 * 1 × avoid-inline-spacing:  Ensure that text spacing set through style attributes can be adjusted with custom stylesheets
-* 1 × blink:  Ensures <blink> elements are not used
-* 1 × button-name:  Ensures buttons have discernible text
-* 1 × bypass:  Ensures each page has at least one mechanism for a user to bypass navigation and jump straight to the content
-* 1 × color-contrast-enhanced:  Ensures the contrast between foreground and background colors meets WCAG 2 AAA enhanced contrast ratio thresholds
-* 1 × color-contrast:  Ensures the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds
-* 1 × css-orientation-lock:  Ensures content is not locked to any specific display orientation, and the content is operable in all display orientations
-* 1 × definition-list:  Ensures <dl> elements are structured correctly
-* 1 × dlitem:  Ensures <dt> and <dd> elements are contained by a <dl>
-* 1 × document-title:  Ensures each HTML document contains a non-empty <title> element
-* 1 × duplicate-id-active:  Ensures every id attribute value of active elements is unique
-* 1 × duplicate-id-aria:  Ensures every id attribute value used in ARIA and in labels is unique
-* 1 × duplicate-id:  Ensures every id attribute value is unique
-* 1 × empty-heading:  Ensures headings have discernible text
-* 1 × empty-table-header:  Ensures table headers have discernible text
-* 1 × focus-order-semantics:  Ensures elements in the focus order have a role appropriate for interactive content
-* 1 × form-field-multiple-labels:  Ensures form field does not have multiple label elements
-* 1 × frame-focusable-content:  Ensures <frame> and <iframe> elements with focusable content do not have tabindex=-1
-* 1 × frame-tested:  Ensures <iframe> and <frame> elements contain the axe-core script
-* 1 × frame-title-unique:  Ensures <iframe> and <frame> elements contain a unique title attribute
-* 1 × frame-title:  Ensures <iframe> and <frame> elements have an accessible name
-* 1 × heading-order:  Ensures the order of headings is semantically correct
+* 1 × blink:  Ensure <blink> elements are not used
+* 1 × button-name:  Ensure buttons have discernible text
+* 1 × bypass:  Ensure each page has at least one mechanism for a user to bypass navigation and jump straight to the content
+* 1 × color-contrast-enhanced:  Ensure the contrast between foreground and background colors meets WCAG 2 AAA enhanced contrast ratio thresholds
+* 1 × color-contrast:  Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds
+* 1 × css-orientation-lock:  Ensure content is not locked to any specific display orientation, and the content is operable in all display orientations
+* 1 × definition-list:  Ensure <dl> elements are structured correctly
+* 1 × dlitem:  Ensure <dt> and <dd> elements are contained by a <dl>
+* 1 × document-title:  Ensure each HTML document contains a non-empty <title> element
+* 1 × duplicate-id-active:  Ensure every id attribute value of active elements is unique
+* 1 × duplicate-id-aria:  Ensure every id attribute value used in ARIA and in labels is unique
+* 1 × duplicate-id:  Ensure every id attribute value is unique
+* 1 × empty-heading:  Ensure headings have discernible text
+* 1 × empty-table-header:  Ensure table headers have discernible text
+* 1 × focus-order-semantics:  Ensure elements in the focus order have a role appropriate for interactive content
+* 1 × form-field-multiple-labels:  Ensure form field does not have multiple label elements
+* 1 × frame-focusable-content:  Ensure <frame> and <iframe> elements with focusable content do not have tabindex=-1
+* 1 × frame-tested:  Ensure <iframe> and <frame> elements contain the axe-core script
+* 1 × frame-title-unique:  Ensure <iframe> and <frame> elements contain a unique title attribute
+* 1 × frame-title:  Ensure <iframe> and <frame> elements have an accessible name
+* 1 × heading-order:  Ensure the order of headings is semantically correct
 * 1 × hidden-content:  Informs users about hidden content.
-* 1 × html-has-lang:  Ensures every HTML document has a lang attribute
-* 1 × html-lang-valid:  Ensures the lang attribute of the <html> element has a valid value
+* 1 × html-has-lang:  Ensure every HTML document has a lang attribute
+* 1 × html-lang-valid:  Ensure the lang attribute of the <html> element has a valid value
 * 1 × html-xml-lang-mismatch:  Ensure that HTML elements with both valid lang and xml:lang attributes agree on the base language of the page
 * 1 × identical-links-same-purpose:  Ensure that links with the same accessible name serve a similar purpose
-* 1 × image-alt:  Ensures <img> elements have alternate text or a role of none or presentation
+* 1 × image-alt:  Ensure <img> elements have alternative text or a role of none or presentation
 * 1 × image-redundant-alt:  Ensure image alternative is not repeated as text
-* 1 × input-button-name:  Ensures input buttons have discernible text
-* 1 × input-image-alt:  Ensures <input type="image"> elements have alternate text
-* 1 × label-content-name-mismatch:  Ensures that elements labelled through their content must have their visible text as part of their accessible name
-* 1 × label-title-only:  Ensures that every form element has a visible label and is not solely labeled using hidden labels, or the title or aria-describedby attributes
-* 1 × label:  Ensures every form element has a label
-* 1 × landmark-banner-is-top-level:  Ensures the banner landmark is at top level
-* 1 × landmark-complementary-is-top-level:  Ensures the complementary landmark or aside is at top level
-* 1 × landmark-contentinfo-is-top-level:  Ensures the contentinfo landmark is at top level
-* 1 × landmark-main-is-top-level:  Ensures the main landmark is at top level
-* 1 × landmark-no-duplicate-banner:  Ensures the document has at most one banner landmark
-* 1 × landmark-no-duplicate-contentinfo:  Ensures the document has at most one contentinfo landmark
-* 1 × landmark-no-duplicate-main:  Ensures the document has at most one main landmark
-* 1 × landmark-one-main:  Ensures the document has a main landmark
-* 1 × landmark-unique:  Landmarks should have a unique role or role/label/title (i.e. accessible name) combination
+* 1 × input-button-name:  Ensure input buttons have discernible text
+* 1 × input-image-alt:  Ensure <input type="image"> elements have alternative text
+* 1 × label-content-name-mismatch:  Ensure that elements labelled through their content must have their visible text as part of their accessible name
+* 1 × label-title-only:  Ensure that every form element has a visible label and is not solely labeled using hidden labels, or the title or aria-describedby attributes
+* 1 × label:  Ensure every form element has a label
+* 1 × landmark-banner-is-top-level:  Ensure the banner landmark is at top level
+* 1 × landmark-complementary-is-top-level:  Ensure the complementary landmark or aside is at top level
+* 1 × landmark-contentinfo-is-top-level:  Ensure the contentinfo landmark is at top level
+* 1 × landmark-main-is-top-level:  Ensure the main landmark is at top level
+* 1 × landmark-no-duplicate-banner:  Ensure the document has at most one banner landmark
+* 1 × landmark-no-duplicate-contentinfo:  Ensure the document has at most one contentinfo landmark
+* 1 × landmark-no-duplicate-main:  Ensure the document has at most one main landmark
+* 1 × landmark-one-main:  Ensure the document has a main landmark
+* 1 × landmark-unique:  Ensure landmarks are unique
 * 1 × link-in-text-block:  Ensure links are distinguished from surrounding text in a way that does not rely on color
-* 1 × link-name:  Ensures links have discernible text
-* 1 × list:  Ensures that lists are structured correctly
-* 1 × listitem:  Ensures <li> elements are used semantically
-* 1 × marquee:  Ensures <marquee> elements are not used
-* 1 × meta-refresh-no-exceptions:  Ensures <meta http-equiv="refresh"> is not used for delayed refresh
-* 1 × meta-refresh:  Ensures <meta http-equiv="refresh"> is not used for delayed refresh
-* 1 × meta-viewport-large:  Ensures <meta name="viewport"> can scale a significant amount
-* 1 × meta-viewport:  Ensures <meta name="viewport"> does not disable text scaling and zooming
-* 1 × nested-interactive:  Ensures interactive controls are not nested as they are not always announced by screen readers or can cause focus problems for assistive technologies
-* 1 × no-autoplay-audio:  Ensures <video> or <audio> elements do not autoplay audio for more than 3 seconds without a control mechanism to stop or mute the audio
-* 1 × object-alt:  Ensures <object> elements have alternate text
+* 1 × link-name:  Ensure links have discernible text
+* 1 × list:  Ensure that lists are structured correctly
+* 1 × listitem:  Ensure <li> elements are used semantically
+* 1 × marquee:  Ensure <marquee> elements are not used
+* 1 × meta-refresh-no-exceptions:  Ensure <meta http-equiv="refresh"> is not used for delayed refresh
+* 1 × meta-refresh:  Ensure <meta http-equiv="refresh"> is not used for delayed refresh
+* 1 × meta-viewport-large:  Ensure <meta name="viewport"> can scale a significant amount
+* 1 × meta-viewport:  Ensure <meta name="viewport"> does not disable text scaling and zooming
+* 1 × nested-interactive:  Ensure interactive controls are not nested as they are not always announced by screen readers or can cause focus problems for assistive technologies
+* 1 × no-autoplay-audio:  Ensure <video> or <audio> elements do not autoplay audio for more than 3 seconds without a control mechanism to stop or mute the audio
+* 1 × object-alt:  Ensure <object> elements have alternative text
 * 1 × p-as-heading:  Ensure bold, italic text and font-size is not used to style <p> elements as a heading
 * 1 × page-has-heading-one:  Ensure that the page, or at least one of its frames contains a level-one heading
 * 1 × presentation-role-conflict:  Elements marked as presentational should not have global ARIA or tabindex to ensure all screen readers ignore them
-* 1 × region:  Ensures all page content is contained by landmarks
-* 1 × role-img-alt:  Ensures [role="img"] elements have alternate text
-* 1 × scope-attr-valid:  Ensures the scope attribute is used correctly on tables
+* 1 × region:  Ensure all page content is contained by landmarks
+* 1 × role-img-alt:  Ensure [role="img"] elements have alternative text
+* 1 × scope-attr-valid:  Ensure the scope attribute is used correctly on tables
 * 1 × scrollable-region-focusable:  Ensure elements that have scrollable content are accessible by keyboard
-* 1 × select-name:  Ensures select element has an accessible name
-* 1 × server-side-image-map:  Ensures that server-side image maps are not used
+* 1 × select-name:  Ensure select element has an accessible name
+* 1 × server-side-image-map:  Ensure that server-side image maps are not used
 * 1 × skip-link:  Ensure all skip links have a focusable target
-* 1 × svg-img-alt:  Ensures <svg> elements with an img, graphics-document or graphics-symbol role have an accessible text
-* 1 × tabindex:  Ensures tabindex attribute values are not greater than 0
+* 1 × summary-name:  Ensure summary elements have discernible text
+* 1 × svg-img-alt:  Ensure <svg> elements with an img, graphics-document or graphics-symbol role have an accessible text
+* 1 × tabindex:  Ensure tabindex attribute values are not greater than 0
 * 1 × table-duplicate-name:  Ensure the <caption> element does not contain the same text as the summary attribute
 * 1 × table-fake-caption:  Ensure that tables with a caption use the <caption> element.
-* 1 × target-size:  Ensure touch target have sufficient size and space
+* 1 × target-size:  Ensure touch targets have sufficient size and space
 * 1 × td-has-header:  Ensure that each non-empty data cell in a <table> larger than 3 by 3  has one or more table headers
 * 1 × td-headers-attr:  Ensure that each cell in a table that uses the headers attribute refers only to other cells in that table
 * 1 × th-has-data-cells:  Ensure that <th> elements and elements with role=columnheader/rowheader have data cells they describe
-* 1 × valid-lang:  Ensures lang attributes have valid values
-* 1 × video-caption:  Ensures <video> elements have captions
+* 1 × valid-lang:  Ensure lang attributes have valid values
+* 1 × video-caption:  Ensure <video> elements have captions
 
 -------------------
 This scan used axe-core axeVersion (https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) and userAgent with a display resolution of 1920x1080.

--- a/packages/shared/src/mark-down/__custom-snapshots__/axe-descriptions.snap.md
+++ b/packages/shared/src/mark-down/__custom-snapshots__/axe-descriptions.snap.md
@@ -1,111 +1,112 @@
 ### ![Accessibility Insights](https://accessibilityinsights.io/img/a11yinsights-blue.svg) Accessibility Insights
 * **URLs**: 1 URL(s) failed, 1 URL(s) passed, and 1 were not scannable
-* **Rules**: 103 check(s) failed, 1 check(s) passed, and 2 were not applicable
+* **Rules**: 104 check(s) failed, 1 check(s) passed, and 2 were not applicable
 * Download the **Accessibility Insights artifact** to view the detailed results of these checks
 #### Failed instances
-* **1 × accesskeys**:  Ensures every accesskey attribute value is unique
-* **1 × area-alt**:  Ensures \<area> elements of image maps have alternate text
-* **1 × aria-allowed-attr**:  Ensures an element's role supports its ARIA attributes
-* **1 × aria-allowed-role**:  Ensures role attribute has an appropriate value for the element
+* **1 × accesskeys**:  Ensure every accesskey attribute value is unique
+* **1 × area-alt**:  Ensure \<area> elements of image maps have alternative text
+* **1 × aria-allowed-attr**:  Ensure an element's role supports its ARIA attributes
+* **1 × aria-allowed-role**:  Ensure role attribute has an appropriate value for the element
 * **1 × aria-braille-equivalent**:  Ensure aria-braillelabel and aria-brailleroledescription have a non-braille equivalent
-* **1 × aria-command-name**:  Ensures every ARIA button, link and menuitem has an accessible name
-* **1 × aria-conditional-attr**:  Ensures ARIA attributes are used as described in the specification of the element's role
-* **1 × aria-deprecated-role**:  Ensures elements do not use deprecated roles
-* **1 × aria-dialog-name**:  Ensures every ARIA dialog and alertdialog node has an accessible name
-* **1 × aria-hidden-body**:  Ensures aria-hidden="true" is not present on the document body.
-* **1 × aria-hidden-focus**:  Ensures aria-hidden elements are not focusable nor contain focusable elements
-* **1 × aria-input-field-name**:  Ensures every ARIA input field has an accessible name
-* **1 × aria-meter-name**:  Ensures every ARIA meter node has an accessible name
-* **1 × aria-progressbar-name**:  Ensures every ARIA progressbar node has an accessible name
-* **1 × aria-prohibited-attr**:  Ensures ARIA attributes are not prohibited for an element's role
-* **1 × aria-required-attr**:  Ensures elements with ARIA roles have all required ARIA attributes
-* **1 × aria-required-children**:  Ensures elements with an ARIA role that require child roles contain them
-* **1 × aria-required-parent**:  Ensures elements with an ARIA role that require parent roles are contained by them
+* **1 × aria-command-name**:  Ensure every ARIA button, link and menuitem has an accessible name
+* **1 × aria-conditional-attr**:  Ensure ARIA attributes are used as described in the specification of the element's role
+* **1 × aria-deprecated-role**:  Ensure elements do not use deprecated roles
+* **1 × aria-dialog-name**:  Ensure every ARIA dialog and alertdialog node has an accessible name
+* **1 × aria-hidden-body**:  Ensure aria-hidden="true" is not present on the document body.
+* **1 × aria-hidden-focus**:  Ensure aria-hidden elements are not focusable nor contain focusable elements
+* **1 × aria-input-field-name**:  Ensure every ARIA input field has an accessible name
+* **1 × aria-meter-name**:  Ensure every ARIA meter node has an accessible name
+* **1 × aria-progressbar-name**:  Ensure every ARIA progressbar node has an accessible name
+* **1 × aria-prohibited-attr**:  Ensure ARIA attributes are not prohibited for an element's role
+* **1 × aria-required-attr**:  Ensure elements with ARIA roles have all required ARIA attributes
+* **1 × aria-required-children**:  Ensure elements with an ARIA role that require child roles contain them
+* **1 × aria-required-parent**:  Ensure elements with an ARIA role that require parent roles are contained by them
 * **1 × aria-roledescription**:  Ensure aria-roledescription is only used on elements with an implicit or explicit role
-* **1 × aria-roles**:  Ensures all elements with a role attribute use a valid value
-* **1 × aria-text**:  Ensures role="text" is used on elements with no focusable descendants
-* **1 × aria-toggle-field-name**:  Ensures every ARIA toggle field has an accessible name
-* **1 × aria-tooltip-name**:  Ensures every ARIA tooltip node has an accessible name
-* **1 × aria-treeitem-name**:  Ensures every ARIA treeitem node has an accessible name
-* **1 × aria-valid-attr-value**:  Ensures all ARIA attributes have valid values
-* **1 × aria-valid-attr**:  Ensures attributes that begin with aria- are valid ARIA attributes
-* **1 × audio-caption**:  Ensures \<audio> elements have captions
+* **1 × aria-roles**:  Ensure all elements with a role attribute use a valid value
+* **1 × aria-text**:  Ensure role="text" is used on elements with no focusable descendants
+* **1 × aria-toggle-field-name**:  Ensure every ARIA toggle field has an accessible name
+* **1 × aria-tooltip-name**:  Ensure every ARIA tooltip node has an accessible name
+* **1 × aria-treeitem-name**:  Ensure every ARIA treeitem node has an accessible name
+* **1 × aria-valid-attr-value**:  Ensure all ARIA attributes have valid values
+* **1 × aria-valid-attr**:  Ensure attributes that begin with aria- are valid ARIA attributes
+* **1 × audio-caption**:  Ensure \<audio> elements have captions
 * **1 × autocomplete-valid**:  Ensure the autocomplete attribute is correct and suitable for the form field
 * **1 × avoid-inline-spacing**:  Ensure that text spacing set through style attributes can be adjusted with custom stylesheets
-* **1 × blink**:  Ensures \<blink> elements are not used
-* **1 × button-name**:  Ensures buttons have discernible text
-* **1 × bypass**:  Ensures each page has at least one mechanism for a user to bypass navigation and jump straight to the content
-* **1 × color-contrast-enhanced**:  Ensures the contrast between foreground and background colors meets WCAG 2 AAA enhanced contrast ratio thresholds
-* **1 × color-contrast**:  Ensures the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds
-* **1 × css-orientation-lock**:  Ensures content is not locked to any specific display orientation, and the content is operable in all display orientations
-* **1 × definition-list**:  Ensures \<dl> elements are structured correctly
-* **1 × dlitem**:  Ensures \<dt> and \<dd> elements are contained by a \<dl>
-* **1 × document-title**:  Ensures each HTML document contains a non-empty \<title> element
-* **1 × duplicate-id-active**:  Ensures every id attribute value of active elements is unique
-* **1 × duplicate-id-aria**:  Ensures every id attribute value used in ARIA and in labels is unique
-* **1 × duplicate-id**:  Ensures every id attribute value is unique
-* **1 × empty-heading**:  Ensures headings have discernible text
-* **1 × empty-table-header**:  Ensures table headers have discernible text
-* **1 × focus-order-semantics**:  Ensures elements in the focus order have a role appropriate for interactive content
-* **1 × form-field-multiple-labels**:  Ensures form field does not have multiple label elements
-* **1 × frame-focusable-content**:  Ensures \<frame> and \<iframe> elements with focusable content do not have tabindex=-1
-* **1 × frame-tested**:  Ensures \<iframe> and \<frame> elements contain the axe-core script
-* **1 × frame-title-unique**:  Ensures \<iframe> and \<frame> elements contain a unique title attribute
-* **1 × frame-title**:  Ensures \<iframe> and \<frame> elements have an accessible name
-* **1 × heading-order**:  Ensures the order of headings is semantically correct
+* **1 × blink**:  Ensure \<blink> elements are not used
+* **1 × button-name**:  Ensure buttons have discernible text
+* **1 × bypass**:  Ensure each page has at least one mechanism for a user to bypass navigation and jump straight to the content
+* **1 × color-contrast-enhanced**:  Ensure the contrast between foreground and background colors meets WCAG 2 AAA enhanced contrast ratio thresholds
+* **1 × color-contrast**:  Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds
+* **1 × css-orientation-lock**:  Ensure content is not locked to any specific display orientation, and the content is operable in all display orientations
+* **1 × definition-list**:  Ensure \<dl> elements are structured correctly
+* **1 × dlitem**:  Ensure \<dt> and \<dd> elements are contained by a \<dl>
+* **1 × document-title**:  Ensure each HTML document contains a non-empty \<title> element
+* **1 × duplicate-id-active**:  Ensure every id attribute value of active elements is unique
+* **1 × duplicate-id-aria**:  Ensure every id attribute value used in ARIA and in labels is unique
+* **1 × duplicate-id**:  Ensure every id attribute value is unique
+* **1 × empty-heading**:  Ensure headings have discernible text
+* **1 × empty-table-header**:  Ensure table headers have discernible text
+* **1 × focus-order-semantics**:  Ensure elements in the focus order have a role appropriate for interactive content
+* **1 × form-field-multiple-labels**:  Ensure form field does not have multiple label elements
+* **1 × frame-focusable-content**:  Ensure \<frame> and \<iframe> elements with focusable content do not have tabindex=-1
+* **1 × frame-tested**:  Ensure \<iframe> and \<frame> elements contain the axe-core script
+* **1 × frame-title-unique**:  Ensure \<iframe> and \<frame> elements contain a unique title attribute
+* **1 × frame-title**:  Ensure \<iframe> and \<frame> elements have an accessible name
+* **1 × heading-order**:  Ensure the order of headings is semantically correct
 * **1 × hidden-content**:  Informs users about hidden content.
-* **1 × html-has-lang**:  Ensures every HTML document has a lang attribute
-* **1 × html-lang-valid**:  Ensures the lang attribute of the \<html> element has a valid value
+* **1 × html-has-lang**:  Ensure every HTML document has a lang attribute
+* **1 × html-lang-valid**:  Ensure the lang attribute of the \<html> element has a valid value
 * **1 × html-xml-lang-mismatch**:  Ensure that HTML elements with both valid lang and xml:lang attributes agree on the base language of the page
 * **1 × identical-links-same-purpose**:  Ensure that links with the same accessible name serve a similar purpose
-* **1 × image-alt**:  Ensures \<img> elements have alternate text or a role of none or presentation
+* **1 × image-alt**:  Ensure \<img> elements have alternative text or a role of none or presentation
 * **1 × image-redundant-alt**:  Ensure image alternative is not repeated as text
-* **1 × input-button-name**:  Ensures input buttons have discernible text
-* **1 × input-image-alt**:  Ensures \<input type="image"> elements have alternate text
-* **1 × label-content-name-mismatch**:  Ensures that elements labelled through their content must have their visible text as part of their accessible name
-* **1 × label-title-only**:  Ensures that every form element has a visible label and is not solely labeled using hidden labels, or the title or aria-describedby attributes
-* **1 × label**:  Ensures every form element has a label
-* **1 × landmark-banner-is-top-level**:  Ensures the banner landmark is at top level
-* **1 × landmark-complementary-is-top-level**:  Ensures the complementary landmark or aside is at top level
-* **1 × landmark-contentinfo-is-top-level**:  Ensures the contentinfo landmark is at top level
-* **1 × landmark-main-is-top-level**:  Ensures the main landmark is at top level
-* **1 × landmark-no-duplicate-banner**:  Ensures the document has at most one banner landmark
-* **1 × landmark-no-duplicate-contentinfo**:  Ensures the document has at most one contentinfo landmark
-* **1 × landmark-no-duplicate-main**:  Ensures the document has at most one main landmark
-* **1 × landmark-one-main**:  Ensures the document has a main landmark
-* **1 × landmark-unique**:  Landmarks should have a unique role or role/label/title (i.e. accessible name) combination
+* **1 × input-button-name**:  Ensure input buttons have discernible text
+* **1 × input-image-alt**:  Ensure \<input type="image"> elements have alternative text
+* **1 × label-content-name-mismatch**:  Ensure that elements labelled through their content must have their visible text as part of their accessible name
+* **1 × label-title-only**:  Ensure that every form element has a visible label and is not solely labeled using hidden labels, or the title or aria-describedby attributes
+* **1 × label**:  Ensure every form element has a label
+* **1 × landmark-banner-is-top-level**:  Ensure the banner landmark is at top level
+* **1 × landmark-complementary-is-top-level**:  Ensure the complementary landmark or aside is at top level
+* **1 × landmark-contentinfo-is-top-level**:  Ensure the contentinfo landmark is at top level
+* **1 × landmark-main-is-top-level**:  Ensure the main landmark is at top level
+* **1 × landmark-no-duplicate-banner**:  Ensure the document has at most one banner landmark
+* **1 × landmark-no-duplicate-contentinfo**:  Ensure the document has at most one contentinfo landmark
+* **1 × landmark-no-duplicate-main**:  Ensure the document has at most one main landmark
+* **1 × landmark-one-main**:  Ensure the document has a main landmark
+* **1 × landmark-unique**:  Ensure landmarks are unique
 * **1 × link-in-text-block**:  Ensure links are distinguished from surrounding text in a way that does not rely on color
-* **1 × link-name**:  Ensures links have discernible text
-* **1 × list**:  Ensures that lists are structured correctly
-* **1 × listitem**:  Ensures \<li> elements are used semantically
-* **1 × marquee**:  Ensures \<marquee> elements are not used
-* **1 × meta-refresh-no-exceptions**:  Ensures \<meta http-equiv="refresh"> is not used for delayed refresh
-* **1 × meta-refresh**:  Ensures \<meta http-equiv="refresh"> is not used for delayed refresh
-* **1 × meta-viewport-large**:  Ensures \<meta name="viewport"> can scale a significant amount
-* **1 × meta-viewport**:  Ensures \<meta name="viewport"> does not disable text scaling and zooming
-* **1 × nested-interactive**:  Ensures interactive controls are not nested as they are not always announced by screen readers or can cause focus problems for assistive technologies
-* **1 × no-autoplay-audio**:  Ensures \<video> or \<audio> elements do not autoplay audio for more than 3 seconds without a control mechanism to stop or mute the audio
-* **1 × object-alt**:  Ensures \<object> elements have alternate text
+* **1 × link-name**:  Ensure links have discernible text
+* **1 × list**:  Ensure that lists are structured correctly
+* **1 × listitem**:  Ensure \<li> elements are used semantically
+* **1 × marquee**:  Ensure \<marquee> elements are not used
+* **1 × meta-refresh-no-exceptions**:  Ensure \<meta http-equiv="refresh"> is not used for delayed refresh
+* **1 × meta-refresh**:  Ensure \<meta http-equiv="refresh"> is not used for delayed refresh
+* **1 × meta-viewport-large**:  Ensure \<meta name="viewport"> can scale a significant amount
+* **1 × meta-viewport**:  Ensure \<meta name="viewport"> does not disable text scaling and zooming
+* **1 × nested-interactive**:  Ensure interactive controls are not nested as they are not always announced by screen readers or can cause focus problems for assistive technologies
+* **1 × no-autoplay-audio**:  Ensure \<video> or \<audio> elements do not autoplay audio for more than 3 seconds without a control mechanism to stop or mute the audio
+* **1 × object-alt**:  Ensure \<object> elements have alternative text
 * **1 × p-as-heading**:  Ensure bold, italic text and font-size is not used to style \<p> elements as a heading
 * **1 × page-has-heading-one**:  Ensure that the page, or at least one of its frames contains a level-one heading
 * **1 × presentation-role-conflict**:  Elements marked as presentational should not have global ARIA or tabindex to ensure all screen readers ignore them
-* **1 × region**:  Ensures all page content is contained by landmarks
-* **1 × role-img-alt**:  Ensures [role="img"] elements have alternate text
-* **1 × scope-attr-valid**:  Ensures the scope attribute is used correctly on tables
+* **1 × region**:  Ensure all page content is contained by landmarks
+* **1 × role-img-alt**:  Ensure [role="img"] elements have alternative text
+* **1 × scope-attr-valid**:  Ensure the scope attribute is used correctly on tables
 * **1 × scrollable-region-focusable**:  Ensure elements that have scrollable content are accessible by keyboard
-* **1 × select-name**:  Ensures select element has an accessible name
-* **1 × server-side-image-map**:  Ensures that server-side image maps are not used
+* **1 × select-name**:  Ensure select element has an accessible name
+* **1 × server-side-image-map**:  Ensure that server-side image maps are not used
 * **1 × skip-link**:  Ensure all skip links have a focusable target
-* **1 × svg-img-alt**:  Ensures \<svg> elements with an img, graphics-document or graphics-symbol role have an accessible text
-* **1 × tabindex**:  Ensures tabindex attribute values are not greater than 0
+* **1 × summary-name**:  Ensure summary elements have discernible text
+* **1 × svg-img-alt**:  Ensure \<svg> elements with an img, graphics-document or graphics-symbol role have an accessible text
+* **1 × tabindex**:  Ensure tabindex attribute values are not greater than 0
 * **1 × table-duplicate-name**:  Ensure the \<caption> element does not contain the same text as the summary attribute
 * **1 × table-fake-caption**:  Ensure that tables with a caption use the \<caption> element.
-* **1 × target-size**:  Ensure touch target have sufficient size and space
+* **1 × target-size**:  Ensure touch targets have sufficient size and space
 * **1 × td-has-header**:  Ensure that each non-empty data cell in a \<table> larger than 3 by 3  has one or more table headers
 * **1 × td-headers-attr**:  Ensure that each cell in a table that uses the headers attribute refers only to other cells in that table
 * **1 × th-has-data-cells**:  Ensure that \<th> elements and elements with role=columnheader/rowheader have data cells they describe
-* **1 × valid-lang**:  Ensures lang attributes have valid values
-* **1 × video-caption**:  Ensures \<video> elements have captions
+* **1 × valid-lang**:  Ensure lang attributes have valid values
+* **1 × video-caption**:  Ensure \<video> elements have captions
 
 ---
 This scan used [axe-core axeVersion](https://github.com/dequelabs/axe-core/releases/tag/vaxeVersion) and userAgent with a display resolution of 1920x1080.

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,9 +61,9 @@ __metadata:
     "@types/serve-static": ^1.15.7
     "@typescript-eslint/eslint-plugin": ^6.18.1
     "@typescript-eslint/parser": ^6.18.1
-    accessibility-insights-report: 5.1.0
-    accessibility-insights-scan: ^3.0.1
-    axe-core: ^4.9.1
+    accessibility-insights-report: 6.0.0
+    accessibility-insights-scan: ^3.1.0
+    axe-core: ^4.10.2
     eslint: ^8.57.0
     eslint-plugin-security: ^1.7.1
     express: ^4.21.0
@@ -217,14 +217,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@axe-core/puppeteer@npm:4.9.1":
-  version: 4.9.1
-  resolution: "@axe-core/puppeteer@npm:4.9.1"
+"@axe-core/puppeteer@npm:4.10.1":
+  version: 4.10.1
+  resolution: "@axe-core/puppeteer@npm:4.10.1"
   dependencies:
-    axe-core: ~4.9.1
+    axe-core: ~4.10.2
   peerDependencies:
     puppeteer: ">=1.10.0"
-  checksum: 5da866a94a6d79d914a26768369e95919d1f3ac37b2f47e20297320f688d04ebf1ead56f96d907df9e9d74a3b0b973d680cbfa928332858e1275e49aa26c735c
+  checksum: d7f2f65978cac9082f03a9ca746b5775a398a4c894f824674ab0e1dc77a9f5c45e09fc26e141e2ca5344b5d45c3db1d803c5b086cca92fab7d52de70fa7fc7f5
   languageName: node
   linkType: hard
 
@@ -2498,32 +2498,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@crawlee/basic@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "@crawlee/basic@npm:3.5.0"
+"@crawlee/basic@npm:3.12.1":
+  version: 3.12.1
+  resolution: "@crawlee/basic@npm:3.12.1"
   dependencies:
     "@apify/log": ^2.4.0
     "@apify/timeout": ^0.3.0
     "@apify/utilities": ^2.7.10
-    "@crawlee/core": ^3.5.0
-    "@crawlee/types": ^3.5.0
-    "@crawlee/utils": ^3.5.0
-    got-scraping: ^3.2.9
+    "@crawlee/core": 3.12.1
+    "@crawlee/types": 3.12.1
+    "@crawlee/utils": 3.12.1
+    csv-stringify: ^6.2.0
+    fs-extra: ^11.0.0
+    got-scraping: ^4.0.0
     ow: ^0.28.1
     tldts: ^6.0.0
     tslib: ^2.4.0
     type-fest: ^4.0.0
-  checksum: d9510d1d7dda878a1e88408d768de43785117c49f4604755931a400702cf292e845146e607387c5b934ee38c3e5208c04cc06ab3fba5a18b42f2510bfb0dacba
+  checksum: d1eb3d25a141e18cedb6f3950a06309dc2de274619af3bb004ae03baa4f5366cc1e8b1140aa3eb4eba9d0675c886948a414dd5ed1a0c72024e4ff0450919fb9c
   languageName: node
   linkType: hard
 
-"@crawlee/browser-pool@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "@crawlee/browser-pool@npm:3.5.0"
+"@crawlee/browser-pool@npm:3.12.1, @crawlee/browser-pool@npm:^3.11.5":
+  version: 3.12.1
+  resolution: "@crawlee/browser-pool@npm:3.12.1"
   dependencies:
     "@apify/log": ^2.4.0
     "@apify/timeout": ^0.3.0
-    "@crawlee/types": ^3.5.0
+    "@crawlee/core": 3.12.1
+    "@crawlee/types": 3.12.1
     fingerprint-generator: ^2.0.6
     fingerprint-injector: ^2.0.5
     lodash.merge: ^4.6.2
@@ -2535,35 +2538,44 @@ __metadata:
     tiny-typed-emitter: ^2.1.0
     tslib: ^2.4.0
   peerDependencies:
-    playwright: <= 2.x
-    puppeteer: <= 20.x
+    playwright: "*"
+    puppeteer: "*"
   peerDependenciesMeta:
     playwright:
       optional: true
     puppeteer:
       optional: true
-  checksum: 6f12c63e09db8abc2aaf4d2849494c499f2cb32e92b55646d89ae6ab8d3369181445b70250e97a27834493750e0d2f9d2424a1004b8357413e6e8d5bc25f6fc8
+  checksum: 3edccf793bbf37c01fce688d0b9fc6937cf719c5a6f8d86f378ab23950e350008965d5e4f12e471033c1c4797fa06851e490ba01546eedcb79a21c9cba352f5a
   languageName: node
   linkType: hard
 
-"@crawlee/browser@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "@crawlee/browser@npm:3.5.0"
+"@crawlee/browser@npm:3.12.1":
+  version: 3.12.1
+  resolution: "@crawlee/browser@npm:3.12.1"
   dependencies:
     "@apify/timeout": ^0.3.0
-    "@crawlee/basic": ^3.5.0
-    "@crawlee/browser-pool": ^3.5.0
-    "@crawlee/types": ^3.5.0
-    "@crawlee/utils": ^3.5.0
+    "@crawlee/basic": 3.12.1
+    "@crawlee/browser-pool": 3.12.1
+    "@crawlee/types": 3.12.1
+    "@crawlee/utils": 3.12.1
     ow: ^0.28.1
     tslib: ^2.4.0
-  checksum: d30c923a99156789da3fb41366da8f5ecd797de243254843b0e5a31a893ad44c183f14be97fe68569f49e4100704462ac3b0308ce1a1e51982b568f3fa2b124e
+    type-fest: ^4.0.0
+  peerDependencies:
+    playwright: "*"
+    puppeteer: "*"
+  peerDependenciesMeta:
+    playwright:
+      optional: true
+    puppeteer:
+      optional: true
+  checksum: ea9fa838bb10d81f9cf8abc0fe6fe8a6a1a64989bff188f6744ded304fa99716dc9c1eba78f41363345d89c247f234126234145ba3e6bfe6e5f3406942d58abe
   languageName: node
   linkType: hard
 
-"@crawlee/core@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "@crawlee/core@npm:3.5.0"
+"@crawlee/core@npm:3.12.1":
+  version: 3.12.1
+  resolution: "@crawlee/core@npm:3.12.1"
   dependencies:
     "@apify/consts": ^2.20.0
     "@apify/datastructures": ^2.0.0
@@ -2571,33 +2583,32 @@ __metadata:
     "@apify/pseudo_url": ^2.0.30
     "@apify/timeout": ^0.3.0
     "@apify/utilities": ^2.7.10
-    "@crawlee/memory-storage": ^3.5.0
-    "@crawlee/types": ^3.5.0
-    "@crawlee/utils": ^3.5.0
-    "@sapphire/async-queue": ^1.5.0
-    "@types/tough-cookie": ^4.0.2
+    "@crawlee/memory-storage": 3.12.1
+    "@crawlee/types": 3.12.1
+    "@crawlee/utils": 3.12.1
+    "@sapphire/async-queue": ^1.5.1
     "@vladfrangu/async_event_emitter": ^2.2.2
     csv-stringify: ^6.2.0
     fs-extra: ^11.0.0
+    got-scraping: ^4.0.0
     json5: ^2.2.3
     minimatch: ^9.0.0
     ow: ^0.28.1
-    stream-chain: ^2.2.5
-    stream-json: ^1.7.4
+    stream-json: ^1.8.0
     tldts: ^6.0.0
-    tough-cookie: ^4.0.0
+    tough-cookie: ^5.0.0
     tslib: ^2.4.0
     type-fest: ^4.0.0
-  checksum: 3d4109dbe87c2dfe8962f4f796e38bd9108647770db805243596c63e8e0246c0898f98c7454dc1d27053cfe14747cc23ab91609316192dac5e8faa2823aaf9c7
+  checksum: cc4156147bd0927c731514a52f10a8716530096205537399a9f831cf5c03f49208d03bbdb2ec253c5726dc44ddb0fa67b142dba1290291b0e3e756498a674bd2
   languageName: node
   linkType: hard
 
-"@crawlee/memory-storage@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "@crawlee/memory-storage@npm:3.5.0"
+"@crawlee/memory-storage@npm:3.12.1":
+  version: 3.12.1
+  resolution: "@crawlee/memory-storage@npm:3.12.1"
   dependencies:
     "@apify/log": ^2.4.0
-    "@crawlee/types": ^3.5.0
+    "@crawlee/types": 3.12.1
     "@sapphire/async-queue": ^1.5.0
     "@sapphire/shapeshift": ^3.0.0
     content-type: ^1.0.4
@@ -2606,56 +2617,61 @@ __metadata:
     mime-types: ^2.1.35
     proper-lockfile: ^4.1.2
     tslib: ^2.4.0
-  checksum: 456e28fc1bc208d2cc6369675f349a341a331337c60396c102dcdea5a7e34b577032b22586acf758f89421f08e0d39cd50b371c30b68bc40252f074b4dcf18be
+  checksum: e2a14ad8131998160c9c84727217bbc9ff403be41c2ffb9bebe0c9e041d32e60981723eafe042cd8190d2ae62baf5df6d6b8d84abc864528261db33904cd3f91
   languageName: node
   linkType: hard
 
-"@crawlee/puppeteer@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "@crawlee/puppeteer@npm:3.5.0"
+"@crawlee/puppeteer@npm:^3.11.5":
+  version: 3.12.1
+  resolution: "@crawlee/puppeteer@npm:3.12.1"
   dependencies:
     "@apify/datastructures": ^2.0.0
     "@apify/log": ^2.4.0
-    "@crawlee/browser": ^3.5.0
-    "@crawlee/browser-pool": ^3.5.0
-    "@crawlee/types": ^3.5.0
-    "@crawlee/utils": ^3.5.0
-    cheerio: ^1.0.0-rc.12
+    "@crawlee/browser": 3.12.1
+    "@crawlee/browser-pool": 3.12.1
+    "@crawlee/types": 3.12.1
+    "@crawlee/utils": 3.12.1
+    cheerio: 1.0.0-rc.12
     devtools-protocol: "*"
     idcac-playwright: ^0.1.2
     jquery: ^3.6.0
     ow: ^0.28.1
     tslib: ^2.4.0
   peerDependencies:
-    puppeteer: <= 20.x
+    puppeteer: "*"
   peerDependenciesMeta:
     puppeteer:
       optional: true
-  checksum: e1694ba188b789569d5ab26592743d377c069f3b74d70c890c4d24ffce063dffd041517adffb69c36751f985d41da8b8c38f316e85bce9f33357affb41e7fed0
+  checksum: 99d300d30d189faf270971b55204ac13479f7af76b8aacac7d1f74fe490f517d87ab87640e6d929f4c7656d21321a109fb0494cfdab8d33899c04ee6578782e4
   languageName: node
   linkType: hard
 
-"@crawlee/types@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "@crawlee/types@npm:3.5.0"
+"@crawlee/types@npm:3.12.1":
+  version: 3.12.1
+  resolution: "@crawlee/types@npm:3.12.1"
   dependencies:
     tslib: ^2.4.0
-  checksum: 5b9d4b4e363973c0d303b782a8a17646dcd6991dd5c554f494b3a809a0b572c86275e4655338ce14e820c243c651a68eb44dd20d1aca950e89d55537531205ab
+  checksum: debe154dc1e9374ffff071e36f9d5a6e6d44023a43f92d7409ec0bc9e485269f779df5b19dd75bbd9011df2694aceb5d690b184b663f31cd8b334a0f2423c509
   languageName: node
   linkType: hard
 
-"@crawlee/utils@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "@crawlee/utils@npm:3.5.0"
+"@crawlee/utils@npm:3.12.1":
+  version: 3.12.1
+  resolution: "@crawlee/utils@npm:3.12.1"
   dependencies:
     "@apify/log": ^2.4.0
     "@apify/ps-tree": ^1.2.0
-    "@crawlee/types": ^3.5.0
-    cheerio: ^1.0.0-rc.12
-    got-scraping: ^3.2.9
+    "@crawlee/types": 3.12.1
+    "@types/sax": ^1.2.7
+    cheerio: 1.0.0-rc.12
+    file-type: ^19.0.0
+    got-scraping: ^4.0.3
     ow: ^0.28.1
+    robots-parser: ^3.0.1
+    sax: ^1.4.1
     tslib: ^2.4.0
-  checksum: f86b33e6332da47dff6a4d99d3bb868bbcd469b4f544f4ff0330f559c80338168224d9e5114a05051a2797d0ef4b9b6eb89af00c9675ca40395d04dc6dc0abe5
+    whatwg-mimetype: ^4.0.0
+  checksum: 065336518771b0e1753e3f23c2ae16b181c7abcb78e7eadf0adff08863d48d93aa26a4ebfa4cb7ef112b60094f17813369c57e596c61c0f7c66d798f268e8b6d
   languageName: node
   linkType: hard
 
@@ -3987,6 +4003,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/core@npm:1.30.1":
+  version: 1.30.1
+  resolution: "@opentelemetry/core@npm:1.30.1"
+  dependencies:
+    "@opentelemetry/semantic-conventions": 1.28.0
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: fe71452fffc6b5efe4bd1f0ab18b0424e744825f9a837f5bf08be80fe6d2c90c443743cb3d220cffad27b7d83dc38e0a7861c91ec965be156394e752c95e583c
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/exporter-metrics-otlp-grpc@npm:^0.41.0":
   version: 0.41.2
   resolution: "@opentelemetry/exporter-metrics-otlp-grpc@npm:0.41.2"
@@ -4099,6 +4126,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/resources@npm:1.30.1":
+  version: 1.30.1
+  resolution: "@opentelemetry/resources@npm:1.30.1"
+  dependencies:
+    "@opentelemetry/core": 1.30.1
+    "@opentelemetry/semantic-conventions": 1.28.0
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: a930d52fcdb18bda6d27a5d867493a6aa560fcad9f266af0c5d24c26069253b463f5cb9961577c3ebb1de752ae37ef4e1344009273504e19604ea7495a4028bd
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/sdk-logs@npm:0.41.2":
   version: 0.41.2
   resolution: "@opentelemetry/sdk-logs@npm:0.41.2"
@@ -4112,7 +4151,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/sdk-metrics@npm:1.15.2, @opentelemetry/sdk-metrics@npm:^1.15.0":
+"@opentelemetry/sdk-metrics@npm:1.15.2":
   version: 1.15.2
   resolution: "@opentelemetry/sdk-metrics@npm:1.15.2"
   dependencies:
@@ -4122,6 +4161,18 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.3.0 <1.5.0"
   checksum: 15eb40b977618ea24a7ce5bea264ab4c8a428d91c2ef0d824c9c98bea9fe3e136c92d03e5538ce86438e123f59977516112a657c4fc572e71ac544d483348b17
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-metrics@npm:^1.28.0":
+  version: 1.30.1
+  resolution: "@opentelemetry/sdk-metrics@npm:1.30.1"
+  dependencies:
+    "@opentelemetry/core": 1.30.1
+    "@opentelemetry/resources": 1.30.1
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: b74d16b1a0550e840fea4e7585162d3f3f817aef5e6991e86c1d1808c1e18ec32f6e32982756622671505c3d224976e1f6c11fb4b49d39f281fd7848b57277a0
   languageName: node
   linkType: hard
 
@@ -4162,6 +4213,13 @@ __metadata:
   version: 1.15.2
   resolution: "@opentelemetry/semantic-conventions@npm:1.15.2"
   checksum: 6de4f8ffa277af18351dff19b821f04438bd4f3917f84816f0bf1577a810424d11ba5f15dca9739a17812a996eeb251048fc7d61b0eef9dc39beb9d4304f57e2
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/semantic-conventions@npm:1.28.0":
+  version: 1.28.0
+  resolution: "@opentelemetry/semantic-conventions@npm:1.28.0"
+  checksum: 1d708afa654990236cdb6b5da84f7ab899b70bff9f753bc49d93616a5c7f7f339ba1eba6a9fbb57dee596995334f4e7effa57a4624741882ab5b3c419c3511e2
   languageName: node
   linkType: hard
 
@@ -4284,21 +4342,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@puppeteer/browsers@npm:2.2.3":
-  version: 2.2.3
-  resolution: "@puppeteer/browsers@npm:2.2.3"
+"@puppeteer/browsers@npm:2.6.1":
+  version: 2.6.1
+  resolution: "@puppeteer/browsers@npm:2.6.1"
   dependencies:
-    debug: 4.3.4
-    extract-zip: 2.0.1
-    progress: 2.0.3
-    proxy-agent: 6.4.0
-    semver: 7.6.0
-    tar-fs: 3.0.5
-    unbzip2-stream: 1.4.3
-    yargs: 17.7.2
+    debug: ^4.4.0
+    extract-zip: ^2.0.1
+    progress: ^2.0.3
+    proxy-agent: ^6.5.0
+    semver: ^7.6.3
+    tar-fs: ^3.0.6
+    unbzip2-stream: ^1.4.3
+    yargs: ^17.7.2
   bin:
     browsers: lib/cjs/main-cli.js
-  checksum: 44d496e2c4d717e472b40473fd916b1aa3b1a6024b9e4f571ca1521172ae38d090b5f331ccc6694593f41eb0b667865d72e4c9bc29d6a705a369ade53dacbd5c
+  checksum: e5952385a38f2595c29aa5bf4b67b506038ff5862f282aab1d82845bd814aba24b82029628bda5060d8f87f66e50c46a783d44bed2ba56eb819852652e7ab3ad
   languageName: node
   linkType: hard
 
@@ -4374,6 +4432,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sapphire/async-queue@npm:^1.5.1":
+  version: 1.5.5
+  resolution: "@sapphire/async-queue@npm:1.5.5"
+  checksum: 87218b46599728ce83f3829d246f939e6f5857aa002b55ac9c416864b9af16d242e09d069eaf96547596c5e7b042705038cbc9c5eebb07d490ba17271a688e67
+  languageName: node
+  linkType: hard
+
 "@sapphire/shapeshift@npm:^3.0.0, @sapphire/shapeshift@npm:^3.6.0":
   version: 3.9.2
   resolution: "@sapphire/shapeshift@npm:3.9.2"
@@ -4381,6 +4446,13 @@ __metadata:
     fast-deep-equal: ^3.1.3
     lodash: ^4.17.21
   checksum: 0d4572281a2a43dc444f56aef7462d16fdc49cdf0e625d521bfeae4b2219e35b53b7752b4e7396e402ce3b1a21c86afc4c3c82ce1547822a6e844116bb220760
+  languageName: node
+  linkType: hard
+
+"@sec-ant/readable-stream@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@sec-ant/readable-stream@npm:0.4.1"
+  checksum: eb56f72a70995f725269f1c1c206d6dbeb090e88413b1302a456c600041175a7a484c2f0172454f7bed65a8ab95ffed7647d8ad03e6c23b1e3bbc9845f78cd17
   languageName: node
   linkType: hard
 
@@ -4416,6 +4488,20 @@ __metadata:
   version: 4.6.0
   resolution: "@sindresorhus/is@npm:4.6.0"
   checksum: 83839f13da2c29d55c97abc3bc2c55b250d33a0447554997a85c539e058e57b8da092da396e252b11ec24a0279a0bed1f537fa26302209327060643e327f81d2
+  languageName: node
+  linkType: hard
+
+"@sindresorhus/is@npm:^5.3.0":
+  version: 5.6.0
+  resolution: "@sindresorhus/is@npm:5.6.0"
+  checksum: 2e6e0c3acf188dcd9aea0f324ac1b6ad04c9fc672392a7b5a1218512fcde066965797eba8b9fe2108657a504388bd4a6664e6e6602555168e828a6df08b9f10e
+  languageName: node
+  linkType: hard
+
+"@sindresorhus/is@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "@sindresorhus/is@npm:7.0.1"
+  checksum: 490b66ead3b368ab3a216c97fc339b17daed0a5f097a595eba39101a9bd76b6da59bacc0799a5e972b7d3b7aca871e61297eaede5d6fd00dc691ce85126a8f43
   languageName: node
   linkType: hard
 
@@ -4607,12 +4693,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@szmarczak/http-timer@npm:4.0.6, @szmarczak/http-timer@npm:^4.0.5":
+"@szmarczak/http-timer@npm:^4.0.5":
   version: 4.0.6
   resolution: "@szmarczak/http-timer@npm:4.0.6"
   dependencies:
     defer-to-connect: ^2.0.0
   checksum: c29df3bcec6fc3bdec2b17981d89d9c9fc9bd7d0c9bcfe92821dc533f4440bc890ccde79971838b4ceed1921d456973c4180d7175ee1d0023ad0562240a58d95
+  languageName: node
+  linkType: hard
+
+"@szmarczak/http-timer@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@szmarczak/http-timer@npm:5.0.1"
+  dependencies:
+    defer-to-connect: ^2.0.1
+  checksum: fc9cb993e808806692e4a3337c90ece0ec00c89f4b67e3652a356b89730da98bc824273a6d67ca84d5f33cd85f317dcd5ce39d8cc0a2f060145a608a7cb8ce92
+  languageName: node
+  linkType: hard
+
+"@tokenizer/token@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@tokenizer/token@npm:0.3.0"
+  checksum: 1d575d02d2a9f0c5a4ca5180635ebd2ad59e0f18b42a65f3d04844148b49b3db35cf00b6012a1af2d59c2ab3caca59451c5689f747ba8667ee586ad717ee58e1
   languageName: node
   linkType: hard
 
@@ -4726,7 +4828,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/cacheable-request@npm:^6.0.1, @types/cacheable-request@npm:^6.0.2":
+"@types/cacheable-request@npm:^6.0.1":
   version: 6.0.2
   resolution: "@types/cacheable-request@npm:6.0.2"
   dependencies:
@@ -4906,6 +5008,13 @@ __metadata:
   version: 4.0.1
   resolution: "@types/http-cache-semantics@npm:4.0.1"
   checksum: 1048aacf627829f0d5f00184e16548205cd9f964bf0841c29b36bc504509230c40bc57c39778703a1c965a6f5b416ae2cbf4c1d4589c889d2838dd9dbfccf6e9
+  languageName: node
+  linkType: hard
+
+"@types/http-cache-semantics@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@types/http-cache-semantics@npm:4.0.4"
+  checksum: 7f4dd832e618bc1e271be49717d7b4066d77c2d4eed5b81198eb987e532bb3e1c7e02f45d77918185bad936f884b700c10cebe06305f50400f382ab75055f9e8
   languageName: node
   linkType: hard
 
@@ -5197,6 +5306,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/sax@npm:^1.2.7":
+  version: 1.2.7
+  resolution: "@types/sax@npm:1.2.7"
+  dependencies:
+    "@types/node": "*"
+  checksum: 7ece5fbb5d9c8fc76ab0de2f99d705edf92f18e701d4f9d9b0647275e32eb65e656c1badf9dfaa12f4e1ff3e250561c8c9cfe79e8b5f33dd1417ac0f1804f6cc
+  languageName: node
+  linkType: hard
+
 "@types/semver@npm:^7.3.12":
   version: 7.5.8
   resolution: "@types/semver@npm:7.5.8"
@@ -5282,13 +5400,6 @@ __metadata:
   version: 2.0.0
   resolution: "@types/stack-utils@npm:2.0.0"
   checksum: b3fbae25b073116977ecb5c67d22f14567b51a7792403b0bf46e5de8f29bde3bd4ec1626afb22065495ca7f1c699c8bd66720050c94b8f8f9bcefbee79d161fd
-  languageName: node
-  linkType: hard
-
-"@types/tough-cookie@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@types/tough-cookie@npm:4.0.2"
-  checksum: e055556ffdaa39ad85ede0af192c93f93f986f4bd9e9426efdc2948e3e2632db3a4a584d4937dbf6d7620527419bc99e6182d3daf2b08685e710f2eda5291905
   languageName: node
   linkType: hard
 
@@ -6037,42 +6148,59 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"accessibility-insights-report@npm:5.1.0":
-  version: 5.1.0
-  resolution: "accessibility-insights-report@npm:5.1.0"
+"accessibility-insights-report@npm:5.2.0":
+  version: 5.2.0
+  resolution: "accessibility-insights-report@npm:5.2.0"
   dependencies:
     "@fluentui/react": ^8.118.1
-    axe-core: 4.9.1
+    axe-core: 4.10.2
     classnames: ^2.5.1
     lodash: ^4.17.21
-    luxon: ^3.4.4
+    luxon: ^3.5.0
     react: ^18.3.1
     react-dom: ^18.3.1
     react-helmet-async: ^2.0.5
     uuid: ^9.0.1
-  checksum: e6a2b4bf5741f7b9ce62176a9d5c2c3e2e1e38fb088f16231abb1ff1003fc2c31c6637ef5e16a0527179a5f7af34f7996f6569dde840355b362dfc910254122a
+  checksum: 94d1892e9b1941480775588e6555076e8c50d8589bfa23662e50fdf06a0d94d07abd3aa529ac4b6bfcb15cb3aeccd0dacd4fb5459611f3cb11e4f3bc0cb7de80
   languageName: node
   linkType: hard
 
-"accessibility-insights-scan@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "accessibility-insights-scan@npm:3.0.1"
+"accessibility-insights-report@npm:6.0.0":
+  version: 6.0.0
+  resolution: "accessibility-insights-report@npm:6.0.0"
+  dependencies:
+    "@fluentui/react": ^8.118.1
+    axe-core: 4.10.2
+    classnames: ^2.5.1
+    lodash: ^4.17.21
+    luxon: ^3.5.0
+    react: ^18.3.1
+    react-dom: ^18.3.1
+    react-helmet-async: ^2.0.5
+    uuid: ^9.0.1
+  checksum: 84596cd8613e8fafee96f5178beac9636400907baaaeb1d04aedfbb548fe6c38d1d213da76ef00f31fe14b5259f7e730c3256e6b72a36679fd029ccf50f80b21
+  languageName: node
+  linkType: hard
+
+"accessibility-insights-scan@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "accessibility-insights-scan@npm:3.1.0"
   dependencies:
     "@apify/log": 2.2.18
-    "@axe-core/puppeteer": 4.9.1
-    "@crawlee/browser-pool": ^3.5.0
-    "@crawlee/puppeteer": ^3.5.0
+    "@axe-core/puppeteer": 4.10.1
+    "@crawlee/browser-pool": ^3.11.5
+    "@crawlee/puppeteer": ^3.11.5
     "@medv/finder": ^2.1.0
     "@opentelemetry/api": ^1.4.1
     "@opentelemetry/exporter-metrics-otlp-grpc": ^0.41.0
     "@opentelemetry/resources": ^1.15.0
-    "@opentelemetry/sdk-metrics": ^1.15.0
+    "@opentelemetry/sdk-metrics": ^1.28.0
     "@opentelemetry/semantic-conventions": ^1.15.0
     "@sindresorhus/fnv1a": ^2.0.1
-    accessibility-insights-report: 5.1.0
-    ajv: ^8.12.0
+    accessibility-insights-report: 5.2.0
+    ajv: ^8.17.1
     applicationinsights: ^2.3.1
-    axe-core: 4.9.1
+    axe-core: 4.10.2
     convict: ^6.2.4
     dotenv: ^16.0.1
     encoding-down: ^7.1.0
@@ -6088,16 +6216,16 @@ __metadata:
     moment: ^2.29.4
     normalize-path: ^3.0.0
     normalize-url: 6.1.0
-    puppeteer: 22.12.1
+    puppeteer: ^23.9.0
     raw-body: ^2.5.1
-    reflect-metadata: ^0.1.13
+    reflect-metadata: ^0.2.2
     serialize-error: ^8.1.0
     sha.js: ^2.4.11
     uuid-with-v6: ^2.0.0
     yargs: ^17.6.2
   bin:
     ai-scan: dist/ai-scan-cli.js
-  checksum: 60e7285a012fefe2bc36728170b76621a100f66864f47ca210eadfcd42fa1de408290f6377d02da308f59b2c9bc48c347f5011f69313db805fa8695df84cbbd5
+  checksum: 5bc58afd57176a94dbd75fb338c228fcee1efa98a61726b3f6003d0ba46a5bcb7cd2b7f6da0b9e9231aca90d07d9e2fee79453526fa0591e86f42dc81e21c191
   languageName: node
   linkType: hard
 
@@ -6223,12 +6351,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:^7.0.2, agent-base@npm:^7.1.0":
+"agent-base@npm:^7.1.0":
   version: 7.1.0
   resolution: "agent-base@npm:7.1.0"
   dependencies:
     debug: ^4.3.4
   checksum: f7828f991470a0cc22cb579c86a18cbae83d8a3cbed39992ab34fc7217c4d126017f1c74d0ab66be87f71455318a8ea3e757d6a37881b8d0f2a2c6aa55e5418f
+  languageName: node
+  linkType: hard
+
+"agent-base@npm:^7.1.2":
+  version: 7.1.3
+  resolution: "agent-base@npm:7.1.3"
+  checksum: 87bb7ee54f5ecf0ccbfcba0b07473885c43ecd76cb29a8db17d6137a19d9f9cd443a2a7c5fd8a3f24d58ad8145f9eb49116344a66b107e1aeab82cf2383f4753
   languageName: node
   linkType: hard
 
@@ -6299,7 +6434,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.12.0, ajv@npm:^8.6.0, ajv@npm:^8.9.0":
+"ajv@npm:^8.0.0, ajv@npm:^8.6.0, ajv@npm:^8.9.0":
   version: 8.12.0
   resolution: "ajv@npm:8.12.0"
   dependencies:
@@ -6308,6 +6443,18 @@ __metadata:
     require-from-string: ^2.0.2
     uri-js: ^4.2.2
   checksum: 4dc13714e316e67537c8b31bc063f99a1d9d9a497eb4bbd55191ac0dcd5e4985bbb71570352ad6f1e76684fb6d790928f96ba3b2d4fd6e10024be9612fe3f001
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.17.1":
+  version: 8.17.1
+  resolution: "ajv@npm:8.17.1"
+  dependencies:
+    fast-deep-equal: ^3.1.3
+    fast-uri: ^3.0.1
+    json-schema-traverse: ^1.0.0
+    require-from-string: ^2.0.2
+  checksum: 1797bf242cfffbaf3b870d13565bd1716b73f214bb7ada9a497063aada210200da36e3ed40237285f3255acc4feeae91b1fb183625331bad27da95973f7253d9
   languageName: node
   linkType: hard
 
@@ -6817,10 +6964,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axe-core@npm:4.9.1, axe-core@npm:^4.9.1, axe-core@npm:~4.9.1":
-  version: 4.9.1
-  resolution: "axe-core@npm:4.9.1"
-  checksum: 41d9227871781f96c2952e2a777fca73624959dd0e98864f6d82806a77602f82b4fc490852082a7e524d8cd864e50d8b4d9931819b4a150112981d8c932110c5
+"axe-core@npm:4.10.2, axe-core@npm:^4.10.2, axe-core@npm:~4.10.2":
+  version: 4.10.2
+  resolution: "axe-core@npm:4.10.2"
+  checksum: 2b9b1c93ea73ea9f206604e4e17bd771d2d835f077bde54517d73028b8865c69b209460e73d5b109968cbdb39ab3d28943efa5695189bd79e16421ce1706719e
   languageName: node
   linkType: hard
 
@@ -7106,39 +7253,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-fs@npm:^2.1.1":
-  version: 2.3.0
-  resolution: "bare-fs@npm:2.3.0"
+"bare-fs@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "bare-fs@npm:4.0.1"
   dependencies:
     bare-events: ^2.0.0
-    bare-path: ^2.0.0
-    bare-stream: ^1.0.0
-  checksum: 0b2033551d30e51acbca64a885f76e0361cb1e783c410e10589206a9c6a4ac25ff5865aa67e6a5e412d3175694c7aff6ffe490c509f1cb38b329a855dc7471a5
+    bare-path: ^3.0.0
+    bare-stream: ^2.0.0
+  checksum: 80ae7ed1304182633252ce20f69d53bffd39e1a4f1387b309c2f2cf2a48732e8a5440405eb4a7250a3d8d1d2fb923a50bbb8aa67f85729c8a82e08dd09637a17
   languageName: node
   linkType: hard
 
-"bare-os@npm:^2.1.0":
-  version: 2.3.0
-  resolution: "bare-os@npm:2.3.0"
-  checksum: 873aa2d18c5dc4614b63f5a7eaf4ffdd1b5385c57167aa90895d6ba308c92c28e5f7e2cdc8474695df26b3320e72e3174f7b8d7202c46b46f47e016e2ade5185
+"bare-os@npm:^3.0.1":
+  version: 3.4.0
+  resolution: "bare-os@npm:3.4.0"
+  checksum: a473da6219f901b2101fac176ff271b28b9aee7e2d01b13b96320a56656c2f83a7d8275db89238ff46ed348638d86338761b6682684fbd0c4bb6b09201446047
   languageName: node
   linkType: hard
 
-"bare-path@npm:^2.0.0, bare-path@npm:^2.1.0":
-  version: 2.1.3
-  resolution: "bare-path@npm:2.1.3"
+"bare-path@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "bare-path@npm:3.0.0"
   dependencies:
-    bare-os: ^2.1.0
-  checksum: 20301aeb05b735852a396515464908e51e896922c3bb353ef2a09ff54e81ced94e6ad857bb0a36d2ce659c42bd43dd5c3d5643edd8faaf910ee9950c4e137b88
+    bare-os: ^3.0.1
+  checksum: 51d559515f332f62cf9c37c38f2640c1b84b5e8c9de454b70baf029f806058cf94c51d6a0dfec0025cc7760f2069dc3e16c82f0d24f4a9ddb18c829bf9c0206d
   languageName: node
   linkType: hard
 
-"bare-stream@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "bare-stream@npm:1.0.0"
+"bare-stream@npm:^2.0.0":
+  version: 2.6.4
+  resolution: "bare-stream@npm:2.6.4"
   dependencies:
-    streamx: ^2.16.1
-  checksum: 3bc1fab505e12628257e9e162e4194af26a5bb4a66adae142ad82570faf2a4b2a934deef7fd93b180cc6ba1bdf0b57068e79d3d635f14ab38cddd66827379919
+    streamx: ^2.21.0
+  peerDependencies:
+    bare-buffer: "*"
+    bare-events: "*"
+  peerDependenciesMeta:
+    bare-buffer:
+      optional: true
+    bare-events:
+      optional: true
+  checksum: 2f4ea23d7c3d603441b5942180ce997fb80b567713e4792ebd198b1fb3e8cd58ce947398c3d1e3f293cb6d191e7fb6550713842221edfe54d49175bad25f79e8
   languageName: node
   linkType: hard
 
@@ -7304,7 +7459,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.17.5, browserslist@npm:^4.19.1, browserslist@npm:^4.21.3":
+"browserslist@npm:^4.17.5, browserslist@npm:^4.21.3":
   version: 4.21.4
   resolution: "browserslist@npm:4.21.4"
   dependencies:
@@ -7490,10 +7645,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacheable-lookup@npm:^6.0.4":
-  version: 6.0.4
-  resolution: "cacheable-lookup@npm:6.0.4"
-  checksum: 7aea70f5ea081aed12bf54fc165b9f80b580b0d210c85d55cc8fed2beaa9027fd321c1939c65dad945fe9eb207cea45442e01a48b5aa57542e125b716f022b6d
+"cacheable-lookup@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "cacheable-lookup@npm:7.0.0"
+  checksum: 9e2856763fc0a7347ab34d704c010440b819d4bb5e3593b664381b7433e942dd22e67ee5581f12256f908e79b82d30b86ebbacf40a081bfe10ee93fbfbc2d6a9
+  languageName: node
+  linkType: hard
+
+"cacheable-request@npm:^12.0.1":
+  version: 12.0.1
+  resolution: "cacheable-request@npm:12.0.1"
+  dependencies:
+    "@types/http-cache-semantics": ^4.0.4
+    get-stream: ^9.0.1
+    http-cache-semantics: ^4.1.1
+    keyv: ^4.5.4
+    mimic-response: ^4.0.0
+    normalize-url: ^8.0.1
+    responselike: ^3.0.0
+  checksum: 893172f768c329522b3d4b10ae2270f6252249c4440eb3a6bc7b8a9851317e346dc3d6cfe0e268edb502b0b6ff13727a5255a17707f67b3542762906e472f612
   languageName: node
   linkType: hard
 
@@ -7539,6 +7709,13 @@ __metadata:
   version: 3.1.0
   resolution: "callsites@npm:3.1.0"
   checksum: 072d17b6abb459c2ba96598918b55868af677154bec7e73d222ef95a8fdb9bbf7dae96a8421085cdad8cd190d86653b5b6dc55a4484f2e5b2e27d5e0c3fc15b3
+  languageName: node
+  linkType: hard
+
+"callsites@npm:^4.0.0":
+  version: 4.2.0
+  resolution: "callsites@npm:4.2.0"
+  checksum: 9a740675712076a38208967d7f80b525c9c7f4524c2af5d3936c5e278a601af0423a07e91f79679fec0546f3a52514d56969c6fe65f84d794e64a36b1f5eda8a
   languageName: node
   linkType: hard
 
@@ -7716,7 +7893,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cheerio@npm:^1.0.0-rc.12":
+"cheerio@npm:1.0.0-rc.12":
   version: 1.0.0-rc.12
   resolution: "cheerio@npm:1.0.0-rc.12"
   dependencies:
@@ -7790,16 +7967,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromium-bidi@npm:0.5.24":
-  version: 0.5.24
-  resolution: "chromium-bidi@npm:0.5.24"
+"chromium-bidi@npm:0.11.0":
+  version: 0.11.0
+  resolution: "chromium-bidi@npm:0.11.0"
   dependencies:
     mitt: 3.0.1
-    urlpattern-polyfill: 10.0.0
     zod: 3.23.8
   peerDependencies:
     devtools-protocol: "*"
-  checksum: 26c283e3740201c880eb7dbbf0854ffe53ce6c4890e0f1039ddf703b7a68cfea9d5d30e8069b93b95333d852c4028ec6b365f13759dd9763ad1399aae8d47a16
+  checksum: b4c41392a72cf792bec8b16b25c4d144eb52a85b0b1d3b3445a661f52b83e50621e1bf0c0b822432461f4c066b698c18e5a8dda4bd53d9c02950f7be0912f87f
   languageName: node
   linkType: hard
 
@@ -8852,6 +9028,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "debug@npm:4.4.0"
+  dependencies:
+    ms: ^2.1.3
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: fb42df878dd0e22816fc56e1fdca9da73caa85212fbe40c868b1295a6878f9101ae684f4eeef516c13acfc700f5ea07f1136954f43d4cd2d477a811144136479
+  languageName: node
+  linkType: hard
+
 "decamelize-keys@npm:^1.1.0":
   version: 1.1.0
   resolution: "decamelize-keys@npm:1.1.0"
@@ -8941,7 +9129,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"defer-to-connect@npm:^2.0.0":
+"defer-to-connect@npm:^2.0.0, defer-to-connect@npm:^2.0.1":
   version: 2.0.1
   resolution: "defer-to-connect@npm:2.0.1"
   checksum: 8a9b50d2f25446c0bfefb55a48e90afd58f85b21bcf78e9207cd7b804354f6409032a1705c2491686e202e64fc05f147aa5aa45f9aa82627563f045937f5791b
@@ -9090,10 +9278,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"devtools-protocol@npm:0.0.1299070":
-  version: 0.0.1299070
-  resolution: "devtools-protocol@npm:0.0.1299070"
-  checksum: 5b03189a83a64f6a02675062ae83d40257098d334bda0abb940310b21008f2e3279105208cf25649253a1e6165062d32a4f46d934d0adcb48b5cff6954db799c
+"devtools-protocol@npm:0.0.1367902":
+  version: 0.0.1367902
+  resolution: "devtools-protocol@npm:0.0.1367902"
+  checksum: ef1115f4b287ab033c5342f7ba7fbf45314c3b46db2195978db0096b368ffbb79157a69dc361fa539874a37fea87101267049957285b1ecbaa1a96f6df6cf344
   languageName: node
   linkType: hard
 
@@ -9334,6 +9522,15 @@ __metadata:
   dependencies:
     is-obj: ^2.0.0
   checksum: 0f47600a4b93e1dc37261da4e6909652c008832a5d3684b5bf9a9a0d3f4c67ea949a86dceed9b72f5733ed8e8e6383cc5958df3bbd0799ee317fd181f2ece700
+  languageName: node
+  linkType: hard
+
+"dot-prop@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "dot-prop@npm:7.2.0"
+  dependencies:
+    type-fest: ^2.11.2
+  checksum: 08e4ff14f7305ffb5fda7e4c88f3cdbeb3cd97bd27efa4f47503869a2ee7f96938b4c21b0a2abf9c37d891a1bdb3994a09d219b0dcfd6130da4eaeb44c6f067e
   languageName: node
   linkType: hard
 
@@ -10425,7 +10622,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extract-zip@npm:2.0.1":
+"extract-zip@npm:2.0.1, extract-zip@npm:^2.0.1":
   version: 2.0.1
   resolution: "extract-zip@npm:2.0.1"
   dependencies:
@@ -10460,6 +10657,13 @@ __metadata:
   version: 1.3.0
   resolution: "fast-fifo@npm:1.3.0"
   checksum: edc589b818eede61d0048f399daf67cbc5ef736588669482a20f37269b4808356e54ab89676fd8fa59b26c216c11e5ac57335cc70dca54fbbf692d4acde10de6
+  languageName: node
+  linkType: hard
+
+"fast-fifo@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "fast-fifo@npm:1.3.2"
+  checksum: 6bfcba3e4df5af7be3332703b69a7898a8ed7020837ec4395bb341bd96cc3a6d86c3f6071dd98da289618cf2234c70d84b2a6f09a33dd6f988b1ff60d8e54275
   languageName: node
   linkType: hard
 
@@ -10514,6 +10718,13 @@ __metadata:
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 92cfec0a8dfafd9c7a15fba8f2cc29cd0b62b85f056d99ce448bbcd9f708e18ab2764bda4dd5158364f4145a7c72788538994f0d1787b956ef0d1062b0f7c24c
+  languageName: node
+  linkType: hard
+
+"fast-uri@npm:^3.0.1":
+  version: 3.0.5
+  resolution: "fast-uri@npm:3.0.5"
+  checksum: b56cda8e7355bad9adcc3c2eacd94cb592eaa9536497a4779a9527784f4f95a3755f30525c63583bd85807c493b396ac89926c970f19a60905ed875121ca78fd
   languageName: node
   linkType: hard
 
@@ -10587,6 +10798,18 @@ __metadata:
   peerDependencies:
     webpack: ^4.0.0 || ^5.0.0
   checksum: faf43eecf233f4897b0150aaa874eeeac214e4f9de49738a9e0ef734a30b5260059e85b7edadf852b98e415f875bd5f12587768a93fd52aaf2e479ecf95fab20
+  languageName: node
+  linkType: hard
+
+"file-type@npm:^19.0.0":
+  version: 19.6.0
+  resolution: "file-type@npm:19.6.0"
+  dependencies:
+    get-stream: ^9.0.1
+    strtok3: ^9.0.1
+    token-types: ^6.0.0
+    uint8array-extras: ^1.3.0
+  checksum: f9f130bd5432e8c8fd9c663f87eecad0226b2ae3deda87247be22fed3abe9f931368dbbf526a5b6bdacef883a8a83c25e150a80723fecaa3752f6daae0d5312b
   languageName: node
   linkType: hard
 
@@ -10848,10 +11071,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data-encoder@npm:1.7.1":
-  version: 1.7.1
-  resolution: "form-data-encoder@npm:1.7.1"
-  checksum: a2a360d5588a70d323c12a140c3db23a503a38f0a5d141af1efad579dde9f9fff2e49e5f31f378cb4631518c1ab4a826452c92f0d2869e954b6b2d77b05613e1
+"form-data-encoder@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "form-data-encoder@npm:4.0.2"
+  checksum: 12769f21af2d750c20111f8a626560eaf613c2c62769d5924d9e5a44ba4ef52406f973844129151efd35533eb79ecf8e0b95b0839560e335204d2212efb9a9ef
   languageName: node
   linkType: hard
 
@@ -11055,15 +11278,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"generative-bayesian-network@npm:0.1.0-beta.1":
-  version: 0.1.0-beta.1
-  resolution: "generative-bayesian-network@npm:0.1.0-beta.1"
-  dependencies:
-    ow: ^0.23.0
-  checksum: ee773ed88affcbeec7c0f7198214a1db7e6a10f963ab7f0f9b7dcaf78fe14db6f8a04db8dfb6bffae2547017bf08be635fb2cfdabf4ae9ebf3e49a827630f2b9
-  languageName: node
-  linkType: hard
-
 "generative-bayesian-network@npm:^2.1.38":
   version: 2.1.38
   resolution: "generative-bayesian-network@npm:2.1.38"
@@ -11071,6 +11285,16 @@ __metadata:
     adm-zip: ^0.5.9
     tslib: ^2.4.0
   checksum: 50a017a86a9c5626d91d4afd12ad8ec13021e77ae054d29160ac36f31b875942df2308e5f9bf54714d94e0fe823dac6079a4c290bad396411762f64a053280a5
+  languageName: node
+  linkType: hard
+
+"generative-bayesian-network@npm:^2.1.62":
+  version: 2.1.62
+  resolution: "generative-bayesian-network@npm:2.1.62"
+  dependencies:
+    adm-zip: ^0.5.9
+    tslib: ^2.4.0
+  checksum: 9e251e1c6779e660ee34c8d41a10dbd4561b3b95afebe0da4540b6b28ecc9574c3adb4c2f9d02c67821a0da0019fe2b3e37e3c9d207e9cbcfb0732a2e5b7255f
   languageName: node
   linkType: hard
 
@@ -11156,10 +11380,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^6.0.0, get-stream@npm:^6.0.1":
+"get-stream@npm:^6.0.0":
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: e04ecece32c92eebf5b8c940f51468cd53554dcbb0ea725b2748be583c9523d00128137966afce410b9b051eb2ef16d657cd2b120ca8edafcf5a65e81af63cad
+  languageName: node
+  linkType: hard
+
+"get-stream@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "get-stream@npm:9.0.1"
+  dependencies:
+    "@sec-ant/readable-stream": ^0.4.1
+    is-stream: ^4.0.1
+  checksum: 631df71d7bd60a7f373094d3c352e2ce412b82d30b1b0ec562e5a4aced976173a4cc0dabef019050e1aceaffb1f0e086349ab3d14377b0b7280510bd75bd3e1e
   languageName: node
   linkType: hard
 
@@ -11387,39 +11621,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"got-cjs@npm:12.0.1":
-  version: 12.0.1
-  resolution: "got-cjs@npm:12.0.1"
+"got-scraping@npm:^4.0.0, got-scraping@npm:^4.0.3":
+  version: 4.0.8
+  resolution: "got-scraping@npm:4.0.8"
   dependencies:
-    "@sindresorhus/is": ^4.2.0
-    "@szmarczak/http-timer": 4.0.6
-    "@types/cacheable-request": ^6.0.2
-    "@types/responselike": ^1.0.0
-    cacheable-lookup: ^6.0.4
-    cacheable-request: ^7.0.2
-    decompress-response: ^6.0.0
-    form-data-encoder: 1.7.1
-    get-stream: ^6.0.1
-    http2-wrapper: ^2.1.9
-    lowercase-keys: 2.0.0
-    p-cancelable: 2.1.1
-    responselike: ^2.0.0
-  checksum: c27c71bf5e995f29dda9293cf7459ef8e06106515410cebb98c2c9ff775b5be709e43e169c91faae05bd25a551ceb6e20cd1e4e1106d0dccba949926adb78f46
-  languageName: node
-  linkType: hard
-
-"got-scraping@npm:^3.2.9":
-  version: 3.2.9
-  resolution: "got-scraping@npm:3.2.9"
-  dependencies:
-    got-cjs: 12.0.1
-    header-generator: 2.0.0-beta.10
-    http2-wrapper: ^2.1.4
-    mimic-response: ^3.1.0
-    ow: ^0.23.0
-    quick-lru: ^5.1.1
-    tslib: ^2.3.1
-  checksum: e92263cb19e27d3d900e7282147c587d659a15dc1fd699b7947f362efe86d3adc0ae3ed251cfc2224aa707c499f61c8098d8e4244de57406f0a2c9667f08a5cf
+    got: ^14.2.1
+    header-generator: ^2.1.41
+    http2-wrapper: ^2.2.0
+    mimic-response: ^4.0.0
+    ow: ^1.1.1
+    quick-lru: ^7.0.0
+    tslib: ^2.6.2
+  checksum: cafdacd8ed60011fbf3f4d75e5d136bf073f22351d98b32e82c5499b7ae83ef693d52051979d19721f437b21e853249eea6a805b2683b0aca8f1493432e70683
   languageName: node
   linkType: hard
 
@@ -11439,6 +11652,25 @@ __metadata:
     p-cancelable: ^2.0.0
     responselike: ^2.0.0
   checksum: 2de8a1bbda4e9b6b2b72b2d2100bc055a59adc1740529e631f61feb44a8b9a1f9f8590941ed9da9df0090b6d6d0ed8ffee94cd9ac086ec3409b392b33440f7d2
+  languageName: node
+  linkType: hard
+
+"got@npm:^14.2.1":
+  version: 14.4.5
+  resolution: "got@npm:14.4.5"
+  dependencies:
+    "@sindresorhus/is": ^7.0.1
+    "@szmarczak/http-timer": ^5.0.1
+    cacheable-lookup: ^7.0.0
+    cacheable-request: ^12.0.1
+    decompress-response: ^6.0.0
+    form-data-encoder: ^4.0.2
+    http2-wrapper: ^2.2.1
+    lowercase-keys: ^3.0.0
+    p-cancelable: ^4.0.1
+    responselike: ^3.0.0
+    type-fest: ^4.26.1
+  checksum: 873f20d9d7c0a432d2361abc9ed706a747bdba0299a70349895dcb988f9bc0b03ef276a2b96f25c81b90d6352496835fa2aeb8692541b9dd21c25919b48b0692
   languageName: node
   linkType: hard
 
@@ -11594,18 +11826,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"header-generator@npm:2.0.0-beta.10":
-  version: 2.0.0-beta.10
-  resolution: "header-generator@npm:2.0.0-beta.10"
-  dependencies:
-    browserslist: ^4.19.1
-    generative-bayesian-network: 0.1.0-beta.1
-    ow: ^0.23.0
-    tslib: ^2.3.1
-  checksum: 63ef9d7a820cde9d1944e0ada1ec8e289f05f213bc80680b3969908a07c9e18c32925df7903796ccab87aa285a912e1defa21e7e4400361a5f6415d01bbaef59
-  languageName: node
-  linkType: hard
-
 "header-generator@npm:^2.1.38":
   version: 2.1.38
   resolution: "header-generator@npm:2.1.38"
@@ -11615,6 +11835,18 @@ __metadata:
     ow: ^0.28.1
     tslib: ^2.4.0
   checksum: 8ab4b238e3f58ecec514a45a3646294cb15c5d4335b8c33db83db2170511fa9c0d5b389b5083023fc4d0926c9309a5aa432acc0a56e9cbc48e36d34599a80a80
+  languageName: node
+  linkType: hard
+
+"header-generator@npm:^2.1.41":
+  version: 2.1.62
+  resolution: "header-generator@npm:2.1.62"
+  dependencies:
+    browserslist: ^4.21.1
+    generative-bayesian-network: ^2.1.62
+    ow: ^0.28.1
+    tslib: ^2.4.0
+  checksum: 33bffed8ea09a97693cc0f80a5ea6302b34be2a12ed22e0880e45d8f0682113746b1c5384712382daad7932e64160161a15b44229847b7772a4b24a99aa99f52
   languageName: node
   linkType: hard
 
@@ -11897,13 +12129,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http2-wrapper@npm:^2.1.4, http2-wrapper@npm:^2.1.9":
-  version: 2.1.11
-  resolution: "http2-wrapper@npm:2.1.11"
+"http2-wrapper@npm:^2.2.0, http2-wrapper@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "http2-wrapper@npm:2.2.1"
   dependencies:
     quick-lru: ^5.1.1
     resolve-alpn: ^1.2.0
-  checksum: 5da05aa2c77226ac9cc82c616383f59c8f31b79897b02ecbe44b09714be1fca1f21bb184e672a669ca2830eefea4edac5f07e71c00cb5a8c5afec8e5a20cfaf7
+  checksum: e95e55e22c6fd61182ce81fecb9b7da3af680d479febe8ad870d05f7ebbc9f076e455193766f4e7934e50913bf1d8da3ba121fb5cd2928892390b58cf9d5c509
   languageName: node
   linkType: hard
 
@@ -11927,23 +12159,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^7.0.2":
-  version: 7.0.2
-  resolution: "https-proxy-agent@npm:7.0.2"
+"https-proxy-agent@npm:^7.0.6":
+  version: 7.0.6
+  resolution: "https-proxy-agent@npm:7.0.6"
   dependencies:
-    agent-base: ^7.0.2
+    agent-base: ^7.1.2
     debug: 4
-  checksum: 088969a0dd476ea7a0ed0a2cf1283013682b08f874c3bc6696c83fa061d2c157d29ef0ad3eb70a2046010bb7665573b2388d10fdcb3e410a66995e5248444292
-  languageName: node
-  linkType: hard
-
-"https-proxy-agent@npm:^7.0.3":
-  version: 7.0.4
-  resolution: "https-proxy-agent@npm:7.0.4"
-  dependencies:
-    agent-base: ^7.0.2
-    debug: 4
-  checksum: daaab857a967a2519ddc724f91edbbd388d766ff141b9025b629f92b9408fc83cee8a27e11a907aede392938e9c398e240d643e178408a59e4073539cde8cfe9
+  checksum: b882377a120aa0544846172e5db021fa8afbf83fea2a897d397bd2ddd8095ab268c24bc462f40a15f2a8c600bf4aa05ce52927f70038d4014e68aefecfa94e8d
   languageName: node
   linkType: hard
 
@@ -12580,6 +12802,13 @@ __metadata:
   version: 2.0.0
   resolution: "is-stream@npm:2.0.0"
   checksum: 4dc47738e26bc4f1b3be9070b6b9e39631144f204fc6f87db56961220add87c10a999ba26cf81699f9ef9610426f69cb08a4713feff8deb7d8cadac907826935
+  languageName: node
+  linkType: hard
+
+"is-stream@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "is-stream@npm:4.0.1"
+  checksum: cbea3f1fc271b21ceb228819d0c12a0965a02b57f39423925f99530b4eb86935235f258f06310b67cd02b2d10b49e9a0998f5ececf110ab7d3760bae4055ad23
   languageName: node
   linkType: hard
 
@@ -14230,6 +14459,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"keyv@npm:^4.5.4":
+  version: 4.5.4
+  resolution: "keyv@npm:4.5.4"
+  dependencies:
+    json-buffer: 3.0.1
+  checksum: 74a24395b1c34bd44ad5cb2b49140d087553e170625240b86755a6604cd65aa16efdbdeae5cdb17ba1284a0fbb25ad06263755dbc71b8d8b06f74232ce3cdd72
+  languageName: node
+  linkType: hard
+
 "kind-of@npm:^6.0.2, kind-of@npm:^6.0.3":
   version: 6.0.3
   resolution: "kind-of@npm:6.0.3"
@@ -14588,10 +14826,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lowercase-keys@npm:2.0.0, lowercase-keys@npm:^2.0.0":
+"lowercase-keys@npm:^2.0.0":
   version: 2.0.0
   resolution: "lowercase-keys@npm:2.0.0"
   checksum: 24d7ebd56ccdf15ff529ca9e08863f3c54b0b9d1edb97a3ae1af34940ae666c01a1e6d200707bce730a8ef76cb57cc10e65f245ecaaf7e6bc8639f2fb460ac23
+  languageName: node
+  linkType: hard
+
+"lowercase-keys@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "lowercase-keys@npm:3.0.0"
+  checksum: 67a3f81409af969bc0c4ca0e76cd7d16adb1e25aa1c197229587eaf8671275c8c067cd421795dbca4c81be0098e4c426a086a05e30de8a9c587b7a13c0c7ccc5
   languageName: node
   linkType: hard
 
@@ -14644,10 +14889,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"luxon@npm:^3.4.4":
-  version: 3.4.4
-  resolution: "luxon@npm:3.4.4"
-  checksum: 36c1f99c4796ee4bfddf7dc94fa87815add43ebc44c8934c924946260a58512f0fd2743a629302885df7f35ccbd2d13f178c15df046d0e3b6eb71db178f1c60c
+"luxon@npm:^3.5.0":
+  version: 3.5.0
+  resolution: "luxon@npm:3.5.0"
+  checksum: f290fe5788c8e51e748744f05092160d4be12150dca70f9fadc0d233e53d60ce86acd82e7d909a114730a136a77e56f0d3ebac6141bbb82fd310969a4704825b
   languageName: node
   linkType: hard
 
@@ -14911,6 +15156,13 @@ __metadata:
   version: 3.1.0
   resolution: "mimic-response@npm:3.1.0"
   checksum: 25739fee32c17f433626bf19f016df9036b75b3d84a3046c7d156e72ec963dd29d7fc8a302f55a3d6c5a4ff24259676b15d915aad6480815a969ff2ec0836867
+  languageName: node
+  linkType: hard
+
+"mimic-response@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "mimic-response@npm:4.0.0"
+  checksum: 33b804cc961efe206efdb1fca6a22540decdcfce6c14eb5c0c50e5ae9022267ab22ce8f5568b1f7247ba67500fe20d523d81e0e9f009b321ccd9d472e78d1850
   languageName: node
   linkType: hard
 
@@ -15190,7 +15442,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:2.1.3, ms@npm:^2.0.0, ms@npm:^2.1.1":
+"ms@npm:2.1.3, ms@npm:^2.0.0, ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
@@ -15506,6 +15758,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"normalize-url@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "normalize-url@npm:8.0.1"
+  checksum: 43ea9ef0d6d135dd1556ab67aa4b74820f0d9d15aa504b59fa35647c729f1147dfce48d3ad504998fd1010f089cfb82c86c6d9126eb5c5bd2e9bd25f3a97749b
+  languageName: node
+  linkType: hard
+
 "npm-run-all@npm:^4.1.5":
   version: 4.1.5
   resolution: "npm-run-all@npm:4.1.5"
@@ -15813,20 +16072,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ow@npm:^0.23.0":
-  version: 0.23.1
-  resolution: "ow@npm:0.23.1"
-  dependencies:
-    "@sindresorhus/is": ^4.0.0
-    callsites: ^3.1.0
-    dot-prop: ^6.0.1
-    lodash.isequal: ^4.5.0
-    type-fest: ^1.2.0
-    vali-date: ^1.0.0
-  checksum: 01c8b83541ce8c1eb9b8166933ed966203053189b1a54bc87d6ab65911e34ecd8ad16db098cd0f3ffc39e0888463f302dc1809e5d9bec394c5e049be00326089
-  languageName: node
-  linkType: hard
-
 "ow@npm:^0.28.1":
   version: 0.28.1
   resolution: "ow@npm:0.28.1"
@@ -15841,10 +16086,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-cancelable@npm:2.1.1, p-cancelable@npm:^2.0.0":
+"ow@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "ow@npm:1.1.1"
+  dependencies:
+    "@sindresorhus/is": ^5.3.0
+    callsites: ^4.0.0
+    dot-prop: ^7.2.0
+    lodash.isequal: ^4.5.0
+    vali-date: ^1.0.0
+  checksum: 475ece4268af8cb3558ecd3f5b64bf35c91a705515be4854404b0f75871b5aee711973d9a24d973c1b2eef5d5ee6a87735cfb0da8a57ba7ddfaa362a832a09ee
+  languageName: node
+  linkType: hard
+
+"p-cancelable@npm:^2.0.0":
   version: 2.1.1
   resolution: "p-cancelable@npm:2.1.1"
   checksum: 3dba12b4fb4a1e3e34524535c7858fc82381bbbd0f247cc32dedc4018592a3950ce66b106d0880b4ec4c2d8d6576f98ca885dc1d7d0f274d1370be20e9523ddf
+  languageName: node
+  linkType: hard
+
+"p-cancelable@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "p-cancelable@npm:4.0.1"
+  checksum: 7c01982aceb717915ffdc59fda8c2f1cb9b2563eced7fab527e0b574ddd6a23a764e3462f40ed5d6bf475d5bd5d497cc021e1926da060a4dc4d30d748261be13
   languageName: node
   linkType: hard
 
@@ -15926,19 +16191,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pac-proxy-agent@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "pac-proxy-agent@npm:7.0.1"
+"pac-proxy-agent@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "pac-proxy-agent@npm:7.1.0"
   dependencies:
     "@tootallnate/quickjs-emscripten": ^0.23.0
-    agent-base: ^7.0.2
+    agent-base: ^7.1.2
     debug: ^4.3.4
     get-uri: ^6.0.1
     http-proxy-agent: ^7.0.0
-    https-proxy-agent: ^7.0.2
-    pac-resolver: ^7.0.0
-    socks-proxy-agent: ^8.0.2
-  checksum: 3d4aa48ec1c19db10158ecc1c4c9a9f77792294412d225ceb3dfa45d5a06950dca9755e2db0d9b69f12769119bea0adf2b24390d9c73c8d81df75e28245ae451
+    https-proxy-agent: ^7.0.6
+    pac-resolver: ^7.0.1
+    socks-proxy-agent: ^8.0.5
+  checksum: 0ed8ebca239b5c78f7c5039ec0e33aaf6ce8de2fb53d00996b5b7b362e655af9793721008ddf56c4b1d30fb5202b2cb5baee97e374ed1285c0cfb5be7c4574a5
   languageName: node
   linkType: hard
 
@@ -16142,6 +16407,13 @@ __metadata:
   dependencies:
     through: ~2.3
   checksum: 3c4a14052a638b92e0c96eb00c0d7977df7f79ea28395250c525d197f1fc02d34ce1165d5362e2e6ebbb251524b94a76f3f0d4abc39ab8b016d97449fe15583c
+  languageName: node
+  linkType: hard
+
+"peek-readable@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "peek-readable@npm:5.3.1"
+  checksum: 5db122ce37b79f89f34181e4d8326e3f4f5e8d797707fb9aa2f3a1a6fb87cdb9a5b23677cdb3f4687f8ccff0000ce4c0ebb8e5cad64f49997ff29c38ee6d0bc8
   languageName: node
   linkType: hard
 
@@ -17199,7 +17471,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"progress@npm:2.0.3":
+"progress@npm:^2.0.3":
   version: 2.0.3
   resolution: "progress@npm:2.0.3"
   checksum: f67403fe7b34912148d9252cb7481266a354bd99ce82c835f79070643bb3c6583d10dbcfda4d41e04bbc1d8437e9af0fb1e1f2135727878f5308682a579429b7
@@ -17348,19 +17620,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-agent@npm:6.4.0":
-  version: 6.4.0
-  resolution: "proxy-agent@npm:6.4.0"
+"proxy-agent@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "proxy-agent@npm:6.5.0"
   dependencies:
-    agent-base: ^7.0.2
+    agent-base: ^7.1.2
     debug: ^4.3.4
     http-proxy-agent: ^7.0.1
-    https-proxy-agent: ^7.0.3
+    https-proxy-agent: ^7.0.6
     lru-cache: ^7.14.1
-    pac-proxy-agent: ^7.0.1
+    pac-proxy-agent: ^7.1.0
     proxy-from-env: ^1.1.0
-    socks-proxy-agent: ^8.0.2
-  checksum: 4d3794ad5e07486298902f0a7f250d0f869fa0e92d790767ca3f793a81374ce0ab6c605f8ab8e791c4d754da96656b48d1c24cb7094bfd310a15867e4a0841d7
+    socks-proxy-agent: ^8.0.5
+  checksum: d03ad2d171c2768280ade7ea6a7c5b1d0746215d70c0a16e02780c26e1d347edd27b3f48374661ae54ec0f7b41e6e45175b687baf333b36b1fd109a525154806
   languageName: node
   linkType: hard
 
@@ -17443,30 +17715,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"puppeteer-core@npm:22.12.1":
-  version: 22.12.1
-  resolution: "puppeteer-core@npm:22.12.1"
+"puppeteer-core@npm:23.11.1":
+  version: 23.11.1
+  resolution: "puppeteer-core@npm:23.11.1"
   dependencies:
-    "@puppeteer/browsers": 2.2.3
-    chromium-bidi: 0.5.24
-    debug: ^4.3.5
-    devtools-protocol: 0.0.1299070
-    ws: ^8.17.1
-  checksum: 22678bba55cfc84aad3994ed653e1bc7ded0b0b933db15dae93415fe7cc6a188561ec7ddcd7bc36fc7c86f4e261cd742328a8d323b0e5ac74f9db8a73baa7d13
+    "@puppeteer/browsers": 2.6.1
+    chromium-bidi: 0.11.0
+    debug: ^4.4.0
+    devtools-protocol: 0.0.1367902
+    typed-query-selector: ^2.12.0
+    ws: ^8.18.0
+  checksum: f4573b87d8c963b11695fbda14ec05042c3f0b0979f561730d44c5bfc69cdd9fadc75319d2b49c3ce804f3c7d917d63edd9d0c5d2873a29c26ce59ba8624302b
   languageName: node
   linkType: hard
 
-"puppeteer@npm:22.12.1":
-  version: 22.12.1
-  resolution: "puppeteer@npm:22.12.1"
+"puppeteer@npm:^23.9.0":
+  version: 23.11.1
+  resolution: "puppeteer@npm:23.11.1"
   dependencies:
-    "@puppeteer/browsers": 2.2.3
+    "@puppeteer/browsers": 2.6.1
+    chromium-bidi: 0.11.0
     cosmiconfig: ^9.0.0
-    devtools-protocol: 0.0.1299070
-    puppeteer-core: 22.12.1
+    devtools-protocol: 0.0.1367902
+    puppeteer-core: 23.11.1
+    typed-query-selector: ^2.12.0
   bin:
-    puppeteer: lib/esm/puppeteer/node/cli.js
-  checksum: 07e899d987857c00c7124f282007c413c79a2e98068a5d44dbd85dbcf869602e4a5528603349750007b108e36bb9e4af4442621279083e3030eeec093ef34b87
+    puppeteer: lib/cjs/puppeteer/node/cli.js
+  checksum: 5844c1deef77e0fa578950eff680f521ecb3509923ea9e63a17309c0d4235a1cf326e6fb280ab7b3b47d95296e4a74c6e680278c8bf8a793f0ecdbc288efdae2
   languageName: node
   linkType: hard
 
@@ -17527,6 +17802,13 @@ __metadata:
   version: 5.1.1
   resolution: "quick-lru@npm:5.1.1"
   checksum: a516faa25574be7947969883e6068dbe4aa19e8ef8e8e0fd96cddd6d36485e9106d85c0041a27153286b0770b381328f4072aa40d3b18a19f5f7d2b78b94b5ed
+  languageName: node
+  linkType: hard
+
+"quick-lru@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "quick-lru@npm:7.0.0"
+  checksum: a178af41f7a912efee41f01bd9d6a3f8a62729e68d3d14f236aaf2512dced7a587f6a2c65ea3bfd241f127721508e6dda6a65176c46f498046afde790ea4ef08
   languageName: node
   linkType: hard
 
@@ -17954,13 +18236,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reflect-metadata@npm:^0.1.13":
-  version: 0.1.13
-  resolution: "reflect-metadata@npm:0.1.13"
-  checksum: 798d379a7b6f6455501145419505c97dd11cbc23857a386add2b9ef15963ccf15a48d9d15507afe01d4cd74116df8a213247200bac00320bd7c11ddeaa5e8fb4
-  languageName: node
-  linkType: hard
-
 "reflect-metadata@npm:^0.2.2":
   version: 0.2.2
   resolution: "reflect-metadata@npm:0.2.2"
@@ -18320,6 +18595,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"responselike@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "responselike@npm:3.0.0"
+  dependencies:
+    lowercase-keys: ^3.0.0
+  checksum: e0cc9be30df4f415d6d83cdede3c5c887cd4a73e7cc1708bcaab1d50a28d15acb68460ac5b02bcc55a42f3d493729c8856427dcf6e57e6e128ad05cba4cfb95e
+  languageName: node
+  linkType: hard
+
 "retry@npm:^0.12.0":
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
@@ -18367,6 +18651,13 @@ __metadata:
   bin:
     rimraf: dist/esm/bin.mjs
   checksum: d66eef829b2e23b16445f34e73d75c7b7cf4cbc8834b04720def1c8f298eb0753c3d76df77325fad79d0a2c60470525d95f89c2475283ad985fd7441c32732d1
+  languageName: node
+  linkType: hard
+
+"robots-parser@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "robots-parser@npm:3.0.1"
+  checksum: fa85e44937da98da053cea78ab97d46a434a9efcac67045f8608ffc57dfff9f8cfb1e06224738c5d0a0aca32a3f9941a357ec561f39465edfc8b54548ef16f22
   languageName: node
   linkType: hard
 
@@ -18508,6 +18799,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sax@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "sax@npm:1.4.1"
+  checksum: 3ad64df16b743f0f2eb7c38ced9692a6d924f1cd07bbe45c39576c2cf50de8290d9d04e7b2228f924c7d05fecc4ec5cf651423278e0c7b63d260c387ef3af84a
+  languageName: node
+  linkType: hard
+
 "saxes@npm:^5.0.1":
   version: 5.0.1
   resolution: "saxes@npm:5.0.1"
@@ -18608,17 +18906,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.6.0, semver@npm:^7.3.2, semver@npm:^7.3.7":
-  version: 7.6.0
-  resolution: "semver@npm:7.6.0"
-  dependencies:
-    lru-cache: ^6.0.0
-  bin:
-    semver: bin/semver.js
-  checksum: 7427f05b70786c696640edc29fdd4bc33b2acf3bbe1740b955029044f80575fc664e1a512e4113c3af21e767154a94b4aa214bf6cd6e42a1f6dba5914e0b208c
-  languageName: node
-  linkType: hard
-
 "semver@npm:^6.0.0, semver@npm:^6.3.0":
   version: 6.3.0
   resolution: "semver@npm:6.3.0"
@@ -18634,6 +18921,17 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: ae47d06de28836adb9d3e25f22a92943477371292d9b665fb023fae278d345d508ca1958232af086d85e0155aee22e313e100971898bbb8d5d89b8b1d4054ca2
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.3.2, semver@npm:^7.3.7":
+  version: 7.6.0
+  resolution: "semver@npm:7.6.0"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 7427f05b70786c696640edc29fdd4bc33b2acf3bbe1740b955029044f80575fc664e1a512e4113c3af21e767154a94b4aa214bf6cd6e42a1f6dba5914e0b208c
   languageName: node
   linkType: hard
 
@@ -19005,14 +19303,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:^8.0.2":
-  version: 8.0.2
-  resolution: "socks-proxy-agent@npm:8.0.2"
+"socks-proxy-agent@npm:^8.0.5":
+  version: 8.0.5
+  resolution: "socks-proxy-agent@npm:8.0.5"
   dependencies:
-    agent-base: ^7.0.2
+    agent-base: ^7.1.2
     debug: ^4.3.4
-    socks: ^2.7.1
-  checksum: 4fb165df08f1f380881dcd887b3cdfdc1aba3797c76c1e9f51d29048be6e494c5b06d68e7aea2e23df4572428f27a3ec22b3d7c75c570c5346507433899a4b6d
+    socks: ^2.8.3
+  checksum: b4fbcdb7ad2d6eec445926e255a1fb95c975db0020543fbac8dfa6c47aecc6b3b619b7fb9c60a3f82c9b2969912a5e7e174a056ae4d98cb5322f3524d6036e1d
   languageName: node
   linkType: hard
 
@@ -19288,12 +19586,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stream-json@npm:^1.7.4":
-  version: 1.7.4
-  resolution: "stream-json@npm:1.7.4"
+"stream-json@npm:^1.8.0":
+  version: 1.9.1
+  resolution: "stream-json@npm:1.9.1"
   dependencies:
     stream-chain: ^2.2.5
-  checksum: 50aca250cedde7b35fcc12b3f4936d28431f351392f25f1baa7898b618d363368f8049af07c486ce7c47ee19ea15fd31642df0819e62e514c6193f1e2b05d85e
+  checksum: 2ebf0648f9ed82ee79727a9a47805231a70d5032e0c21cee3e05cd3c449d3ce49c72b371555447eeef55904bae22ac64be8ae6086fc6cce0b83b3aa617736b64
   languageName: node
   linkType: hard
 
@@ -19307,17 +19605,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"streamx@npm:^2.16.1":
-  version: 2.17.0
-  resolution: "streamx@npm:2.17.0"
+"streamx@npm:^2.21.0":
+  version: 2.21.1
+  resolution: "streamx@npm:2.21.1"
   dependencies:
     bare-events: ^2.2.0
-    fast-fifo: ^1.1.0
+    fast-fifo: ^1.3.2
     queue-tick: ^1.0.1
+    text-decoder: ^1.1.0
   dependenciesMeta:
     bare-events:
       optional: true
-  checksum: 69289e04c6534bbd819bf8c97dc3907a6398013035cdbfeca5b58e86530bf859c214f1045d2a4cf0a96b3f1c6d3bfab9cdace8bc610803ade1bfe7257455cbf9
+  checksum: 98abdd0a926b172be6f2b306cdda3d8689a4da51e478518aa187d321ceca31ebfcbfff222c55ef4140fdc2a5c14da5db9da19fdfd7a08bcdcb0c1c6e6df96f22
   languageName: node
   linkType: hard
 
@@ -19589,6 +19888,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strtok3@npm:^9.0.1":
+  version: 9.1.1
+  resolution: "strtok3@npm:9.1.1"
+  dependencies:
+    "@tokenizer/token": ^0.3.0
+    peek-readable: ^5.3.1
+  checksum: 6af257b04edb3f59b0e537830a43c0b8d64354247a0de9f5980e98883722b17d9f6ae073d4b2742a0af0ab3357e40ce7131aa582e8bbe494aa73025298a8a405
+  languageName: node
+  linkType: hard
+
 "stubs@npm:^3.0.0":
   version: 3.0.0
   resolution: "stubs@npm:3.0.0"
@@ -19802,12 +20111,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-fs@npm:3.0.5":
-  version: 3.0.5
-  resolution: "tar-fs@npm:3.0.5"
+"tar-fs@npm:^3.0.6":
+  version: 3.0.8
+  resolution: "tar-fs@npm:3.0.8"
   dependencies:
-    bare-fs: ^2.1.1
-    bare-path: ^2.1.0
+    bare-fs: ^4.0.1
+    bare-path: ^3.0.0
     pump: ^3.0.0
     tar-stream: ^3.1.5
   dependenciesMeta:
@@ -19815,7 +20124,7 @@ __metadata:
       optional: true
     bare-path:
       optional: true
-  checksum: e31c7e3e525fec0afecdec1cac58071809e396187725f2eba442f08a4c5649c8cd6b7ce25982f9a91bb0f055628df47c08177dd2ea4f5dafd3c22f42f8da8f00
+  checksum: 5bebadd68e7a10cc3aa9c30b579c295e158cef7b1f42a73ee1bb1992925027aa8ef6cbcdb0d03e202e7f3850799391de30adf2585f7f240b606faa65df1a6b68
   languageName: node
   linkType: hard
 
@@ -19972,6 +20281,15 @@ __metadata:
     glob: ^7.1.4
     minimatch: ^3.0.4
   checksum: 3b34a3d77165a2cb82b34014b3aba93b1c4637a5011807557dc2f3da826c59975a5ccad765721c4648b39817e3472789f9b0fa98fc854c5c1c7a1e632aacdc28
+  languageName: node
+  linkType: hard
+
+"text-decoder@npm:^1.1.0":
+  version: 1.2.3
+  resolution: "text-decoder@npm:1.2.3"
+  dependencies:
+    b4a: ^1.6.4
+  checksum: d7642a61f9d72330eac52ff6b6e8d34dea03ebbb1e82749a8734e7892e246cf262ed70730d20c4351c5dc5334297b9cc6c0b6a8725a204a63a197d7728bb35e5
   languageName: node
   linkType: hard
 
@@ -20144,6 +20462,16 @@ __metadata:
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 952c29e2a85d7123239b5cfdd889a0dde47ab0497f0913d70588f19c53f7e0b5327c95f4651e413c74b785147f9637b17410ac8c846d5d4a20a5a33eb6dc3a45
+  languageName: node
+  linkType: hard
+
+"token-types@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "token-types@npm:6.0.0"
+  dependencies:
+    "@tokenizer/token": ^0.3.0
+    ieee754: ^1.2.1
+  checksum: 9d4fb5fad76bb968687a03aaae37f7eb606cca54c35b840ec438bbbc9b696ad0fbbd72760248b4eed16cbb3c87ab61590c287fc6bd973583944626b7c772f47b
   languageName: node
   linkType: hard
 
@@ -20350,6 +20678,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.6.2":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: e4aba30e632b8c8902b47587fd13345e2827fa639e7c3121074d5ee0880723282411a8838f830b55100cbe4517672f84a2472667d355b81e8af165a55dc6203a
+  languageName: node
+  linkType: hard
+
 "tsutils@npm:^3.21.0":
   version: 3.21.0
   resolution: "tsutils@npm:3.21.0"
@@ -20414,10 +20749,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^1.0.1, type-fest@npm:^1.2.0, type-fest@npm:^1.2.1, type-fest@npm:^1.2.2":
+"type-fest@npm:^1.0.1, type-fest@npm:^1.2.1, type-fest@npm:^1.2.2":
   version: 1.4.0
   resolution: "type-fest@npm:1.4.0"
   checksum: b011c3388665b097ae6a109a437a04d6f61d81b7357f74cbcb02246f2f5bd72b888ae33631b99871388122ba0a87f4ff1c94078e7119ff22c70e52c0ff828201
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^2.11.2":
+  version: 2.19.0
+  resolution: "type-fest@npm:2.19.0"
+  checksum: a4ef07ece297c9fba78fc1bd6d85dff4472fe043ede98bd4710d2615d15776902b595abf62bd78339ed6278f021235fb28a96361f8be86ed754f778973a0d278
   languageName: node
   linkType: hard
 
@@ -20439,6 +20781,13 @@ __metadata:
   version: 4.2.0
   resolution: "type-fest@npm:4.2.0"
   checksum: 76c5dfde9293b1b185b266a07df669f68d58ae3e19c06e33f0ff0dd0ba68628f05389bc26bcee8476e29a79ab7da054653670b9778399ceb079c4c259bac29f0
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^4.26.1":
+  version: 4.32.0
+  resolution: "type-fest@npm:4.32.0"
+  checksum: 0010e2fbe040e46f9d3a76a97e8917e5f0c9a5d7883529a3916fac5c2d2638429864b7dfc083d2c7883894e3c8cee026f91d0301c64fa74c1c0c2dafb488e3c6
   languageName: node
   linkType: hard
 
@@ -20504,6 +20853,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typed-query-selector@npm:^2.12.0":
+  version: 2.12.0
+  resolution: "typed-query-selector@npm:2.12.0"
+  checksum: c4652f2eec16112d69e0da30c2effab3f03d1710f9559da1e1209bbfc9a20990d5de4ba97890c11f9d17d85c8ae3310953a86c198166599d4c36abc63664f169
+  languageName: node
+  linkType: hard
+
 "typed-rest-client@npm:^1.8.4":
   version: 1.8.6
   resolution: "typed-rest-client@npm:1.8.6"
@@ -20555,6 +20911,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uint8array-extras@npm:^1.3.0":
+  version: 1.4.0
+  resolution: "uint8array-extras@npm:1.4.0"
+  checksum: 791c07e1f632cb6b4d5c0275dcac2efa4689be523f021cc78b66377872e500dbe5b4c56749367cc97892f6952bc5bccd34cf9147a2a16ccb253f3b7f94588398
+  languageName: node
+  linkType: hard
+
 "unbox-primitive@npm:^1.0.1":
   version: 1.0.1
   resolution: "unbox-primitive@npm:1.0.1"
@@ -20579,7 +20942,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unbzip2-stream@npm:1.4.3":
+"unbzip2-stream@npm:1.4.3, unbzip2-stream@npm:^1.4.3":
   version: 1.4.3
   resolution: "unbzip2-stream@npm:1.4.3"
   dependencies:
@@ -20784,13 +21147,6 @@ __metadata:
   dependencies:
     fast-url-parser: ^1.1.3
   checksum: bc09df2474da59f95c8577746322bfb0f219c3a084722b427a916906ea7dab538fdbaf6a5582f64f617e9405fb1c9cc437ce40ec73abdddf26d7771a3d2f088b
-  languageName: node
-  linkType: hard
-
-"urlpattern-polyfill@npm:10.0.0":
-  version: 10.0.0
-  resolution: "urlpattern-polyfill@npm:10.0.0"
-  checksum: 61d890f151ea4ecf34a3dcab32c65ad1f3cda857c9d154af198260c6e5b2ad96d024593409baaa6d4428dd1ab206c14799bf37fe011117ac93a6a44913ac5aa4
   languageName: node
   linkType: hard
 
@@ -21288,6 +21644,13 @@ __metadata:
   version: 2.3.0
   resolution: "whatwg-mimetype@npm:2.3.0"
   checksum: 23eb885940bcbcca4ff841c40a78e9cbb893ec42743993a42bf7aed16085b048b44b06f3402018931687153550f9a32d259dfa524e4f03577ab898b6965e5383
+  languageName: node
+  linkType: hard
+
+"whatwg-mimetype@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "whatwg-mimetype@npm:4.0.0"
+  checksum: f97edd4b4ee7e46a379f3fb0e745de29fe8b839307cc774300fd49059fcdd560d38cb8fe21eae5575b8f39b022f23477cc66e40b0355c2851ce84760339cef30
   languageName: node
   linkType: hard
 
@@ -21849,21 +22212,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:17.7.2, yargs@npm:^17.7.2":
-  version: 17.7.2
-  resolution: "yargs@npm:17.7.2"
-  dependencies:
-    cliui: ^8.0.1
-    escalade: ^3.1.1
-    get-caller-file: ^2.0.5
-    require-directory: ^2.1.1
-    string-width: ^4.2.3
-    y18n: ^5.0.5
-    yargs-parser: ^21.1.1
-  checksum: 73b572e863aa4a8cbef323dd911d79d193b772defd5a51aab0aca2d446655216f5002c42c5306033968193bdbf892a7a4c110b0d77954a7fdf563e653967b56a
-  languageName: node
-  linkType: hard
-
 "yargs@npm:^13.3.0":
   version: 13.3.2
   resolution: "yargs@npm:13.3.2"
@@ -21909,6 +22257,21 @@ __metadata:
     y18n: ^5.0.5
     yargs-parser: ^21.1.1
   checksum: 47da1b0d854fa16d45a3ded57b716b013b2179022352a5f7467409da5a04a1eef5b3b3d97a2dfc13e8bbe5f2ffc0afe3bc6a4a72f8254e60f5a4bd7947138643
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.7.2":
+  version: 17.7.2
+  resolution: "yargs@npm:17.7.2"
+  dependencies:
+    cliui: ^8.0.1
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.3
+    y18n: ^5.0.5
+    yargs-parser: ^21.1.1
+  checksum: 73b572e863aa4a8cbef323dd911d79d193b772defd5a51aab0aca2d446655216f5002c42c5306033968193bdbf892a7a4c110b0d77954a7fdf563e653967b56a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Axe core version upgrade to 4.10.2 for Accessibility Insights for Action
Along with axe-core version upgrade, upgraded other packages with latest Node and axe core versions.

accessibility-insights-report
accessibility-insights-scan

#### Details

Updated report package dependency
Updated scan package dependency

The test cases have snapshot with decreased passed rules because deprecated duplicate-id-active rule is removed. Please refer PR https://github.com/microsoft/accessibility-insights-service/pull/2589 for more details


##### Motivation

https://dev.azure.com/mseng/1ES/_workitems/edit/2244203

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
