### PR TITLE
CG issue fixes for fast-uri and Protobufjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
         "file-type@^20.0.0": "21.3.2",
         "file-type@^20.5.0": "21.3.2",
         "@azure/msal-browser": "^4.30.0",
-        "protobufjs": "^7.5.5",
+        "protobufjs": "^7.5.8",
         "keyv": "^5.6.0",
         "basic-ftp": "^5.3.1"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11941,9 +11941,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.0.5
-  resolution: "fast-uri@npm:3.0.5"
-  checksum: b56cda8e7355bad9adcc3c2eacd94cb592eaa9536497a4779a9527784f4f95a3755f30525c63583bd85807c493b396ac89926c970f19a60905ed875121ca78fd
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 73a6e1b04e6fcf7a09ed93316e72d643ef177d26969973784690708612141f2c2f74657120bab75bf5bbc26bfd535a32c90a8c3bc50aca50584cf01f98815afe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Details

Fixing CG issue relates to fast-uri and protobufjs npm packages

#### Motivation

Addresses below CG Issues:
**fast-uri** : [2389861](https://dev.azure.com/mseng/1ES/_workitems/edit/2389861), [2389862](https://dev.azure.com/mseng/1ES/_workitems/edit/2389862)
**protobufjs** : [2393900](https://dev.azure.com/mseng/1ES/_workitems/edit/2393900), [2393901](https://dev.azure.com/mseng/1ES/_workitems/edit/2393901), [2393902](https://dev.azure.com/mseng/1ES/_workitems/edit/2393902), [2393903](https://dev.azure.com/mseng/1ES/_workitems/edit/2393903), [2393904](https://dev.azure.com/mseng/1ES/_workitems/edit/2393904), [2393905](https://dev.azure.com/mseng/1ES/_workitems/edit/2393905), [2393906](https://dev.azure.com/mseng/1ES/_workitems/edit/2393906)

#### Context

This PR is to fix the above CG issues by adding resolution to update version of packages as below
fast-uri : 3.0.5 -> 3.1.2
protobifjs: 7.5.5 -> 7.5.8

### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes [2389861](https://dev.azure.com/mseng/1ES/_workitems/edit/2389861), [2389862](https://dev.azure.com/mseng/1ES/_workitems/edit/2389862), [2393900](https://dev.azure.com/mseng/1ES/_workitems/edit/2393900), [2393901](https://dev.azure.com/mseng/1ES/_workitems/edit/2393901), [2393902](https://dev.azure.com/mseng/1ES/_workitems/edit/2393902), [2393903](https://dev.azure.com/mseng/1ES/_workitems/edit/2393903), [2393904](https://dev.azure.com/mseng/1ES/_workitems/edit/2393904), [2393905](https://dev.azure.com/mseng/1ES/_workitems/edit/2393905), [2393906](https://dev.azure.com/mseng/1ES/_workitems/edit/2393906)
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
