### PR TITLE
Mutiple CG issue fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
         "@azure/msal-browser": "^4.30.0",
         "protobufjs": "^7.5.5",
         "keyv": "^5.6.0",
-        "basic-ftp": "^5.3.1",
-        "accessibility-insights-report": "^7.5.0"
+        "basic-ftp": "^5.3.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,6 @@
         "@azure/msal-browser": "^4.30.0",
         "protobufjs": "^7.5.5",
         "keyv": "^5.6.0",
-        "basic-ftp": "^5.3.0"
+        "basic-ftp": "^5.3.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "ansi-regex@^4.1.0": "^5.0.1",
         "cosmiconfig@^7.0.1": "^8.1.3",
         "pac-resolver": "^7.0.1",
-        "socks": "^2.8.3",
+        "socks": "^2.8.9",
         "ws": "^8.17.1",
         "path-to-regexp": "^1.9.0",
         "express": "^4.22.0",
@@ -104,6 +104,7 @@
         "file-type@^20.5.0": "21.3.2",
         "@azure/msal-browser": "^4.30.0",
         "protobufjs": "^7.5.5",
-        "keyv": "^5.6.0"
+        "keyv": "^5.6.0",
+        "basic-ftp": "^5.3.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
         "@azure/msal-browser": "^4.30.0",
         "protobufjs": "^7.5.5",
         "keyv": "^5.6.0",
-        "basic-ftp": "^5.3.1"
+        "basic-ftp": "^5.3.1",
+        "accessibility-insights-report": "^7.5.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8391,7 +8391,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"basic-ftp@npm:^5.3.0":
+"basic-ftp@npm:^5.3.1":
   version: 5.3.1
   resolution: "basic-ftp@npm:5.3.1"
   checksum: a3b5ffbedb070f89636aaaa5f639b2b275cab3486f8e216902bd60529e51047b42c732059dc94869581e2f585937a76d183a09fc519b1ce909155c137a502953

--- a/yarn.lock
+++ b/yarn.lock
@@ -7185,37 +7185,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"accessibility-insights-report@npm:6.0.0":
-  version: 6.0.0
-  resolution: "accessibility-insights-report@npm:6.0.0"
+"accessibility-insights-report@npm:^7.5.0":
+  version: 7.5.0
+  resolution: "accessibility-insights-report@npm:7.5.0"
   dependencies:
     "@fluentui/react": ^8.118.1
-    axe-core: 4.10.2
+    axe-core: 4.11.3
     classnames: ^2.5.1
-    lodash: ^4.17.21
+    lodash: ^4.18.0
     luxon: ^3.5.0
     react: ^18.3.1
     react-dom: ^18.3.1
     react-helmet-async: ^2.0.5
-    uuid: ^9.0.1
-  checksum: 84596cd8613e8fafee96f5178beac9636400907baaaeb1d04aedfbb548fe6c38d1d213da76ef00f31fe14b5259f7e730c3256e6b72a36679fd029ccf50f80b21
-  languageName: node
-  linkType: hard
-
-"accessibility-insights-report@npm:7.0.0":
-  version: 7.0.0
-  resolution: "accessibility-insights-report@npm:7.0.0"
-  dependencies:
-    "@fluentui/react": ^8.118.1
-    axe-core: 4.10.2
-    classnames: ^2.5.1
-    lodash: ^4.17.21
-    luxon: ^3.5.0
-    react: ^18.3.1
-    react-dom: ^18.3.1
-    react-helmet-async: ^2.0.5
-    uuid: ^9.0.1
-  checksum: f9f056fae2588287ba520e4ba359927352405013348c454936f449b551712fb448e28087e4a59aea26450630fc57b41f72ad57f5fbbd5215ffed8a7ba7195a8a
+    uuid: ^14.0.0
+  checksum: 564f531cf53d74818d6e272869eae1579c3fe7a607b00af4c6db5c1f7a670860f48268b2ed1e0dedfac38d9b94141f17247de303cf5041e662f78dc6d4f051d8
   languageName: node
   linkType: hard
 
@@ -8039,6 +8022,13 @@ __metadata:
   version: 4.10.2
   resolution: "axe-core@npm:4.10.2"
   checksum: 2b9b1c93ea73ea9f206604e4e17bd771d2d835f077bde54517d73028b8865c69b209460e73d5b109968cbdb39ab3d28943efa5695189bd79e16421ce1706719e
+  languageName: node
+  linkType: hard
+
+"axe-core@npm:4.11.3":
+  version: 4.11.3
+  resolution: "axe-core@npm:4.11.3"
+  checksum: b01fc82cd0e809db09166a90bbb8942a978eefab5ba1ebab8faebd94969e0bd36df9848e4e510520cd08cde9800a6d14888ebbca380dfc4594db48e9b494d399
   languageName: node
   linkType: hard
 
