### PR TITLE
Fix CG alert: ws 8.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "cosmiconfig@^7.0.1": "^8.1.3",
         "pac-resolver": "^7.0.1",
         "socks": "^2.8.9",
-        "ws": "^8.17.1",
+        "ws": "^8.20.1",
         "path-to-regexp": "^1.9.0",
         "express": "^4.22.0",
         "serve-static": "^1.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23981,9 +23981,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.17.1":
-  version: 8.18.0
-  resolution: "ws@npm:8.18.0"
+"ws@npm:^8.20.1":
+  version: 8.20.1
+  resolution: "ws@npm:8.20.1"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -23992,7 +23992,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 91d4d35bc99ff6df483bdf029b9ea4bfd7af1f16fc91231a96777a63d263e1eabf486e13a2353970efc534f9faa43bdbf9ee76525af22f4752cbc5ebda333975
+  checksum: e639c83de2f58430a8f5d3ffea49711d37a766822e2e7ec8f131e5b890a95314203f1f83ee124de5c0185849907c9ab19db0210a723f2c03a99eaf448589d2f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Details

Bumps `ws` resolution from `^8.17.1` to `^8.20.1` to fix CVE-2026-45736

##### Motivation

Addresses CG alert #2404091

#### Pull request checklist
- [x] Addresses an existing issue: CG #2404091
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`