### PR TITLE
fix: renamed downloadPath parameter to targetPath

### DIFF
--- a/pipelines/release-template.yaml
+++ b/pipelines/release-template.yaml
@@ -55,7 +55,7 @@ jobs:
                 buildType: 'current'
                 downloadType: 'single'
                 artifactName: '${{ parameters.environment }}-vsix'
-                downloadPath: '$(System.DefaultWorkingDirectory)/${{ parameters.environment }}-vsix'
+                targetPath: '$(System.DefaultWorkingDirectory)/${{ parameters.environment }}-vsix'
       environment: ${{ parameters.environment }}
       strategy:
           runOnce:


### PR DESCRIPTION
#### Details

DownloadPipelineArtifact@2 task has parameter name targetPath and alias downloadPath but 1ES template specifically works with targetPath so renamed the parameter so that it can be consumed by 1ES template.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