@@ -22926,21 +22916,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "uuid@npm:14.0.0"
+  bin:
+    uuid: dist-node/bin/uuid
+  checksum: 08608584a79e987cdae000fa8eb724fa51dd8aafc136cd9fa9a8c87d07b246c56eec5fd9027fdb3e49a863eedf758bc19e325909ce281955c7a027fed67dc89e
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^3.0.1":
   version: 3.4.0
   resolution: "uuid@npm:3.4.0"
   bin:
     uuid: ./bin/uuid
   checksum: 58de2feed61c59060b40f8203c0e4ed7fd6f99d42534a499f1741218a1dd0c129f4aa1de797bcf822c8ea5da7e4137aa3673431a96dae729047f7aca7b27866f
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "uuid@npm:9.0.1"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8391,10 +8391,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"basic-ftp@npm:^5.0.2":
-  version: 5.3.0
-  resolution: "basic-ftp@npm:5.3.0"
-  checksum: b2c93d98541c805171813bddd7e6349b7fc304ba8896acf60b0b4393253204cff88aa2a31adbaec2f1a58f78e90005672c30796042a2c717a69ccae10160d72d
+"basic-ftp@npm:^5.3.0":
+  version: 5.3.1
+  resolution: "basic-ftp@npm:5.3.1"
+  checksum: a3b5ffbedb070f89636aaaa5f639b2b275cab3486f8e216902bd60529e51047b42c732059dc94869581e2f585937a76d183a09fc519b1ce909155c137a502953
   languageName: node
   linkType: hard
 
@@ -13779,13 +13779,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^9.0.5":
-  version: 9.0.5
-  resolution: "ip-address@npm:9.0.5"
-  dependencies:
-    jsbn: 1.1.0
-    sprintf-js: ^1.1.3
-  checksum: aa15f12cfd0ef5e38349744e3654bae649a34c3b10c77a674a167e99925d1549486c5b14730eebce9fea26f6db9d5e42097b00aa4f9f612e68c79121c71652dc
+"ip-address@npm:^10.1.1":
+  version: 10.2.0
+  resolution: "ip-address@npm:10.2.0"
+  checksum: 3ffba04dc4cdaf81ed2ed6edc47eee1494bb97550ef73f1918ca28405d175c03efa416b8337e868123b08c2cc677e3a07c5ce03eda3b1aeb2741c149bd37ddf9
   languageName: node
   linkType: hard
 
@@ -15612,13 +15609,6 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: ea2339c6930fe048ec31b007b3c90be2714ab3e7defcc2c27ebf30c74fd940358f29070b4345af0019ef151875bf3bc3f8644bea1bab0372652b5044813ac02d
-  languageName: node
-  linkType: hard
-
-"jsbn@npm:1.1.0":
-  version: 1.1.0
-  resolution: "jsbn@npm:1.1.0"
-  checksum: 944f924f2bd67ad533b3850eee47603eed0f6ae425fd1ee8c760f477e8c34a05f144c1bd4f5a5dd1963141dc79a2c55f89ccc5ab77d039e7077f3ad196b64965
   languageName: node
   linkType: hard
 
@@ -20991,13 +20981,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks@npm:^2.8.3":
-  version: 2.8.3
-  resolution: "socks@npm:2.8.3"
+"socks@npm:^2.8.9":
+  version: 2.8.9
+  resolution: "socks@npm:2.8.9"
   dependencies:
-    ip-address: ^9.0.5
+    ip-address: ^10.1.1
     smart-buffer: ^4.2.0
-  checksum: 7a6b7f6eedf7482b9e4597d9a20e09505824208006ea8f2c49b71657427f3c137ca2ae662089baa73e1971c62322d535d9d0cf1c9235cf6f55e315c18203eadd
+  checksum: b573ed4cfb935624d3688e7065cd03fd72ca258156923c9ebb9d462e545cd78f296b64a0e36f911b16326c94aabe2bf94ff405f8afef27ac7bf80fa3c971c6f6
   languageName: node
   linkType: hard
 
@@ -21152,13 +21142,6 @@ __metadata:
   dependencies:
     through: 2
   checksum: 2e076634c9637cfdc54ab4387b6a243b8c33b360874a25adf6f327a5647f07cb3bf1c755d515248eb3afee4e382278d01f62c62d87263c118f28065b86f74f02
