### PR TITLE
Fix CG alert: cross-spawn 7.0.3 (CVE-2024-21538)

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,10 @@
         "@azure/msal-browser": "^4.30.0",
         "protobufjs": "^7.5.8",
         "keyv": "^5.6.0",
-        "basic-ftp": "^5.3.1"
+        "basic-ftp": "^5.3.1",
+        "cross-spawn@^7.0.0": "^7.0.5",
+        "cross-spawn@^7.0.2": "^7.0.5",
+        "cross-spawn@^7.0.3": "^7.0.5",
+        "cross-spawn@^6.0.5": "^6.0.6"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9791,31 +9791,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^6.0.5":
-  version: 6.0.5
-  resolution: "cross-spawn@npm:6.0.5"
+"cross-spawn@npm:^6.0.6":
+  version: 6.0.6
+  resolution: "cross-spawn@npm:6.0.6"
   dependencies:
     nice-try: ^1.0.4
     path-key: ^2.0.1
     semver: ^5.5.0
     shebang-command: ^1.2.0
     which: ^1.2.9
-  checksum: f893bb0d96cd3d5751d04e67145bdddf25f99449531a72e82dcbbd42796bbc8268c1076c6b3ea51d4d455839902804b94bc45dfb37ecbb32ea8e54a6741c3ab9
+  checksum: a6e2e5b04a0e0f806c1df45f92cd079b65f95fbe5a7650ee1ab60318c33a6c156a8a2f8b6898f57764f7363ec599a0625e9855dfa78d52d2d73dbd32eb11c25e
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
-  version: 7.0.3
-  resolution: "cross-spawn@npm:7.0.3"
-  dependencies:
-    path-key: ^3.1.0
-    shebang-command: ^2.0.0
-    which: ^2.0.1
-  checksum: 671cc7c7288c3a8406f3c69a3ae2fc85555c04169e9d611def9a675635472614f1c0ed0ef80955d5b6d4e724f6ced67f0ad1bb006c2ea643488fcfef994d7f52
-  languageName: node
-  linkType: hard
-
-"cross-spawn@npm:^7.0.6":
+"cross-spawn@npm:^7.0.5, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:


### PR DESCRIPTION
#### Details

Adds scoped Yarn resolutions to pin `cross-spawn` to patched versions, fixing CVE-2024-21538

##### Motivation

Addresses [CG alert #2407545](https://dev.azure.com/mseng/1ES/_workitems/edit/2407545/?view=edit)

##### Context

`cross-spawn` is a transitive dependency via multiple packages (eslint, jest, webpack-cli, tfx-cli, azure-pipelines-task-lib, react-scripts). Scoped resolutions added to avoid a major version jump for the v6 consumer (npm-run-all).

Resolutions added:
- `cross-spawn@^7.0.0`, `@^7.0.2`, `@^7.0.3` → `^7.0.5` (resolves to 7.0.6)
- `cross-spawn@^6.0.5` → `^6.0.6` (resolves to 6.0.6, for npm-run-all)

#### Pull request checklist
- [x] Addresses an existing issue: CG #2407545
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`