### PR TITLE
fix: update ESRP sign-in task to use PME managed identity

### DIFF
--- a/pipelines/package-vsix-file.yaml
+++ b/pipelines/package-vsix-file.yaml
@@ -82,8 +82,10 @@ steps:
       displayName: 'ESRP: Sign VSIX file '
       inputs:
           ConnectedServiceName: 'a11y-insights-esrp-code-signing-mi'
+          UseMSIAuthentication: true
           AppRegistrationClientId: $(esrp-app-registration-client-id)
           AppRegistrationTenantId: $(esrp-app-registration-tenant-id)
+          EsrpClientId: $(esrp-client-id)
           AuthAKVName: 'a11y-insights-esrp-certs'
           AuthCertName: 'a11y-insights-action-esrp-auth-cert'
           AuthSignCertName: 'a11y-insights-action-esrp-cert'

--- a/pipelines/release-template.yaml
+++ b/pipelines/release-template.yaml
@@ -44,24 +44,24 @@ jobs:
                 shouldSign: ${{ parameters.shouldSign }}
                 visibility: ${{parameters.visibility}}
 
-    # - deployment: publish_vsix_file
-    #   displayName: deploy vsix file
-    #   dependsOn: package_job
-    #   templateContext:
-    #       type: releaseJob
-    #       isProduction: ${{ parameters.isProduction }}
-    #       inputs:
-    #           - input: pipelineArtifact
-    #             buildType: 'current'
-    #             downloadType: 'single'
-    #             artifactName: '${{ parameters.environment }}-vsix'
-    #             targetPath: '$(System.DefaultWorkingDirectory)/${{ parameters.environment }}-vsix'
-    #   environment: ${{ parameters.environment }}
-    #   strategy:
-    #       runOnce:
-    #           deploy:
-    #               steps:
-    #                   - template: publish-vsix-file.yaml@self
-    #                     parameters:
-    #                         environment: ${{ parameters.environment }}
-    #                         visibility: ${{parameters.visibility}}
+    - deployment: publish_vsix_file
+      displayName: deploy vsix file
+      dependsOn: package_job
+      templateContext:
+          type: releaseJob
+          isProduction: ${{ parameters.isProduction }}
+          inputs:
+              - input: pipelineArtifact
+                buildType: 'current'
+                downloadType: 'single'
+                artifactName: '${{ parameters.environment }}-vsix'
+                targetPath: '$(System.DefaultWorkingDirectory)/${{ parameters.environment }}-vsix'
+      environment: ${{ parameters.environment }}
+      strategy:
+          runOnce:
+              deploy:
+                  steps:
+                      - template: publish-vsix-file.yaml@self
+                        parameters:
+                            environment: ${{ parameters.environment }}
+                            visibility: ${{parameters.visibility}}

--- a/pipelines/release-template.yaml
+++ b/pipelines/release-template.yaml
@@ -44,24 +44,24 @@ jobs:
                 shouldSign: ${{ parameters.shouldSign }}
                 visibility: ${{parameters.visibility}}
 
-    - deployment: publish_vsix_file
-      displayName: deploy vsix file
-      dependsOn: package_job
-      templateContext:
-          type: releaseJob
-          isProduction: ${{ parameters.isProduction }}
-          inputs:
-              - input: pipelineArtifact
-                buildType: 'current'
-                downloadType: 'single'
-                artifactName: '${{ parameters.environment }}-vsix'
-                targetPath: '$(System.DefaultWorkingDirectory)/${{ parameters.environment }}-vsix'
-      environment: ${{ parameters.environment }}
-      strategy:
-          runOnce:
-              deploy:
-                  steps:
-                      - template: publish-vsix-file.yaml@self
-                        parameters:
-                            environment: ${{ parameters.environment }}
-                            visibility: ${{parameters.visibility}}
+    # - deployment: publish_vsix_file
+    #   displayName: deploy vsix file
+    #   dependsOn: package_job
+    #   templateContext:
+    #       type: releaseJob
+    #       isProduction: ${{ parameters.isProduction }}
+    #       inputs:
+    #           - input: pipelineArtifact
+    #             buildType: 'current'
+    #             downloadType: 'single'
+    #             artifactName: '${{ parameters.environment }}-vsix'
+    #             targetPath: '$(System.DefaultWorkingDirectory)/${{ parameters.environment }}-vsix'
+    #   environment: ${{ parameters.environment }}
+    #   strategy:
+    #       runOnce:
+    #           deploy:
+    #               steps:
+    #                   - template: publish-vsix-file.yaml@self
+    #                     parameters:
+    #                         environment: ${{ parameters.environment }}
+    #                         visibility: ${{parameters.visibility}}


### PR DESCRIPTION
#### Details

This PR is to migrated ESRP code sign-in task to use PME tenant managed identity from corp tenant app ID. The changes are made following the TSG [Integrating ESRP ADO Task into your build pipeline during Corp Migration](https://eng.ms/docs/microsoft-security/identity/trust-and-security-services/tss-high-security-environments/tss-esrp-fabric-and-platform-services/esrp-documentation/tsgs/sfi/tsg502-integrating-esrp-ado-task-into-your-build-pipeline-during-corp-migration).
Successful run of the pipeline with managed identity: [20250421.1](https://dev.azure.com/mseng/1ES/_build/results?buildId=29864324&view=logs&j=10f84eb7-256f-5ab6-3ea7-b7bd1acd1bff&t=cfda1591-f138-5aeb-4e19-bc6fa393545a)

Logs Screnshots:

![image](https://github.com/user-attachments/assets/ea6b333e-5618-4e21-99bd-cafcb90aa03b)

##### Motivation

Security Improvement

##### Context

Below variables in the pipelines need to be updated with PME values
`esrp-app-registration-client-id` :  Managed identity id from PME tenant
`esrp-app-registration-tenant-id`:  Tenant that holds the Managed Identity
 `esrp-client-id` : A new parameter is added in the pipelines for CORP App Registration ClientID that was already onboarded in ESRP Portal.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