-  languageName: node
-  linkType: hard
-
-"sprintf-js@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "sprintf-js@npm:1.1.3"
-  checksum: a3fdac7b49643875b70864a9d9b469d87a40dfeaf5d34d9d0c5b1cda5fd7d065531fcb43c76357d62254c57184a7b151954156563a4d6a747015cfb41021cad0
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7185,20 +7185,37 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"accessibility-insights-report@npm:^7.5.0":
-  version: 7.5.0
-  resolution: "accessibility-insights-report@npm:7.5.0"
+"accessibility-insights-report@npm:6.0.0":
+  version: 6.0.0
+  resolution: "accessibility-insights-report@npm:6.0.0"
   dependencies:
     "@fluentui/react": ^8.118.1
-    axe-core: 4.11.3
+    axe-core: 4.10.2
     classnames: ^2.5.1
-    lodash: ^4.18.0
+    lodash: ^4.17.21
     luxon: ^3.5.0
     react: ^18.3.1
     react-dom: ^18.3.1
     react-helmet-async: ^2.0.5
-    uuid: ^14.0.0
-  checksum: 564f531cf53d74818d6e272869eae1579c3fe7a607b00af4c6db5c1f7a670860f48268b2ed1e0dedfac38d9b94141f17247de303cf5041e662f78dc6d4f051d8
+    uuid: ^9.0.1
+  checksum: 84596cd8613e8fafee96f5178beac9636400907baaaeb1d04aedfbb548fe6c38d1d213da76ef00f31fe14b5259f7e730c3256e6b72a36679fd029ccf50f80b21
+  languageName: node
+  linkType: hard
+
+"accessibility-insights-report@npm:7.0.0":
+  version: 7.0.0
+  resolution: "accessibility-insights-report@npm:7.0.0"
+  dependencies:
+    "@fluentui/react": ^8.118.1
+    axe-core: 4.10.2
+    classnames: ^2.5.1
+    lodash: ^4.17.21
+    luxon: ^3.5.0
+    react: ^18.3.1
+    react-dom: ^18.3.1
+    react-helmet-async: ^2.0.5
+    uuid: ^9.0.1
+  checksum: f9f056fae2588287ba520e4ba359927352405013348c454936f449b551712fb448e28087e4a59aea26450630fc57b41f72ad57f5fbbd5215ffed8a7ba7195a8a
   languageName: node
   linkType: hard
 
@@ -8022,13 +8039,6 @@ __metadata:
   version: 4.10.2
   resolution: "axe-core@npm:4.10.2"
   checksum: 2b9b1c93ea73ea9f206604e4e17bd771d2d835f077bde54517d73028b8865c69b209460e73d5b109968cbdb39ab3d28943efa5695189bd79e16421ce1706719e
-  languageName: node
-  linkType: hard
-
-"axe-core@npm:4.11.3":
-  version: 4.11.3
-  resolution: "axe-core@npm:4.11.3"
-  checksum: b01fc82cd0e809db09166a90bbb8942a978eefab5ba1ebab8faebd94969e0bd36df9848e4e510520cd08cde9800a6d14888ebbca380dfc4594db48e9b494d399
   languageName: node
   linkType: hard
 
@@ -22916,21 +22926,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^14.0.0":
-  version: 14.0.0
-  resolution: "uuid@npm:14.0.0"
-  bin:
-    uuid: dist-node/bin/uuid
-  checksum: 08608584a79e987cdae000fa8eb724fa51dd8aafc136cd9fa9a8c87d07b246c56eec5fd9027fdb3e49a863eedf758bc19e325909ce281955c7a027fed67dc89e
-  languageName: node
-  linkType: hard
-
 "uuid@npm:^3.0.1":
   version: 3.4.0
   resolution: "uuid@npm:3.4.0"
   bin:
     uuid: ./bin/uuid
   checksum: 58de2feed61c59060b40f8203c0e4ed7fd6f99d42534a499f1741218a1dd0c129f4aa1de797bcf822c8ea5da7e4137aa3673431a96dae729047f7aca7b27866f
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Details

Fix Component Governance alerts for 2 vulnerable.

##### Motivation

Addresses CG alerts:
- **[#2388162](https://dev.azure.com/mseng/1ES/_workitems/edit/2388162/?view=edit)**: CVE-2026-44240 in basic-ftp 5.3.0 (High)
- **[#2386624](https://dev.azure.com/mseng/1ES/_workitems/edit/2386624/?view=edit)**: CVE-2026-42338 in ip-address 9.0.5 (Medium)

**Changes:**
- `"socks": "^2.8.3"` → `"^2.8.9"` — upgrades socks to 2.8.9, which uses ip-address 10.2.0 (fixes CVE-2026-42338)
- Added `"basic-ftp": "^5.3.1"` resolution — upgrades basic-ftp from 5.3.0 to 5.3.1 (fixes CVE-2026-44240)

#### Pull request checklist
- [x] Addresses an existing issue: Fixes #2388162, #2386624
- [x] Added relevant unit test for your changes. (`yarn test`) — no code changes, only dependency resolutions
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)