### PR TITLE
Changes made for Registry feed and Network Isolation policy

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@
 .gitattributes
 .github
 .prettierignore
+.vs
 .yarn
 **/.DS_Store
 **/.funcignore
@@ -16,6 +17,7 @@
 **/*.ts.snap
 **/*.snap.md
 **/bin/
+**/build/
 **/obj/
 **/dist/
 **/yarn-*.log

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,16 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+# SFI ES-4.2.4: restore from the Central Feed Service feed rather than the public npm
+# registry. This is the single place the feed URL is declared: the ADO pipelines supply
+# only a credential and read the URL from here, as do local installs.
+#
+# Reading the feed requires auth to accessibility-insights-private. Run the Azure
+# Artifacts npm credential provider, which writes a token into a home-level .yarnrc.yml,
+# or set YARN_NPM_AUTH_TOKEN before running yarn install.
+npmRegistryServer: 'https://pkgs.dev.azure.com/accessibility-insights-private/c79273f4-2dcc-480f-852b-0267a30c82db/_packaging/a11y-insights-public/npm/registry/' 
+npmAlwaysAuth: true
+
 nodeLinker: node-modules
 
 plugins:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,7 +8,7 @@
 # Reading the feed requires auth to accessibility-insights-private. Run the Azure
 # Artifacts npm credential provider, which writes a token into a home-level .yarnrc.yml,
 # or set YARN_NPM_AUTH_TOKEN before running yarn install.
-npmRegistryServer: 'https://pkgs.dev.azure.com/accessibility-insights-private/c79273f4-2dcc-480f-852b-0267a30c82db/_packaging/a11y-insights-public/npm/registry/' 
+npmRegistryServer: 'https://pkgs.dev.azure.com/accessibility-insights-private/c79273f4-2dcc-480f-852b-0267a30c82db/_packaging/a11y-insights-public/npm/registry/'
 npmAlwaysAuth: true
 
 nodeLinker: node-modules

--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -155,8 +155,20 @@ extends:
                               versionSpec: '20.x'
                           displayName: Use Node 20.x
 
+                        - task: AzureCLI@2
+                          displayName: Mint feed access token from managed identity
+                          inputs:
+                              azureSubscription: ${{ parameters.azureSubscription }}
+                              scriptType: pscore
+                              scriptLocation: 'inlineScript'
+                              inlineScript: |
+                                  $accessToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query "accessToken" --output tsv
+                                  write-host "##vso[task.setvariable variable=feedAccessToken;issecret=true]$accessToken"
+
                         - script: yarn install --immutable
                           displayName: Install dependencies
+                          env:
+                              YARN_NPM_AUTH_TOKEN: $(feedAccessToken)
 
                         - script: yarn cbuild
                           displayName: Build

--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -59,34 +59,25 @@ extends:
                           inputs:
                               versionSpec: '20.x'
                           displayName: Use Node 20.x
-                        # Same-org pipelines: the build identity works, no service connection needed.
-                        - ${{ if eq(parameters.feedServiceConnection, '') }}:
-                              - task: npmAuthenticate@0
-                                inputs:
-                                    workingFile: '$(Build.SourcesDirectory)/.npmrc'
 
-                        # Cross-org pipelines: mint a token and inject it into the connection.
-                        - ${{ if ne(parameters.feedServiceConnection, '') }}:
-                              - task: AzureCLI@2
-                                displayName: Mint feed access token from managed identity
-                                inputs:
-                                    azureSubscription: ${{ parameters.azureSubscription }}
-                                    scriptType: pscore
-                                    scriptLocation: 'inlineScript'
-                                    # 499b84ac-... is the Azure DevOps Services resource ID. The token
-                                    # authenticates the IDENTITY, not the org, which is what makes it
-                                    # work across org boundaries.
-                                    inlineScript: |
-                                        $accessToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query "accessToken" --output tsv
-                                        write-host "##vso[task.setsecret]$accessToken"
-                                        write-host "##vso[task.setendpoint id=${{ parameters.feedServiceConnectionId }};field=authParameter;key=apitoken]$accessToken"
+                        - task: AzureCLI@2
+                          displayName: Mint feed access token from managed identity
+                          inputs:
+                              azureSubscription: ${{ parameters.azureSubscription }}
+                              scriptType: pscore
+                              scriptLocation:
+                                  'inlineScript'
+                                  # 499b84ac-... is the Azure DevOps Services resource ID. The token
+                                  # authenticates the IDENTITY, not the org, which is what makes it
+                                  # work across org boundaries.
+                              inlineScript: |
+                                  $accessToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query "accessToken" --output tsv
+                                  write-host "##vso[task.setvariable variable=feedAccessToken;issecret=true]$accessToken"
 
-                              - task: npmAuthenticate@0
-                                inputs:
-                                    workingFile: '$(Build.SourcesDirectory)/.npmrc'
-                                    customEndpoint: ${{ parameters.feedServiceConnection }}
                         - script: yarn install --immutable
                           displayName: Install dependencies
+                          env:
+                              YARN_NPM_AUTH_TOKEN: $(feedAccessToken)
 
                         - script: yarn copyright:check
                           displayName: Check copyright headers

--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -20,6 +20,21 @@ extends:
     template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
 
     parameters:
+        - name: feedServiceConnection
+          type: string
+          default: 'a11y-insights-public-feed'
+        - name: feedServiceConnectionId
+          type: string
+          default: 'fbd6df0e-39c9-4a5d-912b-3f0ca3166fad'
+        - name: azureSubscription
+          type: string
+          default: 'a11y-insights-corp-tenant-identity'
+
+        settings:
+            # SFI ES-4.2.4: block public package feeds. Appended to Permissive.
+            # Registry routing alone does not satisfy the control.
+            networkIsolationPolicy: Permissive,CFSClean
+            
         # Accessibility Insights team's 1ES hosted pool.
         # This variable is saved in Azure DevOps from the "Edit" pipeline view.
         pool:
@@ -32,7 +47,7 @@ extends:
             # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/baselines#azure-devops-based-builds
             suppression:
                 suppressionFile: $(Build.SourcesDirectory)\guardian\SDL\.gdnsuppress
-
+        
         stages:
             - stage: Stage
               jobs:
@@ -43,7 +58,32 @@ extends:
                           inputs:
                               versionSpec: '20.x'
                           displayName: Use Node 20.x
+                        # Same-org pipelines: the build identity works, no service connection needed.
+                        - ${{ if eq(parameters.feedServiceConnection, '') }}:
+                              - task: npmAuthenticate@0
+                                inputs:
+                                    workingFile: '$(Build.SourcesDirectory)/.npmrc'
 
+                        # Cross-org pipelines: mint a token and inject it into the connection.
+                        - ${{ if ne(parameters.feedServiceConnection, '') }}:
+                              - task: AzureCLI@2
+                                displayName: Mint feed access token from managed identity
+                                inputs:
+                                    azureSubscription: ${{ parameters.azureSubscription }}
+                                    scriptType: pscore
+                                    scriptLocation: 'inlineScript'
+                                    # 499b84ac-... is the Azure DevOps Services resource ID. The token
+                                    # authenticates the IDENTITY, not the org, which is what makes it
+                                    # work across org boundaries.
+                                    inlineScript: |
+                                        $accessToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query "accessToken" --output tsv
+                                        write-host "##vso[task.setsecret]$accessToken"
+                                        write-host "##vso[task.setendpoint id=${{ parameters.feedServiceConnectionId }};field=authParameter;key=apitoken]$accessToken"
+
+                              - task: npmAuthenticate@0
+                                inputs:
+                                    workingFile: '$(Build.SourcesDirectory)/.npmrc'
+                                    customEndpoint: ${{ parameters.feedServiceConnection }}
                         - script: yarn install --immutable
                           displayName: Install dependencies
 

--- a/pipelines/build.yaml
+++ b/pipelines/build.yaml
@@ -14,27 +14,28 @@ resources:
           name: 1ESPipelineTemplates/1ESPipelineTemplates
           ref: refs/tags/release
 
+parameters:
+    - name: feedServiceConnection
+      type: string
+      default: 'a11y-insights-public-feed'
+    - name: feedServiceConnectionId
+      type: string
+      default: 'fbd6df0e-39c9-4a5d-912b-3f0ca3166fad'
+    - name: azureSubscription
+      type: string
+      default: 'a11y-insights-corp-tenant-identity'
+
 extends:
     # Do not edit. This is the 1ES template that holds different SDL and compliance tasks that the template injects into the pipeline.
     # It uses the Official template because it's a production pipeline.
     template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
 
     parameters:
-        - name: feedServiceConnection
-          type: string
-          default: 'a11y-insights-public-feed'
-        - name: feedServiceConnectionId
-          type: string
-          default: 'fbd6df0e-39c9-4a5d-912b-3f0ca3166fad'
-        - name: azureSubscription
-          type: string
-          default: 'a11y-insights-corp-tenant-identity'
-
         settings:
             # SFI ES-4.2.4: block public package feeds. Appended to Permissive.
             # Registry routing alone does not satisfy the control.
             networkIsolationPolicy: Permissive,CFSClean
-            
+
         # Accessibility Insights team's 1ES hosted pool.
         # This variable is saved in Azure DevOps from the "Edit" pipeline view.
         pool:
@@ -47,7 +48,7 @@ extends:
             # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/baselines#azure-devops-based-builds
             suppression:
                 suppressionFile: $(Build.SourcesDirectory)\guardian\SDL\.gdnsuppress
-        
+
         stages:
             - stage: Stage
               jobs:


### PR DESCRIPTION


#### Details

This pull request updates the project's package management and CI pipeline configuration to enhance security and ensure that dependencies are restored from a private Azure Artifacts feed instead of the public npm registry. It introduces new authentication mechanisms for both local development and Azure DevOps pipelines, and enforces stricter network isolation policies.

Dependency management and registry configuration:

* Configured `.yarnrc.yml` to use the private Azure Artifacts npm feed (`a11y-insights-public`) as the default registry, enabling `npmAlwaysAuth` to require authentication for all operations.
* Added detailed comments in `.yarnrc.yml` explaining how authentication is handled for both local and CI environments.

Pipeline security and authentication:

* Updated `pipelines/build.yaml` to add parameters for feed service connection, service connection ID, and Azure subscription, supporting both same-org and cross-org pipeline scenarios.
* Implemented conditional logic in the pipeline to authenticate with the private npm feed: for same-org pipelines, uses `npmAuthenticate@0` directly; for cross-org pipelines, mints an Azure access token using `AzureCLI@2` and injects it into the service connection.
* Enforced a stricter `networkIsolationPolicy` (`Permissive,CFSClean`) in the pipeline to block public package feeds and improve compliance.

##### Motivation

Enforced networkIsolationPolicy and npm feed in this PR.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
